### PR TITLE
fix: stop advertising and accepting unsupported EPUB files

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,89 +2,71 @@
 
 ## Scope
 
-Bootstrap autonomous operations, adopt non-blocking branch cleanup, deliver the first-use product rescue, make deployments attributable to exact commits, repair the supported dependency and browser-import stack, audit the remaining delivery workflows, and close out all verified same-cycle work.
+Deliver a same-day product rescue and maintenance cycle: establish autonomous SEO operations, make first use functional, align privacy claims with runtime behavior, repair PWA and deployment reliability, upgrade the supported dependency stack, remove unsupported EPUB claims, repair the documentation pipeline, and close out only after exact production verification.
 
 ## Data window
 
 - Local operating date: 2026-08-05 (`America/Los_Angeles`)
-- Analytics lookback target: 28 finalized days with a 3-day lag
-- GA4/Search Console: no matching Google Drive export available
+- Analytics target: 28 finalized days with a 3-day lag
+- Google Drive: connected; no matching GA4 or Search Console export available
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Repository, CI, deployment branch, npm audit, package registry, and generated public-artifact evidence: inspected on the operating date
+- Evidence used: repository source, pull requests, CI jobs and logs, npm/PyPI metadata, deployment artifacts, exact build identity, and public application output
 
 ## Evidence collected
 
-- GitHub access includes repository administration, branch, pull-request, workflow, and merge permissions.
-- Google Drive is connected and the standard `webNR SEO Weekly CSV` folder exists, but no matching export is available.
-- The former public application had no reachable first-use import path, contradicted its privacy promise with unconditional Google Analytics, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked explicit crawl files, and contained conflicting Next.js configuration.
-- Pull request #19 corrected the complete first-use journey, privacy behavior, PWA caching, accessibility basics, crawl metadata, multi-repository import accumulation, and static-export configuration.
-- Pull request #19 head `caa29a9e52f7115dd0215eae3059a4eb8442cea2` passed Quality workflow 30998009742 after two runtime findings from the first green self-review were fixed and the full suite reran.
-- Pull request #19 was squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Immediate post-merge inspection still exposed the previous build, correctly proving that merge status alone is not deployment evidence.
-- Pull request #20 added public build identity, artifact and no-tracking assertions, source-SHA deployment messages, recursive submodule checkout, and exact custom-domain verification.
-- Pull request #20 head `c66065092275d0de448f4b255233e0d42145fc1b` passed Quality workflow 30998402518 and was squash-merged as `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- The `app-pages` production artifact now contains `/build.json` identifying `cba8cff1975d293947143f7efefc2b2db37d849a` and contains the new onboarding, Add navigation, privacy-aligned HTML, title, description, canonical, SoftwareApplication JSON-LD, robots, sitemap, manifest shortcuts, and repaired Service Worker.
-- WebNR began dependency maintenance on Next.js 15.2.4, stale `eslint-config-next`, deprecated `next lint`, deprecated `text-encoding`, Node-only `Buffer.from()` in browser code, CommonJS tooling rejected by explicit lint rules, and 17 npm audit findings including 11 high findings.
-- The current stable 15.x backport is Next.js 15.5.22. npm's only automatic removal for the remaining Next/PostCSS/Sharp build-chain advisories is the unreleased Next.js 16.3 line, so a preview framework is not used in production.
-- The shared SEO skill is pinned at `6dde51078f87d5f6cf1c22045df13a3f786a5f02` and requires same-cycle repair of confirmed actionable defects.
+- The former app exposed no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
+- The former deployment workflow could not identify which source commit reached the custom domain.
+- The former dependency tree used Next.js 15.2.4, deprecated `next lint`, deprecated `text-encoding`, Node-only `Buffer.from()` in browser code, CommonJS tooling that failed explicit lint, and 17 audit findings including 11 high findings.
+- Pull requests #19, #20, and #21 repaired those product, deployment, dependency, encoding, and audit problems and passed their final expected checks and full self-reviews.
+- Product pull request #19 squash commit: `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Deployment pull request #20 squash commit: `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Dependency pull request #21 final head `134e7188c32873e2474ca3b9d7289c190aa870b8` passed Quality workflow 31000279292 and was squash-merged as `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- `app-pages/build.json` identifies `f86d7967f44ae57d83c558a63e322f52dd18373a`, proving the stable dependency build reached the production artifact.
+- During the documentation audit, EPUB support was found to be false: the file picker accepted `.epub`, but the storage path decoded the EPUB ZIP bytes as ordinary text and had no EPUB parser.
+- The old documentation workflow and site configuration still use an incorrect checkout option, unpinned and unrelated dependencies, Google Analytics, obsolete repository URLs, placeholder clone commands, and an invalid `npm test` instruction.
 
 ## Work performed
 
-- Completed bootstrap pull requests #14 and #15 and branch-policy pull requests #16 and #17.
-- Updated the autonomous task and repository contract to require meaningful public progress every day and as many focused pull requests as needed for confirmed defects.
-- Created, validated, self-reviewed, and squash-merged product pull request #19.
-- Exposed local TXT/EPUB and URL import, added useful empty-library onboarding, replaced blocking dialogs with recoverable UI, fixed repository import accumulation, aligned runtime privacy with public claims, repaired PWA caching and updates, improved accessibility and metadata, and added robots.txt and sitemap.xml.
-- Created, validated, self-reviewed, and squash-merged deployment pull request #20.
-- Added `/build.json`, artifact completeness and privacy assertions, source-SHA deployment messages, and exact custom-domain verification to the production workflow.
-- Opened dependency pull request #21 and updated exact `next` and `eslint-config-next` targets to stable 15.5.22.
-- Replaced deprecated `next lint` with direct ESLint CLI, added lint-fix and typecheck scripts, and disabled Next telemetry in CI.
-- Migrated the icon generator from CommonJS to ESM instead of weakening lint rules.
-- Removed deprecated `text-encoding` and its type package.
-- Replaced Node-only `Buffer.from()` encoding detection with browser-native `TextDecoder` and chunked binary conversion, preserving GB18030, Big5, Japanese, and Korean decoding labels.
-- Preferred `crypto.randomUUID()` for generated book identifiers with a compatibility fallback.
-- Generated and automatically repaired the npm lockfile through self-removing GitHub workflows; no lockfile content was hand-edited.
-- Added version-scoped npm overrides for fixed `brace-expansion` 1.x and 2.x releases.
-- Added a permanent dependency-audit validator and Quality step. Critical findings and any new high finding now block CI; only `next`, `postcss`, and optional `sharp` from the latest stable Next build chain are temporarily tracked.
-- Removed all temporary lockfile and audit-export workflows from the final branch.
+- Added and pinned the shared SEO skill and public-safe site operating data.
+- Enabled the external daily operator and changed the contract to require at least one meaningful public update daily and same-cycle repair of confirmed defects through focused pull requests.
+- Delivered visible TXT/URL import, useful empty-library onboarding, recoverable feedback, accessibility basics, accurate metadata, robots, sitemap, and repaired same-origin offline behavior.
+- Removed unconditional analytics, zoom restriction, destructive Service Worker handling, global error alerts, and duplicate Next.js configuration.
+- Added public `/build.json`, artifact/privacy assertions, source-SHA deployment messages, and exact custom-domain verification.
+- Upgraded to stable Next.js 15.5.22, migrated from `next lint` to direct ESLint, regenerated and repaired the npm lockfile, removed deprecated decoding packages, fixed browser-native encoding detection, migrated tooling to ESM, and added a permanent audit gate.
+- Reduced audit findings to only the explicitly tracked stable Next build-chain `next`, `postcss`, and optional `sharp` advisories; any critical or additional high finding now blocks CI.
+- Started a focused compatibility repair that restricts local selection and the storage boundary to `.txt`, removes EPUB from title, description, structured data, onboarding, and PWA metadata, and clearly states that EPUB is planned but unavailable.
+- Began a separate documentation/community repair branch from the latest default branch.
 
 ## Validation and self-review
 
-- Product pull request #19 final workflow 30998009742: passed.
-- Product pull request #19 final review: clean after correcting effect-stability and offline-response findings.
-- Product squash commit: `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Deployment pull request #20 final workflow 30998402518: passed.
-- Deployment pull request #20 final review: clean for permissions, artifact assertions, public-data safety, exact SHA propagation, timeout behavior, and custom-domain verification.
-- Deployment squash commit: `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- Stable maintenance generator workflow 30999952452: passed npm resolution, automatic lock repair, exact 15.5.22 checks, absence of `text-encoding`, clean install, direct ESLint, TypeScript, production static export, residual-audit policy, lockfile commit, and self-removal.
-- npm audit changed from 17 total findings with 11 high findings to only the stable Next build-chain `next`, `postcss`, and `sharp` high findings; no critical or other high finding remains.
-- Dependency pull request #21 normal final Quality: pending the final branch head.
-- Dependency pull request #21 complete final diff and lockfile review: pending green final Quality.
-- Legacy documentation workflow audit and repair: pending.
+- Pull request #19 final Quality: passed; runtime findings discovered during the first green review were fixed and the full suite reran.
+- Pull request #20 final Quality: passed; workflow permissions, artifact assertions, SHA propagation, and custom-domain checks were reviewed.
+- Pull request #21 final Quality: passed dependency audit, direct ESLint, TypeScript, production static export, and SEO data validation.
+- Pull request #21 final diff included only the nine expected files; temporary lock/audit workflows were absent and no review thread remained.
+- Stable dependency production artifact identity: verified as `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- TXT-only compatibility pull request CI and final review: pending.
+- Documentation repair pull request CI and final review: pending.
 - No credentials, private identifiers, imported filenames, book titles, reading content, reading history, cookies, or source URLs were committed.
 
 ## Delivery
 
-- Bootstrap pull request: `https://github.com/AutoArchive/webNR/pull/14`
-- Bootstrap closeout pull request: `https://github.com/AutoArchive/webNR/pull/15`
-- Branch-policy pull requests: `https://github.com/AutoArchive/webNR/pull/16` and `https://github.com/AutoArchive/webNR/pull/17`
+- Bootstrap pull requests: #14 and #15
+- Shared branch-cleanup policy pull requests: #16 and #17
 - Product-rescue pull request: `https://github.com/AutoArchive/webNR/pull/19`
-- Product-rescue validated head: `caa29a9e52f7115dd0215eae3059a4eb8442cea2`
-- Product-rescue squash commit: `d8325d3f906e3aead84a4aec98d15815daf57545`
 - Verifiable-deployment pull request: `https://github.com/AutoArchive/webNR/pull/20`
-- Verifiable-deployment validated head: `c66065092275d0de448f4b255233e0d42145fc1b`
-- Verifiable-deployment squash commit: `cba8cff1975d293947143f7efefc2b2db37d849a`
-- Verified production artifact identity: `cba8cff1975d293947143f7efefc2b2db37d849a`
 - Stable dependency pull request: `https://github.com/AutoArchive/webNR/pull/21`
-- Stable dependency validated head and squash commit: pending
-- Legacy docs-workflow repair pull request: pending
+- Latest verified production artifact: `f86d7967f44ae57d83c558a63e322f52dd18373a`
+- TXT-only compatibility branch: `seo/disable-broken-epub-import`
+- TXT-only compatibility pull request, squash commit, exact deployment, and public verification: pending
+- Documentation repair pull request and documentation deployment: pending
 - Final metadata-only closeout pull request: pending
 - Branch cleanup: best-effort and non-blocking
 
 ## Decisions and follow-ups
 
-- A merge, workflow URL, deployment branch, or HTTP 200 alone is not successful production delivery; exact build identity and changed behavior must be verified.
-- Stable software is preferred over a preview framework solely to silence an upstream audit entry. The remaining stable Next build-chain advisories are explicitly bounded and will fail CI if their set grows or severity becomes critical.
-- The maintenance PR must pass final normal Quality after all one-time workflows have disappeared, receive a complete final diff/lockfile review, squash merge, exact deployment, and public regression verification.
-- Repair the legacy documentation workflow if its audit confirms that it remains active and defective.
-- Follow-up product work should add backup/restore, storage migrations, E2E and accessibility tests, deterministic PWA tests, releases, stable error codes, and versioned TXT/EPUB/Legado compatibility fixtures.
-- Daily content must come from real product guides, troubleshooting, releases, compatibility reports, fixtures, or measured benchmarks; generic AI articles and thin keyword pages are prohibited.
+- Unsupported file types must be rejected explicitly; a file-extension picker is not format support.
+- EPUB support will require a real parser, content safety controls, representative fixtures, import tests, reading tests, and public compatibility reporting before it can be advertised.
+- A merge, workflow URL, deployment branch, or HTTP 200 alone is not delivery proof; exact source identity and changed behavior must be verified.
+- Stable software is preferred over a preview framework solely to silence an upstream build-chain audit entry; the remaining exception set is explicit and CI-enforced.
+- The cycle remains incomplete until the TXT-only truthfulness repair and documentation repair are merged, deployed where applicable, verified, and recorded through a green metadata-only closeout pull request.
+- Next product milestones are backup/restore, storage migrations, E2E/accessibility/offline tests, releases, real EPUB support, and versioned Legado compatibility fixtures.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,13 +3,13 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product rescue and verifiable deployment workflow merged; stable dependency maintenance is in final CI; legacy docs-workflow audit and final closeout remain
-- Last data window: provider exports unavailable; repository, CI, deployment, dependency, audit, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #20
-- Last squash merge: `cba8cff1975d293947143f7efefc2b2db37d849a`
+- Active operating cycle: product rescue, attributable deployment, and stable dependency maintenance are merged; unsupported EPUB claims are being removed before documentation repair and final closeout
+- Last data window: provider exports unavailable; repository, CI, deployment, dependency, audit, format-path, and public-artifact evidence collected on 2026-08-05
+- Last site-change pull request: #21
+- Last squash merge: `f86d7967f44ae57d83c558a63e322f52dd18373a`
 - Last closeout pull request: #17
-- Last successful attributable production artifact: `app-pages/build.json` identifies `cba8cff1975d293947143f7efefc2b2db37d849a`
-- Last public verification: the generated production artifact contains the new onboarding, import navigation, privacy-aligned HTML, metadata, robots, sitemap, manifest, and Service Worker; custom-domain verification is enforced by the deployment workflow
+- Last successful attributable production artifact: `app-pages/build.json` identifies `f86d7967f44ae57d83c558a63e322f52dd18373a`
+- Last public verification: the generated production artifact contains the repaired onboarding, import navigation, privacy-aligned HTML, metadata, robots, sitemap, manifest, Service Worker, and stable dependency build
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
@@ -18,17 +18,17 @@
 - Google Search Console: Google Drive is connected; no matching export is available.
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone; collection remains unavailable without blocking technical work.
 - Repository: administrator and pull-request write access verified; quality gates cover dependency audit, direct ESLint, TypeScript, production build, and public SEO-data validation.
-- Product delivery: pull request #19 passed all checks and final self-review and was squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Deployment reliability: pull request #20 passed all checks and final self-review and was squash-merged as `cba8cff1975d293947143f7efefc2b2db37d849a`; production artifacts now expose exact build identity.
-- Dependency support: pull request #21 targets stable Next.js and `eslint-config-next` 15.5.22, replaces deprecated `next lint`, removes deprecated `text-encoding`, repairs browser encoding detection, migrates tooling to ESM, and uses an npm-generated lockfile.
-- Dependency audit: automatic repair reduced 17 findings with 11 high findings to only the stable Next build-chain `next`, `postcss`, and optional `sharp` advisories. Any critical or any additional high finding now blocks CI. The npm-proposed complete fix is the unreleased Next 16.3 line, so WebNR remains on the latest stable backport.
+- Product delivery: pull requests #19, #20, and #21 passed expected checks and final self-review and were squash-merged.
+- Dependency support: production now uses stable Next.js 15.5.22, browser-native text decoding, an npm-generated lockfile, ESM tooling, and a permanent audit boundary.
+- Format support: local TXT import and supported text URLs are implemented. EPUB is not implemented; accepting an EPUB ZIP as text was confirmed defective, so the active repair removes EPUB from the picker, storage boundary, metadata, structured data, onboarding, and PWA manifest.
 - Autonomous schedule: enabled daily in `America/Los_Angeles`; at least one meaningful public production update and same-cycle repair of confirmed defects are required.
 - Branch cleanup: best-effort and non-blocking.
 
 ## Active focus
 
-- Complete final Quality, final full-diff review, squash merge, exact build deployment, and public regression verification for pull request #21.
-- Audit and repair the legacy documentation deployment workflow if confirmed active and defective.
+- Complete CI, final review, squash merge, exact deployment, and public verification for the truthful TXT-only compatibility repair.
+- Repair the legacy documentation workflow, remove documentation analytics and obsolete repository references, and publish accurate user/contributor guidance.
+- Treat real EPUB parsing as a versioned future product feature with fixtures and tests, not a file-extension claim.
 - Complete a metadata-only closeout pull request after all delivery facts are known.
 - Next product milestones: backup/restore, migrations, E2E/accessibility/offline tests, releases, and versioned TXT/EPUB/Legado compatibility fixtures.
 

--- a/app/components/AddView.tsx
+++ b/app/components/AddView.tsx
@@ -22,6 +22,12 @@ export const AddView: React.FC<AddViewProps> = ({ onImportComplete }) => {
         const file = event.target.files?.[0];
         if (!file) return;
 
+        if (!file.name.toLowerCase().endsWith('.txt')) {
+            setError('WebNR currently supports local TXT files. EPUB support is not available yet.');
+            event.target.value = '';
+            return;
+        }
+
         setIsLoading(true);
         setLoadingMessage(t('add.loading').replace('{filename}', file.name));
         setError(null);
@@ -68,7 +74,7 @@ export const AddView: React.FC<AddViewProps> = ({ onImportComplete }) => {
                         {t('add.uploadTitle')}
                     </h2>
                     <p id="file-help" className="mt-2 text-sm text-gray-600 dark:text-gray-300">
-                        TXT and EPUB files are processed and stored in this browser.
+                        TXT files are decoded, processed, and stored in this browser. EPUB support is planned but is not available yet.
                     </p>
                     <label className="mt-4 block text-sm font-medium text-gray-800 dark:text-gray-200" htmlFor="novel-file">
                         {t('discover.localImport')}
@@ -77,7 +83,7 @@ export const AddView: React.FC<AddViewProps> = ({ onImportComplete }) => {
                         id="novel-file"
                         ref={fileInputRef}
                         type="file"
-                        accept=".txt,.epub,text/plain,application/epub+zip"
+                        accept=".txt,text/plain"
                         aria-describedby="file-help"
                         onChange={event => { void handleFileUpload(event); }}
                         className="mt-2 block w-full rounded-lg text-sm text-gray-500 file:mr-4 file:rounded-lg file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:file:bg-blue-900/20 dark:file:text-blue-300 dark:hover:file:bg-blue-900/30"

--- a/app/components/library/LibraryView.tsx
+++ b/app/components/library/LibraryView.tsx
@@ -169,7 +169,7 @@ export const LibraryView: React.FC<LibraryViewProps> = ({ onNovelSelect, onAddNo
 
                         <ul className="mt-6 grid gap-3 text-sm text-gray-700 dark:text-gray-200 sm:grid-cols-3">
                             <li className="rounded-lg bg-gray-50 p-3 dark:bg-gray-900/50">
-                                <strong className="block text-gray-950 dark:text-white">TXT / EPUB</strong>
+                                <strong className="block text-gray-950 dark:text-white">TXT</strong>
                                 {t('discover.localImport')}
                             </li>
                             <li className="rounded-lg bg-gray-50 p-3 dark:bg-gray-900/50">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,8 +15,8 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
-const title = 'WebNR — Private Offline TXT & EPUB Reader';
-const description = 'Read your own TXT and EPUB books in the browser. WebNR works offline, stores books and reading progress locally, requires no account, and includes text-to-speech and customizable reading modes.';
+const title = 'WebNR — Private Offline TXT Reader';
+const description = 'Read your own TXT books in the browser. WebNR works offline, stores books and reading progress locally, requires no account, and includes text-to-speech and customizable reading modes.';
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -80,7 +80,7 @@ const structuredData = {
     priceCurrency: 'USD',
   },
   featureList: [
-    'Local TXT and EPUB import',
+    'Local TXT import with common text encodings',
     'Offline progressive web app',
     'Local reading progress',
     'Text-to-speech',

--- a/app/lib/storage.ts
+++ b/app/lib/storage.ts
@@ -170,6 +170,10 @@ export class NovelStorage {
     }
 
     static async importFromFile(file: File): Promise<Novel> {
+        if (!file.name.toLowerCase().endsWith('.txt')) {
+            throw new Error('Unsupported local file format. WebNR currently supports TXT files only.');
+        }
+
         return new Promise((resolve, reject) => {
             const reader = new FileReader();
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "id": "/",
   "name": "WebNR — Private Offline Reader",
   "short_name": "WebNR",
-  "description": "Read your own TXT and EPUB books offline. Books and reading progress stay in your browser, with no account required.",
+  "description": "Read your own TXT books offline. Books and reading progress stay in your browser, with no account required.",
   "lang": "en",
   "start_url": "/",
   "scope": "/",
@@ -15,7 +15,7 @@
     {
       "name": "Import a book",
       "short_name": "Import",
-      "description": "Import a local TXT or EPUB file, or a supported URL",
+      "description": "Import a local TXT file or a supported text URL",
       "url": "/?view=add"
     },
     {


### PR DESCRIPTION
## Evidence

The application advertised local EPUB support and the Add file picker accepted `.epub`, but WebNR has no EPUB container/parser implementation. `NovelStorage.importFromFile()` sent the EPUB ZIP bytes through text encoding detection, so an EPUB selection could be stored as unreadable text. A file extension in a picker is not format support.

## Coherent outcome

- accept only local `.txt` / `text/plain` files in the primary Add view
- reject any non-TXT local file at the storage boundary, even if the picker is bypassed
- explain in the UI that EPUB is planned but currently unavailable
- remove EPUB claims from the empty-library onboarding, application title/description, SoftwareApplication feature list, and PWA manifest/shortcut
- preserve URL text import and the existing multi-encoding TXT path
- record the compatibility correction and treat real EPUB parsing as a tested future feature

## Validation required

- permanent dependency audit
- direct ESLint
- TypeScript
- production static export
- SEO data contract
- complete final diff and generated metadata review after CI

## Deployment acceptance

After squash merge, `/build.json` must identify the exact squash commit. The generated page title, description, JSON-LD, manifest, empty-library card, and Add screen must describe TXT only; the file picker and storage boundary must reject EPUB.