### PR TITLE
fix: make production deployments attributable and self-verifying

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Bootstrap autonomous operations, adopt the shared non-blocking branch-cleanup policy, and deliver WebNR's first production product rescue. The site-change scope is the complete first-use journey: make import reachable, replace the empty-library dead end with useful onboarding, align privacy claims with runtime behavior, repair PWA update/cache behavior, restore accessibility basics, publish crawl metadata, and remove conflicting build configuration. Delivery fields remain pending until CI, squash merge, exact deployment attribution, and public verification complete.
+Bootstrap autonomous operations, adopt the shared non-blocking branch-cleanup policy, deliver WebNR's first production product rescue, make production deployments attributable to exact source commits, and complete the remaining confirmed same-cycle technical repairs before closeout.
 
 ## Data window
 
@@ -10,70 +10,75 @@ Bootstrap autonomous operations, adopt the shared non-blocking branch-cleanup po
 - Analytics lookback target: 28 finalized days with a 3-day lag
 - GA4/Search Console: no matching Google Drive export available
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Repository and public-site evidence: current code and production behavior inspected on the operating date
+- Repository, CI, deployment branch, and public-site evidence: inspected on the operating date
 
 ## Evidence collected
 
 - GitHub access includes repository administration, branch, pull-request, workflow, and merge permissions.
 - Google Drive is connected and the standard `webNR SEO Weekly CSV` folder exists, but no matching export is available.
-- The public empty library exposes no direct import action even though `AddView` already implements local TXT/EPUB and URL import.
-- The footer omits the existing Add destination and uses inconsistent translation keys.
-- The root layout unconditionally loads Google Analytics while settings promise no tracking.
-- The root viewport prevents user zoom with `maximumScale: 1`.
-- Every application load unregisters all Service Workers before registering a new one, and global application errors trigger blocking browser alerts.
-- The old Service Worker uses broad cache-first behavior, can retain unsuitable navigation requests, and has only a plain-text offline failure.
-- Both `next.config.js` and `next.config.ts` exist with conflicting behavior; only one authoritative static-export configuration should remain.
-- The application publishes no explicit `robots.txt` or sitemap.
-- The shared SEO skill advanced to `6dde51078f87d5f6cf1c22045df13a3f786a5f02`, requiring same-cycle repair of confirmed actionable defects and clarifying that one coherent change is a per-PR boundary rather than a daily limit.
-- Official Next.js guidance recommends the patched 15.5.21 Maintenance LTS line; dependency upgrade is an independent follow-up because lockfile regeneration and framework regression validation should not be mixed into the first-use product PR.
+- The former public empty library exposed no direct import action even though local TXT/EPUB and URL import existed.
+- The former runtime loaded Google Analytics while settings promised no tracking, prevented user zoom, unregistered Service Workers on every load, and surfaced internal failures through blocking browser dialogs.
+- The former Service Worker used broad cache-first behavior and the repository contained conflicting Next.js configuration files.
+- The application formerly published no explicit robots file or sitemap.
+- Pull request #19 fixed the complete first-use journey, privacy behavior, PWA caching, accessibility basics, crawl metadata, repository import accumulation, and build configuration.
+- Pull request #19 head `caa29a9e52f7115dd0215eae3059a4eb8442cea2` passed lint, TypeScript, production static export, and the SEO data contract in workflow run 30998009742 after two runtime issues found in the first green self-review were corrected.
+- Pull request #19 was squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Immediately after the merge, both the public application and the `app-pages` artifact still exposed the previous build, correctly proving that merge status alone is not deployment evidence.
+- The existing deployment workflow did not publish its source SHA, did not verify required output files, and did not confirm that the custom production domain served the exact build.
+- The shared SEO skill is pinned at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`, which requires same-cycle repair of confirmed actionable defects.
+- Official Next.js security guidance identifies 15.5.21 as the patched Maintenance LTS target for the current major line; WebNR still uses 15.2.4 and requires a separate lockfile-backed upgrade.
 
 ## Work performed
 
-- Previously completed bootstrap pull requests #14 and #15 and policy-adoption pull requests #16 and #17.
-- Updated the pinned `seo-skill` submodule to the current same-cycle repair contract.
-- Added a real Add view to the application state machine and footer navigation, including installable PWA shortcuts.
-- Connected local file and URL import to the visible application shell and opens successfully imported books in the reader.
-- Replaced the empty-library dead end with a static, search-visible, privacy-focused onboarding panel and direct import call to action.
-- Hid irrelevant library controls when no books exist and added inline loading, load, deletion, and export states.
-- Replaced native delete confirmation and export error alerts with application UI.
-- Added semantic form labels, URL validation, keyboard-sized controls, status/alert semantics, `aria-current`, and a skip link.
-- Synchronized the document language with the selected interface language.
-- Removed unconditional Google Analytics, browser zoom restriction, global exception alerts, and destructive Service Worker unregister behavior.
-- Replaced the Service Worker with same-origin application-shell caching, network-first navigation, safe cache cleanup, offline HTML fallback, and no caching of query-bearing import navigation.
-- Improved manifest identity, descriptions, categories, scope, and shortcuts.
-- Added specific product metadata, canonical ownership, crawler directives, social metadata, and SoftwareApplication JSON-LD.
-- Added `robots.txt` and `sitemap.xml`.
-- Made `next.config.ts` the single static-export configuration and removed the conflicting JavaScript config.
-- Updated the durable plan and daily task so every day requires a meaningful user-visible production update and confirmed defects are repaired in the same cycle through as many focused PRs as needed.
+- Previously completed bootstrap pull requests #14 and #15 and branch-policy pull requests #16 and #17.
+- Updated the pinned SEO skill to the same-cycle repair contract.
+- Created, validated, self-reviewed, and squash-merged product pull request #19.
+- Exposed Add in application navigation and PWA shortcuts and connected local TXT/EPUB and URL import to the visible shell.
+- Replaced the empty-library dead end with static, privacy-focused onboarding and a direct import action.
+- Replaced native confirm/alert behavior in the library, URL import, repository import, and discovery paths with recoverable application feedback.
+- Fixed multi-repository import accumulation so each imported repository is retained.
+- Removed unconditional Google Analytics, zoom restriction, global exception alerts, and destructive Service Worker re-registration.
+- Added safer same-origin PWA caching, offline fallbacks, manifest improvements, accessible forms/navigation, synchronized document language, specific metadata, SoftwareApplication JSON-LD, robots.txt, and sitemap.xml.
+- Consolidated static-export configuration into `next.config.ts`.
+- Created a focused deployment-reliability branch that writes a public `/build.json` containing the source commit, validates required static artifacts and privacy assertions before publishing, records the SHA in the deployment commit message, and checks the custom production URL until it serves that exact SHA.
+- Updated the external daily operator and repository contract to require at least one meaningful user-visible production update daily and as many focused pull requests as needed for confirmed defects.
 
 ## Validation and self-review
 
-- Local network cloning is unavailable in the execution environment, so GitHub Actions is the authoritative build environment.
-- Static review completed for application routing, import callbacks, translation-key availability, same-origin cache boundaries, privacy behavior, canonical URL ownership, manifest shortcuts, static-export configuration, and public-data safety.
-- No credentials, analytics identifiers, imported filenames, book titles, reading history, source URLs, private URLs, or user-level data were added.
-- Main pull request CI: pending.
-- Complete final pull-request diff review after green CI: pending.
-- Exact production deployment and public acceptance verification: pending.
+- Product pull request #19 final SEO data contract: passed.
+- Product pull request #19 final lint: passed.
+- Product pull request #19 final TypeScript check: passed.
+- Product pull request #19 final production build: passed.
+- Product pull request #19 final workflow: `https://github.com/AutoArchive/webNR/actions/runs/30998009742`.
+- Product pull request #19 final review covered all changed files, submodule movement, routing, translations, privacy, public-data boundaries, cache behavior, offline response validity, and generated metadata; no unresolved review thread remained.
+- Product squash commit: `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Initial post-merge production inspection still showed the previous build; no false deployment completion was recorded.
+- Deployment-attribution pull request CI: pending.
+- Deployment-attribution final self-review: pending.
+- Exact production build verification through `/build.json`: pending.
+- Next.js maintenance upgrade CI and review: pending.
+- No credentials, private identifiers, imported filenames, book titles, reading content, reading history, cookies, or source URLs were committed.
 
 ## Delivery
 
-- Earlier bootstrap main pull request: `https://github.com/AutoArchive/webNR/pull/14`
-- Earlier bootstrap squash commit: `a773984e95baa28dbf7f846d7b514e2229755585`
-- Earlier metadata closeout pull request: `https://github.com/AutoArchive/webNR/pull/15`
-- Shared branch-cleanup policy commit: `16446ddbec8eeb1173362c7ce41977a274e897e8`
-- Earlier WebNR policy-adoption pull request: `https://github.com/AutoArchive/webNR/pull/16`
-- First-use product-rescue branch: `seo/first-use-product-rescue`
-- First-use product-rescue pull request: pending
-- Validated head commit: pending
-- Squash commit: pending
-- Exact production deployment: pending
-- Public verification: pending
-- Metadata-only closeout pull request: pending
+- Bootstrap pull request: `https://github.com/AutoArchive/webNR/pull/14`
+- Bootstrap closeout pull request: `https://github.com/AutoArchive/webNR/pull/15`
+- Branch-policy pull requests: `https://github.com/AutoArchive/webNR/pull/16` and `https://github.com/AutoArchive/webNR/pull/17`
+- Product-rescue pull request: `https://github.com/AutoArchive/webNR/pull/19`
+- Product-rescue validated head: `caa29a9e52f7115dd0215eae3059a4eb8442cea2`
+- Product-rescue squash commit: `d8325d3f906e3aead84a4aec98d15815daf57545`
+- Product-rescue exact production deployment: pending; the first inspection still served the previous artifact
+- Deployment-attribution branch: `seo/verifiable-pages-deployment`
+- Deployment-attribution pull request: pending
+- Next.js maintenance upgrade pull request: pending
+- Final metadata-only closeout pull request: pending
 - Branch cleanup: best-effort and non-blocking
 
 ## Decisions and follow-ups
 
-- Today is not complete until the product rescue is squash-merged, its exact commit is deployed, the public onboarding/import/privacy/PWA/robots/sitemap behavior is verified, and a metadata-only closeout PR is merged.
-- Next.js must be upgraded to 15.5.21 in a separate same-day focused PR with a regenerated lockfile and full build validation.
-- Follow-up product work should add backup/restore, storage migrations, E2E and accessibility tests, deterministic PWA tests, release channels, stable error codes, and versioned TXT/EPUB/Legado compatibility fixtures.
+- Do not equate a merge, workflow URL, deployment-branch existence, or HTTP 200 with successful production delivery.
+- The cycle is incomplete until production exposes a build identity matching the exact deployed squash commit and the onboarding, import, privacy, PWA, robots, sitemap, and metadata acceptance checks pass.
+- Upgrade Next.js and `eslint-config-next` to the supported patched 15.5.21 line in a separate focused pull request with a regenerated lockfile and complete CI.
+- Repair the remaining legacy documentation deployment workflow if its same-day audit confirms an actionable defect.
+- Follow-up product work should add backup/restore, storage migrations, E2E and accessibility tests, deterministic PWA tests, releases, stable error codes, and versioned TXT/EPUB/Legado compatibility fixtures.
 - Daily content must come from real product guides, troubleshooting, releases, compatibility reports, fixtures, or measured benchmarks; generic AI articles and thin keyword pages are prohibited.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,30 +3,34 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: first-use product rescue, privacy alignment, PWA repair, crawlability, and build-configuration cleanup; delivery evidence is pending
-- Last data window: provider exports unavailable; repository and public-site evidence collected on 2026-08-05
-- Last completed site-change pull request: none
-- Last squash merge: `2275505bcfb0838ec67e53d37198922002c4482c`
+- Active operating cycle: product rescue merged; exact deployment attribution, public verification, supported Next.js maintenance upgrade, and final closeout remain in progress
+- Last data window: provider exports unavailable; repository, CI, deployment branch, and public-site evidence collected on 2026-08-05
+- Last site-change pull request: #19
+- Last squash merge: `d8325d3f906e3aead84a4aec98d15815daf57545`
 - Last closeout pull request: #17
-- Last successful production deployment: not yet attributable to an exact site-change squash commit
-- Last public verification: public application reviewed during bootstrap on 2026-08-05
-- Skill submodule commit on the active branch: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
+- Last successful attributable production deployment: none yet
+- Last public verification: immediate post-merge inspection still showed the previous build, so product pull request #19 is not yet recorded as deployed
+- Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
-- Google Analytics 4: Google Drive is connected; no matching export was found during bootstrap. The application-level Google Analytics loader is being removed so runtime behavior matches the no-tracking promise.
-- Google Search Console: Google Drive is connected; no matching export was found during bootstrap.
+- Google Analytics 4: Google Drive is connected; no matching export is available. Product source no longer includes the unconditional Google Analytics loader after pull request #19.
+- Google Search Console: Google Drive is connected; no matching export is available.
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone; collection remains unavailable without blocking technical work.
-- Repository: administrator and pull-request write access verified; PR quality gates cover lint, TypeScript, production build, and public SEO-data validation.
-- Production: `https://app.webnovel.win/` is publicly reachable, but deployment-to-commit evidence still needs enforcement and verification.
-- Autonomous schedule: enabled for daily operation in `America/Los_Angeles`; the repository contract now requires at least one meaningful user-visible production update every day and same-cycle repair of confirmed actionable defects.
-- Branch cleanup: merged automation branch deletion is best-effort and does not affect completion or blocker status.
+- Repository: administrator and pull-request write access verified; quality gates cover lint, TypeScript, production build, and public SEO-data validation.
+- Product delivery: pull request #19 passed all checks and final self-review and was squash-merged, but the first deployment inspection still served the old application.
+- Deployment reliability: active work adds a public build manifest, artifact assertions, source-SHA deployment messages, and exact custom-domain verification.
+- Dependency support: Next.js 15.2.4 remains below the current patched 15.5.21 Maintenance LTS target and requires a separate lockfile-backed upgrade.
+- Autonomous schedule: enabled daily in `America/Los_Angeles`; at least one meaningful public production update and same-cycle repair of confirmed defects are required.
+- Branch cleanup: best-effort and non-blocking.
 
 ## Active focus
 
-- Complete CI, final self-review, squash merge, attributable production deployment, and public verification for the first-use product rescue.
-- Upgrade Next.js to the current supported patched maintenance line in a separate focused pull request.
-- Establish release, storage-migration, backup/restore, end-to-end, accessibility, offline, and compatibility fixtures.
-- Publish a clean-room Legado compatibility RFC and versioned fixture-based support matrix after the core reader is dependable.
+- Merge the verifiable Pages deployment workflow after green CI and final review.
+- Verify the exact production build and all first-use acceptance checks.
+- Upgrade Next.js and `eslint-config-next` to 15.5.21 with a regenerated lockfile and full validation.
+- Audit and repair the legacy documentation deployment workflow when confirmed.
+- Complete a metadata-only closeout pull request after all delivery facts are known.
+- Next product milestones: backup/restore, migrations, E2E/accessibility/offline tests, releases, and versioned TXT/EPUB/Legado compatibility fixtures.
 
 This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,77 +1,95 @@
-# Sample workflow for building and deploying a Next.js site to GitHub Pages
-#
-# To get started with Next.js see: https://nextjs.org/docs/getting-started
-#
-name: Deploy Next.js site to Pages
+name: Deploy WebNR app to Pages
 
 on:
   push:
     branches:
-      - master 
       - main
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: app-pages-production
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - name: Checkout
+      - name: Checkout repository and skills
         uses: actions/checkout@v4
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
-      - name: Setup Node
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
-      - name: Restore cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            .next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+          node-version: '20'
+          cache: npm
+
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-      - name: Build with Next.js
+        run: npm ci
+
+      - name: Write public build identity
+        env:
+          BUILD_SHA: ${{ github.sha }}
         run: |
-          ${{ steps.detect-package-manager.outputs.runner }} next build
-          touch out/.nojekyll  # Prevents GitHub Pages from ignoring files that begin with an underscore
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+          node <<'NODE'
+          const fs = require('node:fs');
+          const manifest = {
+            commit: process.env.BUILD_SHA,
+            builtAt: new Date().toISOString(),
+            source: 'github-actions'
+          };
+          fs.writeFileSync('public/build.json', `${JSON.stringify(manifest, null, 2)}\n`);
+          NODE
+
+      - name: Build static application
+        run: npm run build
+
+      - name: Validate deployment artifact
+        env:
+          BUILD_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          test -f out/index.html
+          test -f out/manifest.json
+          test -f out/robots.txt
+          test -f out/sitemap.xml
+          test -f out/sw.js
+          test -f out/build.json
+          grep -Fq 'WebNR — Private Offline TXT' out/index.html
+          grep -Fq "${BUILD_SHA}" out/build.json
+          if grep -Fq 'googletagmanager.com' out/index.html; then
+            echo 'Unexpected Google Analytics loader in production artifact' >&2
+            exit 1
+          fi
+          touch out/.nojekyll
+
+      - name: Publish app-pages branch
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./out
           publish_branch: app-pages
-          force_orphan: true  # This will ensure clean deployment
+          force_orphan: true
+          commit_message: "deploy: ${{ github.sha }}"
+
+      - name: Verify exact production build
+        env:
+          BUILD_SHA: ${{ github.sha }}
+          PRODUCTION_BUILD_URL: https://app.webnovel.win/build.json
+        run: |
+          set -u
+          for attempt in $(seq 1 30); do
+            response="$(curl --fail --silent --show-error --max-time 15 "${PRODUCTION_BUILD_URL}?commit=${BUILD_SHA}" || true)"
+            if printf '%s' "${response}" | grep -Fq "\"commit\": \"${BUILD_SHA}\""; then
+              printf 'Verified production commit %s\n' "${BUILD_SHA}"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Production did not expose expected commit ${BUILD_SHA}" >&2
+          exit 1


### PR DESCRIPTION
## Evidence

Pull request #19 was correctly squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`, but the immediate production and `app-pages` inspection still served the previous application. The existing workflow publishes static files without exposing the source SHA, validating critical artifacts, or verifying that the custom production domain serves the exact build. Therefore merge status and HTTP 200 cannot prove delivery.

## Coherent outcome

- recursively check out the pinned SEO skill during production builds
- write a public `build.json` containing the exact source commit and build time
- validate index, manifest, robots, sitemap, Service Worker, and build identity before publishing
- fail deployment if the generated HTML contains the removed Google Analytics loader
- record the source SHA in the `app-pages` deployment commit message
- use the current `peaceiris/actions-gh-pages` v4.1.0 release
- verify the custom production domain serves the exact commit after publishing
- record the truthful post-merge state without claiming the old artifact is deployed

## Validation

- existing lint, TypeScript, production static export, and SEO-data contract
- complete final workflow and metadata diff review after CI

## Deployment acceptance

After this PR is squash-merged, `https://app.webnovel.win/build.json` must contain that exact squash commit. The workflow itself must reach success only after the custom domain exposes the matching build identity. The product onboarding, privacy, metadata, robots, sitemap, manifest, and Service Worker checks will then be repeated against the public site.