### PR TITLE
chore: make public app and docs deployment evidence a permanent CI gate

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Deliver a same-day product rescue and maintenance cycle: establish autonomous SEO operations, make first use functional, align privacy claims with runtime behavior, repair PWA and deployment reliability, upgrade the supported dependency stack, remove unsupported EPUB claims, repair the documentation/community pipeline, and close out only after exact production verification.
+Complete a same-day product rescue and maintenance cycle for WebNR: establish autonomous SEO operations, make first use functional, align privacy claims with runtime behavior, repair PWA and deployment reliability, upgrade and audit the dependency stack, remove unsupported EPUB claims, rebuild the documentation/community pipeline, and make custom-domain deployment evidence a permanent CI requirement.
 
 ## Data window
 
@@ -10,74 +10,67 @@ Deliver a same-day product rescue and maintenance cycle: establish autonomous SE
 - Analytics target: 28 finalized days with a 3-day lag
 - Google Drive: connected; no matching GA4 or Search Console export available
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs and logs, npm/PyPI metadata, deployment artifacts, exact build identity, and public app/docs output
+- Evidence used: repository source, pull requests, CI jobs/logs, npm and PyPI metadata, deployment branch artifacts, exact build identities, and public app/docs endpoints
 
 ## Evidence collected
 
-- The former app exposed no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
-- The former deployment workflow could not identify which source commit reached the custom domain.
-- The former dependency tree used Next.js 15.2.4, deprecated `next lint`, deprecated `text-encoding`, Node-only `Buffer.from()` in browser code, CommonJS tooling that failed explicit lint, and 17 audit findings including 11 high findings.
-- Pull requests #19, #20, and #21 repaired those product, deployment, dependency, encoding, and audit problems.
-- Pull request #22 proved EPUB was not implemented, restricted local import and storage to TXT, removed EPUB from product claims, passed Quality workflow 31001024829, and was squash-merged as `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-- The old documentation workflow was mislabeled as CI, used an invalid checkout option, installed unpinned and unrelated packages, skipped strict PR builds, and could not identify the deployed source commit.
-- The old MkDocs configuration loaded Google Analytics, pointed to `yunwei37/webNR`, and carried outdated ownership metadata.
-- README and contributor pages contained `yourusername` clone commands, `npm install` instead of the lockfile, an nonexistent `npm test` command, incorrect repository layout, and unsupported product claims.
-- The old release blog contained speculative anecdotes and architecture/feature claims not backed by current tests.
-- The repository lacked a visible root contribution entrypoint, security policy, evidence-based roadmap, and privacy-aware structured issue forms.
+- The former app had no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
+- The former app deployment could not identify which source commit reached production.
+- The former dependency tree used Next.js 15.2.4, deprecated `next lint`, deprecated `text-encoding`, Node-only `Buffer.from()` in browser code, CommonJS tooling rejected by explicit lint, and 17 npm audit findings including 11 high findings.
+- EPUB was falsely advertised: the picker accepted an EPUB ZIP but no EPUB parser existed, so binary bytes were treated as text.
+- The former documentation workflow was mislabeled as CI, used an invalid checkout option, installed unpinned/unrelated packages, skipped strict PR builds, loaded analytics, pointed to obsolete repositories, and could not attribute its production output.
+- README and contribution content used placeholder clone URLs, an invalid `npm test` command, stale structure, and unsupported claims.
+- Four generic AI storytelling posts were unrelated to WebNR product knowledge and contained placeholder links.
+- `app-pages/build.json` and `gh-pages/build.json` now both identify `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 
 ## Work performed
 
-- Added and pinned the shared SEO skill and public-safe site operating data.
-- Enabled the external daily operator and changed the contract to require at least one meaningful public update daily and same-cycle repair of confirmed defects through focused pull requests.
-- Delivered visible TXT/URL import, useful empty-library onboarding, recoverable feedback, accessibility basics, accurate metadata, robots, sitemap, and repaired same-origin offline behavior.
-- Removed unconditional app analytics, zoom restriction, destructive Service Worker handling, global error alerts, and duplicate Next.js configuration.
-- Added public app `/build.json`, artifact/privacy assertions, source-SHA deployment messages, and exact custom-domain verification.
-- Upgraded to stable Next.js 15.5.22, migrated to direct ESLint, repaired the npm lockfile, removed deprecated decoding packages, fixed browser-native text decoding, migrated tooling to ESM, and added a permanent audit gate.
-- Reduced audit findings to only the explicitly tracked stable Next build-chain `next`, `postcss`, and optional `sharp` advisories; any critical or additional high finding now blocks CI.
-- Merged the TXT-only truthfulness repair through pull request #22.
-- Pinned MkDocs and its required plugins in `.github/requirements-docs.txt`.
-- Replaced the legacy documentation publisher with strict, attributable `gh-pages` deployment and exact `www.webnovel.win/build.json` verification.
-- Added a permanent strict documentation job to PR Quality and updated app/docs/SEO workflows to current action runtimes.
-- Removed documentation analytics and obsolete repository/home metadata.
-- Rewrote repository and documentation home pages with current TXT-only use, privacy, CORS, storage, development, and content-policy guidance.
-- Rewrote contribution instructions to match actual scripts, CI, review, deployment, privacy, and compatibility rules.
-- Replaced English and Chinese speculative launch stories with auditable release archives.
-- Added `CONTRIBUTING.md`, `SECURITY.md`, `ROADMAP.md`, structured bug/compatibility forms, and private security-report routing.
-- Removed the obsolete analytics constant and corrected the repository URL in application configuration.
+- Added and pinned `AutoArchive/seo-skill`, public-safe site metadata, current status, plan, blocker policy, and the daily operating record.
+- Enabled the external daily operator and required at least one meaningful public production update daily plus same-cycle repair of every confirmed low-risk, reversible, verifiable defect.
+- Pull request #19 delivered visible TXT/URL import, first-use onboarding, recoverable feedback, accessible forms/navigation, truthful privacy behavior, repaired PWA caching, specific metadata, SoftwareApplication JSON-LD, robots, sitemap, and a single static-export configuration.
+- Pull request #20 added app `/build.json`, artifact/privacy assertions, source-SHA deployment messages, and exact custom-domain verification.
+- Pull request #21 upgraded to stable Next.js 15.5.22, replaced deprecated lint/decoder paths, fixed browser-native encoding, migrated tooling to ESM, regenerated/repaired the lockfile through npm, overrode fixed `brace-expansion` lines, and added a permanent dependency-audit boundary.
+- Pull request #22 restricted local import and storage to the implemented TXT path and removed false EPUB claims from UI, metadata, JSON-LD, and manifest.
+- Pull request #23 pinned the MkDocs toolchain, added strict documentation CI, replaced the legacy publisher with exact-SHA docs deployment, updated Actions runtimes, removed docs analytics and obsolete references, rewrote bilingual usage/contribution/release/source guidance, added security/roadmap/community forms, and deleted the unrelated AI article series.
+- Created a permanent production-evidence validator that reads the last successful app/docs commits from `status.md` and verifies both public `/build.json` endpoints during every Quality run.
+- Updated the app deploy trigger so metadata-only closeouts and CI-only evidence changes do not create meaningless application deployments.
 
 ## Validation and self-review
 
-- Pull request #19 final Quality: passed after runtime findings discovered during the first green review were fixed and the full suite reran.
-- Pull request #20 final Quality: passed; workflow permissions, artifact assertions, SHA propagation, and custom-domain checks were reviewed.
-- Pull request #21 final Quality: passed dependency audit, direct ESLint, TypeScript, production static export, and SEO data validation.
-- Pull request #22 final Quality: passed dependency audit, direct ESLint, TypeScript, production static export, and SEO data validation; final diff review found no unresolved thread.
-- Stable dependency production artifact identity: verified as `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-- TXT-only production artifact identity and generated behavior: pending the post-merge deployment refresh.
-- Documentation/community repair strict app/docs/SEO CI: pending.
-- Documentation/community final diff and generated-site review: pending green CI.
-- Documentation exact production deployment: pending.
+- Pull request #19 final head `caa29a9e52f7115dd0215eae3059a4eb8442cea2`; Quality run 30998009742 passed after two runtime findings from the first green review were fixed and the suite reran; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Pull request #20 final head `c66065092275d0de448f4b255233e0d42145fc1b`; Quality run 30998402518 passed; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Pull request #21 final head `134e7188c32873e2474ca3b9d7289c190aa870b8`; Quality run 31000279292 passed dependency audit, direct ESLint, TypeScript, static export, and SEO data; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- Pull request #22 final head `b979045d44f27805f008e2b7ee2d900b80de58ee`; Quality run 31001024829 passed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+- Pull request #23 final head `fbb3881b344b8115be885a2db1c1584c1b0a1360`; Quality run 31002086657 passed Web quality, strict Documentation quality, and SEO data; complete 24-file final review found no unresolved thread; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Application deployment branch identity: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Documentation deployment branch identity: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Generated application assertions: TXT-only title/description/JSON-LD/manifest, no Google Analytics, robots, sitemap, Service Worker, Add navigation, and build identity.
+- Generated documentation assertions: current `AutoArchive/webNR` links, no Google Analytics, no placeholder/obsolete repository references, strict links/configuration, and current user/security/roadmap/contribution content.
+- Permanent custom-domain evidence pull request CI and final review: pending.
 - No credentials, private identifiers, imported filenames, book titles, reading content, reading history, cookies, analytics property IDs, or private URLs were committed.
 
 ## Delivery
 
-- Bootstrap pull requests: #14 and #15
-- Shared branch-cleanup policy pull requests: #16 and #17
-- Product-rescue pull request: `https://github.com/AutoArchive/webNR/pull/19`
-- Verifiable-deployment pull request: `https://github.com/AutoArchive/webNR/pull/20`
-- Stable dependency pull request: `https://github.com/AutoArchive/webNR/pull/21`
-- TXT-only compatibility pull request: `https://github.com/AutoArchive/webNR/pull/22`
-- TXT-only compatibility squash commit: `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
-- Documentation/community branch: `seo/repair-docs-and-community-foundation`
-- Documentation/community pull request, validated head, squash commit, exact app/docs deployments, and public verification: pending
+- Bootstrap: pull requests #14 and #15
+- Branch-cleanup policy: pull requests #16 and #17
+- Product rescue: `https://github.com/AutoArchive/webNR/pull/19`
+- Verifiable app deployment: `https://github.com/AutoArchive/webNR/pull/20`
+- Stable dependency maintenance: `https://github.com/AutoArchive/webNR/pull/21`
+- TXT-only format correction: `https://github.com/AutoArchive/webNR/pull/22`
+- Documentation/community repair: `https://github.com/AutoArchive/webNR/pull/23`
+- Latest app deployment: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Latest documentation deployment: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Production-evidence branch: `seo/verify-production-evidence`
+- Production-evidence pull request, validated head, and squash commit: pending
 - Final metadata-only closeout pull request: pending
 - Branch cleanup: best-effort and non-blocking
 
 ## Decisions and follow-ups
 
-- Unsupported file types must be rejected explicitly; a file-extension picker is not format support.
-- EPUB support requires a real parser, content safety controls, representative fixtures, import tests, reading tests, and public compatibility reporting before advertisement.
-- A merge, workflow URL, deployment branch, or HTTP 200 alone is not delivery proof; exact source identity and changed behavior must be verified.
-- Stable software is preferred over a preview framework solely to silence an upstream build-chain audit entry; the remaining exception set is explicit and CI-enforced.
-- Documentation builds are now part of the same required PR gate as application builds and public SEO-data validation.
-- The cycle remains incomplete until the documentation/community repair is merged, app/docs deployments are attributable and verified, and a green metadata-only closeout pull request records all facts.
-- Next product milestones are backup/restore, storage migrations, E2E/accessibility/offline tests, releases, real EPUB support, and versioned Legado compatibility fixtures.
+- Merge state, workflow URLs, deployment branches, and HTTP status alone are insufficient; public custom domains must expose the exact recorded build identities.
+- Unsupported formats are rejected explicitly. Real EPUB support requires a parser, content safety controls, representative fixtures, import/reading tests, and compatibility reporting.
+- Stable software is preferred over a preview framework solely to silence an upstream build-chain advisory. Any critical or new high npm finding blocks CI.
+- Documentation is a required product surface: strict builds, current privacy claims, exact deployment identity, and product-backed content are permanent gates.
+- Generic AI articles, keyword variants, fabricated benchmarks, copied documentation, and unverified feature claims are not acceptable daily content.
+- The cycle is complete only after the permanent custom-domain evidence PR and a metadata-only closeout PR both pass all expected checks, final review, and squash merge.
+- Next milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB support, and versioned clean-room Legado compatibility fixtures.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,34 +3,35 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product rescue, attributable deployment, stable dependency maintenance, and truthful TXT-only format correction are merged; documentation/community repair and final closeout remain
+- Active operating cycle: all product, dependency, format, documentation, CI, deployment, and community repairs are merged; permanent public-domain deployment evidence and final closeout remain
 - Last data window: provider exports unavailable; repository, CI, deployment, dependency, audit, format, documentation, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #22
-- Last squash merge: `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
+- Last site-change pull request: #23
+- Last squash merge: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
 - Last closeout pull request: #17
-- Last successful attributable production artifact before documentation repair: `app-pages/build.json` identifies `f86d7967f44ae57d83c558a63e322f52dd18373a`; the TXT-only deployment is pending refresh
-- Last public verification: the generated application artifact contains the repaired onboarding, import navigation, privacy-aligned HTML, metadata, robots, sitemap, manifest, Service Worker, and stable dependency build
+- Last successful attributable application deployment: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Last successful attributable documentation deployment: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Last public verification: `app-pages/build.json` and `gh-pages/build.json` both identify `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`; the active production-evidence gate verifies the same identities through the two public custom domains
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
-- Google Analytics 4: Google Drive is connected; no matching export is available. The reader no longer loads Google Analytics, and the active docs repair removes documentation analytics as well.
+- Google Analytics 4: Google Drive is connected; no matching export is available. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; no matching export is available.
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone; collection remains unavailable without blocking technical work.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, direct ESLint, TypeScript, production build, strict documentation build, and public SEO-data validation.
-- Product delivery: pull requests #19, #20, #21, and #22 passed expected checks and final self-review and were squash-merged.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, direct ESLint, TypeScript, production app build, strict documentation build, public deployment evidence, and public SEO-data validation.
+- Product delivery: pull requests #19, #20, #21, #22, and #23 passed every expected check and final self-review and were squash-merged.
+- Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB is rejected until a real parser and fixtures exist.
+- Privacy and accessibility: analytics loaders, zoom restrictions, destructive Service Worker handling, blocking global error dialogs, and obsolete public claims were removed.
 - Dependency support: production uses stable Next.js 15.5.22, browser-native text decoding, an npm-generated lockfile, ESM tooling, and a permanent audit boundary.
-- Format support: local TXT import and supported text URLs are implemented. EPUB is not implemented and is now rejected at the picker and storage boundary and removed from application metadata.
-- Documentation: active work pins the MkDocs toolchain, replaces the misleading legacy publisher, adds strict PR checks and exact documentation deployment identity, removes analytics/obsolete repository references, and publishes truthful user, security, roadmap, and contribution guidance.
-- Community: structured bug and compatibility issue forms enforce privacy, authorization, reproduction, and build-identity requirements.
+- Documentation and community: the pinned strict MkDocs pipeline, attributable docs deployment, truthful bilingual guidance, security policy, roadmap, contribution policy, and structured issue forms are deployed from pull request #23.
+- Content quality: four unrelated generic AI storytelling posts with placeholder links were deleted; durable content is limited to real product, release, compatibility, troubleshooting, and engineering knowledge.
 - Autonomous schedule: enabled daily in `America/Los_Angeles`; at least one meaningful public production update and same-cycle repair of confirmed defects are required.
 - Branch cleanup: best-effort and non-blocking.
 
 ## Active focus
 
-- Complete strict app/docs/SEO CI, final review, squash merge, exact app/docs deployment, and public verification for the documentation/community repair.
-- Verify the TXT-only application deployment through `/build.json` and generated title/manifest/import behavior.
-- Complete a metadata-only closeout pull request after all delivery facts are known.
-- Next product milestones: backup/restore, migrations, E2E/accessibility/offline tests, releases, real EPUB parsing, and versioned Legado compatibility fixtures.
+- Pass the permanent custom-domain production-evidence check for the recorded app and documentation commits.
+- Complete a metadata-only closeout pull request with the full PR, CI, squash, deployment, and public-verification record.
+- Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
 This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -107,3 +107,19 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
 
 const statusPath = '.github/seo-data/status.md';
 const status = readFileSync(statusPath, 'utf8');
@@ -18,6 +19,25 @@ const targets = [
 
 const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
 
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
 async function verifyTarget(target) {
   const match = status.match(target.pattern);
   if (!match) {
@@ -26,6 +46,8 @@ async function verifyTarget(target) {
 
   const expectedCommit = match[1];
   let lastObserved = 'no response';
+
+  await describeTarget(target);
 
   for (let attempt = 1; attempt <= 12; attempt += 1) {
     try {
@@ -38,14 +60,25 @@ async function verifyTarget(target) {
         signal: AbortSignal.timeout(15_000),
       });
 
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+
       if (!response.ok) {
-        lastObserved = `HTTP ${response.status}`;
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
       } else {
         const payload = await response.json();
-        lastObserved = JSON.stringify(payload);
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
         if (payload.commit === expectedCommit) {
           console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
-          return;
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders,
+          };
         }
       }
     } catch (error) {
@@ -62,6 +95,17 @@ async function verifyTarget(target) {
   );
 }
 
-for (const target of targets) {
-  await verifyTarget(target);
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') {
+    console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Production evidence failed:\n${failures.join('\n')}`);
 }

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -49,7 +49,7 @@ async function verifyTarget(target) {
 
   await describeTarget(target);
 
-  for (let attempt = 1; attempt <= 12; attempt += 1) {
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
     try {
       const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
         cache: 'no-store',
@@ -85,8 +85,10 @@ async function verifyTarget(target) {
       lastObserved = error instanceof Error ? error.message : String(error);
     }
 
-    if (attempt < 12) {
-      await sleep(10_000);
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+
+    if (attempt < 4) {
+      await sleep(5_000);
     }
   }
 

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) {
+    throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  }
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: {
+          accept: 'application/json',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (!response.ok) {
+        lastObserved = `HTTP ${response.status}`;
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify(payload);
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return;
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    if (attempt < 12) {
+      await sleep(10_000);
+    }
+  }
+
+  throw new Error(
+    `${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`,
+  );
+}
+
+for (const target of targets) {
+  await verifyTarget(target);
+}


### PR DESCRIPTION
## Evidence

Pull request #23 deployed both generated branches with the exact source commit `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`. Branch artifacts alone do not prove that both custom domains have finished propagating, and search crawlers can continue showing stale content. The repository needs a repeatable public-domain check rather than manual or cached inspection.

## Coherent outcome

- standardize the last successful application and documentation deployment commits in `.github/seo-data/status.md`
- add `scripts/verify-production-builds.mjs` to read those recorded commits
- request `https://app.webnovel.win/build.json` and `https://www.webnovel.win/build.json` with cache-busting and bounded retries
- fail Quality when either custom domain does not expose the exact recorded commit
- add a permanent `Production evidence` job to every pull request and main Quality run
- avoid redeploying the app for metadata-only closeouts or CI-only evidence changes
- update the daily record with final PR #23 CI, merge, app artifact, and docs artifact facts

## Validation required

- permanent dependency audit, direct ESLint, TypeScript, and application static export
- strict pinned MkDocs build and generated documentation assertions
- SEO data contract
- public custom-domain application and documentation build verification
- complete final review of all five changed files after every job is green

## Production acceptance

The PR may merge only if its own `Production evidence` job proves both custom domains expose `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`. This CI-only PR is excluded from app/docs deployment triggers, so the verified production identities remain stable for the final metadata-only closeout.