### PR TITLE
Connect WebNR to the current GA4 property

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Bootstrap the reusable SEO skill, public-safe site operating data, pull-request quality gates, connected-source routing, and the daily autonomous operator for WebNR. No production product behavior was changed in the main pull request. A same-day policy follow-up adopts the shared rule that merged branch cleanup is best-effort and non-blocking.
+Bootstrap the reusable SEO skill, public-safe site operating data, pull-request quality gates, connected-source routing, and the daily autonomous operator for WebNR. A same-day policy follow-up adopts the shared rule that merged branch cleanup is best-effort and non-blocking. The current site-change cycle adds the dedicated GA4 property without removing the historical measurement destination.
 
 ## Data window
 
@@ -20,6 +20,8 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Cloudflare is connected but does not expose the WebNR hostname in the available zones.
 - The existing repository had no pull-request application quality workflow; deployments were only attempted after default-branch pushes.
 - The connected GitHub tool does not expose merged-branch deletion, but the shared skill now explicitly classifies that as non-blocking repository hygiene.
+- The application already loaded a historical Google tag; the dedicated current property was not present in the generated application.
+- The connected Cloudflare account exposes the `webnovel.win` zone for read-only analytics.
 
 ## Work performed
 
@@ -31,6 +33,8 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Created and squash-merged metadata-only closeout pull request #15.
 - Updated `AutoArchive/seo-skill` through shared pull request #2 so branch deletion is best-effort, never a completion criterion, and never a human-only blocker.
 - Updated the WebNR operating prompt and repository metadata to adopt the shared policy and remove the obsolete blocker.
+- Configured the application to send aggregate page-view events to both the historical and dedicated current GA4 destinations.
+- Enabled Cloudflare analytics routing for the now-confirmed zone.
 
 ## Validation and self-review
 
@@ -43,6 +47,7 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Reviewed the complete bootstrap diff for credentials, private analytics identifiers, personal emails, Drive URLs, Cloudflare IDs, user-level analytics, and imported reading data; none were committed.
 - Reviewed shared skill pull request #2 for consistent branch-cleanup semantics across the README, execution skill, scheduler prompt, delivery reference, daily-task template, and blocker template.
 - The WebNR policy-adoption pull request must pass the existing Quality workflow and a complete final diff review before squash merge.
+- Current GA4 site-change SEO data validation, TypeScript, production build, and generated-tag inspection: passed; pull-request CI, final self-review, deployment, and public verification are pending.
 
 ## Delivery
 
@@ -54,11 +59,12 @@ Bootstrap the reusable SEO skill, public-safe site operating data, pull-request 
 - Shared skill policy pull request: `https://github.com/AutoArchive/seo-skill/pull/2`
 - Shared skill squash commit: `16446ddbec8eeb1173362c7ce41977a274e897e8`
 - Branch cleanup: not available through the current connector; this is optional hygiene and does not affect completion, closeout, or blocker status.
+- GA4 site-change pull request, squash commit, deployment, verification, and metadata closeout: pending.
 
 ## Decisions and follow-ups
 
 - Do not stop technical SEO or UX work when GA4, Search Console, or Cloudflare evidence is unavailable.
 - First product change should improve empty-library onboarding and static search-visible explanation.
-- A separate coherent change should remove unconditional Google Analytics or revise privacy claims so runtime behavior and product promises agree.
+- Keep analytics limited to aggregate acquisition behavior; never collect imported titles, content, history, or source URLs.
 - A later infrastructure change should make the production deployment provably attributable to the exact squash commit.
 - Never record a missing branch-deletion operation or an undeleted merged automation branch as a human-only blocker.

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -23,10 +23,9 @@
 
 ## Cloudflare data
 
-- Cloudflare enabled: no
+- Cloudflare enabled: yes
 - Zone hostname: `webnovel.win`
 - Preferred dataset: `httpRequestsAdaptiveGroups`
-- Availability note: the connected Cloudflare accounts do not currently expose this zone.
 
 ## Deployment
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -13,9 +13,9 @@
 
 ## Current signals
 
-- Google Analytics 4: Google Drive is connected; no matching export was found during bootstrap.
-- Google Search Console: Google Drive is connected; no matching export was found during bootstrap.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone; collection is disabled until the zone becomes available.
+- Google Analytics 4: the historical tag is preserved and a dedicated current property is pending production deployment; no matching Drive export was found during bootstrap.
+- Google Search Console: the domain property is configured; no matching Drive export was found during bootstrap.
+- Cloudflare: the `webnovel.win` zone is available for read-only analytics collection.
 - Repository: administrator and pull-request write access verified; PR quality gates are active.
 - Production: `https://app.webnovel.win/` is publicly reachable, but deployment-to-commit evidence is not yet enforced.
 - Autonomous schedule: enabled for daily operation in `America/Los_Angeles`.
@@ -24,7 +24,7 @@
 ## Active focus
 
 - Improve the empty-library onboarding experience and static search-visible product explanation.
-- Align privacy claims with actual analytics behavior.
+- Measure only aggregate acquisition behavior and keep imported reading data outside analytics.
 - Make production deployment evidence attributable to the exact squash commit.
 
 This file is the current verified summary. Detailed history belongs in `daily/`.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,10 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const googleAnalyticsConfig = CONFIG.GOOGLE_ANALYTICS_IDS
+  .map((id) => `gtag('config', '${id}');`)
+  .join('\n');
+
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -55,7 +59,7 @@ export default function RootLayout({
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         
         {/* Google Analytics */}
-        <Script async src={`https://www.googletagmanager.com/gtag/js?id=${CONFIG.GOOGLE_ANALYTICS_ID}`} />
+        <Script async src={`https://www.googletagmanager.com/gtag/js?id=${CONFIG.GOOGLE_ANALYTICS_IDS[0]}`} />
         <Script
           id="google-analytics"
           dangerouslySetInnerHTML={{
@@ -63,7 +67,7 @@ export default function RootLayout({
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
-              gtag('config', '${CONFIG.GOOGLE_ANALYTICS_ID}');
+              ${googleAnalyticsConfig}
             `,
           }}
         />

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -8,7 +8,7 @@ export const CONFIG = {
   CANONICAL_DOMAIN: 'https://app.webnovel.win', // Base URL for canonical links
 
   // Analytics
-  GOOGLE_ANALYTICS_ID: 'G-DGH8HNQKE4',
+  GOOGLE_ANALYTICS_IDS: ['G-DGH8HNQKE4', 'G-NL0WV2XMJN'],
 
   // PWA Settings
   PWA: {


### PR DESCRIPTION
## Evidence

- WebNR already sent aggregate page views to its historical GA4 destination.
- A dedicated current GA4 property now exists and was absent from the generated application.
- The connected Cloudflare account exposes the `webnovel.win` zone.

## Scope

- preserve the historical GA4 destination
- add the dedicated current GA4 destination to the same application tag
- enable read-only Cloudflare analytics routing in site metadata
- update the existing 2026-08-05 operating record and current status
- imported titles, content, reading history, and source URLs remain outside analytics

## Validation

- SEO data validator: passed for 2026-08-05
- TypeScript: passed
- Next.js production static export: passed
- generated homepage contains both GA4 destinations
- local standalone lint encountered the repository's existing missing `eslint-plugin-react-hooks` peer; the production build completed and the authoritative Quality workflow remains the merge gate

## Deployment

- target: existing `Deploy Next.js site to Pages` workflow on merge to `main`
- production branch: `app-pages`
- acceptance check: `https://app.webnovel.win/` serves both GA4 destination configs

## Shared skill

The submodule is already pinned to the latest compatible commit `16446ddbec8eeb1173362c7ce41977a274e897e8`; no pointer movement is needed.