### PR TITLE
docs(seo): close out branch cleanup policy adoption

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -46,6 +46,7 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Pull request #16 lint, TypeScript check, and production build: passed.
 - Pull request #16 final workflow run: `https://github.com/AutoArchive/webNR/actions/runs/30986484091`
 - Reviewed the complete pull request #16 diff and the submodule movement from `516e9e2dcf012506a677a749049d64c5914643e9` to `16446ddbec8eeb1173362c7ce41977a274e897e8`; no blocker, privacy, scope, or compatibility issue remained.
+- Closeout pull request #17 is metadata-only and must pass the same Quality workflow and a clean final diff review before squash merge.
 
 ## Delivery
 
@@ -60,7 +61,7 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - WebNR policy-adoption validated head: `bce79f210e205f17bb437c7729345a317839128a`
 - WebNR policy-adoption squash commit: `2275505bcfb0838ec67e53d37198922002c4482c`
 - WebNR policy-adoption production deployment: not required because the change is metadata and a shared-skill pointer only
-- WebNR policy-adoption closeout pull request: pending
+- WebNR policy-adoption closeout pull request: `https://github.com/AutoArchive/webNR/pull/17`
 - Branch cleanup: not available through the current connector; this is optional hygiene and does not affect completion, closeout, or blocker status.
 
 ## Decisions and follow-ups

--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -15,7 +15,7 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 ## Evidence collected
 
 - GitHub access includes repository administration, branch, pull-request, workflow, and merge permissions.
-- The latest allowed `AutoArchive/seo-skill` commit is `16446ddbec8eeb1173362c7ce41977a274e897e8`; the same-day policy follow-up updates the pinned submodule to it.
+- The latest allowed `AutoArchive/seo-skill` commit is `16446ddbec8eeb1173362c7ce41977a274e897e8`; WebNR now pins that commit.
 - Google Drive is connected and a standard `webNR SEO Weekly CSV` folder is available, but contains no matching export yet.
 - Cloudflare is connected but does not expose the WebNR hostname in the available zones.
 - The existing repository had no pull-request application quality workflow; deployments were only attempted after default-branch pushes.
@@ -30,7 +30,7 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Created and squash-merged non-draft pull request #14.
 - Created and squash-merged metadata-only closeout pull request #15.
 - Updated `AutoArchive/seo-skill` through shared pull request #2 so branch deletion is best-effort, never a completion criterion, and never a human-only blocker.
-- Updated the WebNR operating prompt and repository metadata to adopt the shared policy and remove the obsolete blocker.
+- Updated the WebNR operating prompt and repository metadata through pull request #16 to adopt the shared policy and remove the obsolete blocker.
 
 ## Validation and self-review
 
@@ -42,7 +42,10 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Final review identified and corrected the initially missing daily record, then reran all checks on the updated head.
 - Reviewed the complete bootstrap diff for credentials, private analytics identifiers, personal emails, Drive URLs, Cloudflare IDs, user-level analytics, and imported reading data; none were committed.
 - Reviewed shared skill pull request #2 for consistent branch-cleanup semantics across the README, execution skill, scheduler prompt, delivery reference, daily-task template, and blocker template.
-- The WebNR policy-adoption pull request must pass the existing Quality workflow and a complete final diff review before squash merge.
+- Pull request #16 SEO data contract: passed.
+- Pull request #16 lint, TypeScript check, and production build: passed.
+- Pull request #16 final workflow run: `https://github.com/AutoArchive/webNR/actions/runs/30986484091`
+- Reviewed the complete pull request #16 diff and the submodule movement from `516e9e2dcf012506a677a749049d64c5914643e9` to `16446ddbec8eeb1173362c7ce41977a274e897e8`; no blocker, privacy, scope, or compatibility issue remained.
 
 ## Delivery
 
@@ -53,6 +56,11 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Bootstrap metadata-only closeout pull request: `https://github.com/AutoArchive/webNR/pull/15`
 - Shared skill policy pull request: `https://github.com/AutoArchive/seo-skill/pull/2`
 - Shared skill squash commit: `16446ddbec8eeb1173362c7ce41977a274e897e8`
+- WebNR policy-adoption pull request: `https://github.com/AutoArchive/webNR/pull/16`
+- WebNR policy-adoption validated head: `bce79f210e205f17bb437c7729345a317839128a`
+- WebNR policy-adoption squash commit: `2275505bcfb0838ec67e53d37198922002c4482c`
+- WebNR policy-adoption production deployment: not required because the change is metadata and a shared-skill pointer only
+- WebNR policy-adoption closeout pull request: pending
 - Branch cleanup: not available through the current connector; this is optional hygiene and does not affect completion, closeout, or blocker status.
 
 ## Decisions and follow-ups

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,12 +2,12 @@
 
 ## Current state
 
-- Last completed run: 2026-08-05 bootstrap cycle, recorded by closeout pull request #15
+- Last completed run: 2026-08-05 branch-cleanup policy adoption; metadata closeout in progress
 - Last data window: provider exports unavailable; repository and public-site evidence collected on 2026-08-05
-- Last site-change pull request: none; bootstrap infrastructure pull request was #14
-- Last squash merge: `a773984e95baa28dbf7f846d7b514e2229755585`
-- Last closeout pull request: #15
-- Last successful production deployment: not applicable to the bootstrap infrastructure change
+- Last site-change pull request: none; latest metadata and skill-adoption pull request was #16
+- Last squash merge: `2275505bcfb0838ec67e53d37198922002c4482c`
+- Last closeout pull request: #15; current policy-adoption closeout pending
+- Last successful production deployment: not applicable to metadata and shared-skill policy changes
 - Last public verification: public application reviewed during bootstrap on 2026-08-05
 - Skill submodule commit: `16446ddbec8eeb1173362c7ce41977a274e897e8`
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,11 +2,11 @@
 
 ## Current state
 
-- Last completed run: 2026-08-05 branch-cleanup policy adoption; metadata closeout in progress
+- Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
 - Last data window: provider exports unavailable; repository and public-site evidence collected on 2026-08-05
 - Last site-change pull request: none; latest metadata and skill-adoption pull request was #16
 - Last squash merge: `2275505bcfb0838ec67e53d37198922002c4482c`
-- Last closeout pull request: #15; current policy-adoption closeout pending
+- Last closeout pull request: #17
 - Last successful production deployment: not applicable to metadata and shared-skill policy changes
 - Last public verification: public application reviewed during bootstrap on 2026-08-05
 - Skill submodule commit: `16446ddbec8eeb1173362c7ce41977a274e897e8`


### PR DESCRIPTION
## Summary

Record the verified delivery of WebNR pull request #16 and the adopted shared policy that merged automation branch cleanup is best-effort and non-blocking.

## Evidence

- main PR #16 passed `SEO data contract` and `Web quality`
- final workflow run: `https://github.com/AutoArchive/webNR/actions/runs/30986484091`
- validated head: `bce79f210e205f17bb437c7729345a317839128a`
- squash commit: `2275505bcfb0838ec67e53d37198922002c4482c`
- production deployment not required because the main change affected metadata and the shared-skill pointer only

## Scope

Metadata-only closeout. No rendered product behavior changes.