### PR TITLE
ci: require exact public app and documentation build evidence

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,15 +2,15 @@
 
 ## Scope
 
-Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous operations, repair first use, privacy, accessibility, PWA behavior, crawlability, dependencies, TXT compatibility, application/documentation deployment, public guidance, and community infrastructure; close out only after both production domains expose exact verified builds.
+Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous operations, repair first use, privacy, accessibility, PWA behavior, crawlability, dependencies, truthful format support, application/documentation deployment, public guidance, and community infrastructure; close out only after both production domains expose exact verified builds.
 
 ## Data window
 
 - Local operating date: 2026-08-05 (`America/Los_Angeles`)
 - Analytics target: 28 finalized days with a 3-day lag
-- Google Drive: connected; no matching GA4 or Search Console export available
+- Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no matching GA4 or Search Console exports
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs/logs, npm/PyPI metadata, deployment branch artifacts, DNS resolution, response headers, public build endpoints, and generated app/docs output
+- Evidence used: repository source, pull requests, CI jobs/logs, dependency metadata, deployment artifacts, DNS/response evidence, public build endpoints, and generated app/docs output
 
 ## Evidence collected
 
@@ -18,62 +18,62 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - The former dependency stack used Next.js 15.2.4, deprecated lint/decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
 - EPUB was falsely advertised even though no EPUB parser existed.
 - The former documentation workflow used an invalid checkout option, unpinned dependencies, no strict PR build, Google Analytics, obsolete repository links, speculative content, and no exact public build identity.
-- Pull requests #19 through #23 repaired those product, deployment, dependency, format, documentation, CI, and community defects and were squash-merged after complete expected CI and final self-review.
-- `app-pages/build.json` and `gh-pages/build.json` both identify pull request #23 squash commit `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-- The public application endpoint also exposes `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-- The public documentation endpoint `https://www.webnovel.win/build.json` returns 404 despite the current `gh-pages` branch.
-- DNS and headers show both public domains are proxied through Cloudflare. The app endpoint is current; the docs origin remains stale.
-- GitHub documents that events caused by workflow `GITHUB_TOKEN` do not trigger another workflow run. The legacy docs publisher only pushed `gh-pages`, so the configured branch-based Pages build was never triggered for the new artifact.
+- Pull requests #19 through #23 repaired those product, dependency, format, documentation, CI, and community defects and were squash-merged after complete expected CI and final self-review.
+- The generated app and documentation artifacts from pull request #23 identified commit `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`; the app custom domain exposed it, while the documentation custom domain returned 404.
+- The documentation failure was caused by the legacy workflow pushing `gh-pages` with `GITHUB_TOKEN`, which did not trigger the configured branch-based Pages build.
+- The shared SEO skill remains current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule movement is required in this follow-up.
 
 ## Work performed
 
-- Added and pinned `AutoArchive/seo-skill`, public-safe operating data, and a daily external operator requiring at least one meaningful public update and same-cycle repair of confirmed defects.
+- Added and pinned `AutoArchive/seo-skill`, public-safe operating data, and a daily external operator requiring meaningful public progress and same-cycle repair of confirmed defects.
 - Pull request #19 delivered visible TXT/URL import, first-use onboarding, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, repaired PWA caching, metadata, JSON-LD, robots, sitemap, and a single static-export configuration.
 - Pull request #20 added exact app build identity, artifact/privacy assertions, source-SHA deployment messages, and public verification.
 - Pull request #21 upgraded to stable Next.js 15.5.22, repaired browser decoding and tooling, regenerated/secured the npm lockfile, and added a permanent dependency-audit boundary.
 - Pull request #22 rejected unsupported local formats and removed false EPUB claims from UI, metadata, structured data, and install metadata.
 - Pull request #23 pinned the MkDocs toolchain, added strict docs CI, removed analytics and obsolete links, published truthful bilingual guidance/security/roadmap/contribution content, added structured community forms, updated Actions, and deleted unrelated generic AI articles.
-- Pull request #24 introduced a permanent custom-domain evidence gate. It passed app, docs, and SEO builds but correctly failed because `www.webnovel.win/build.json` returned 404 while the app domain passed.
-- Opened a focused documentation deployment repair that:
-  - switches the existing GitHub Pages site from branch mode to workflow mode through the Pages REST API;
-  - builds the pinned MkDocs site strictly;
-  - uploads the exact artifact through `actions/upload-pages-artifact`;
-  - deploys through `actions/deploy-pages` with Pages/id-token permissions and the `github-pages` environment;
-  - preserves the existing custom-domain configuration rather than maintaining a generated branch CNAME;
-  - waits until `www.webnovel.win/build.json` exposes the exact squash commit.
+- Pull request #24 proved the application public build passed while the documentation endpoint remained stale; it was later closed as superseded by a current-main evidence branch.
+- Pull request #25 switched the existing documentation site to the official GitHub Pages artifact/deployment API, preserved strict builds and privacy assertions, and added exact custom-domain verification.
+- Pull request #25 passed all expected pull-request CI and a complete final review, then squash-merged as `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
+- Closed stale pull request #18 because it would have reintroduced third-party analytics contrary to the merged privacy contract.
+- Requested a current-main rebase for the focused Lodash security update pull request #12; it remains separate from this delivery cycle until its rebase and CI complete.
+- Rebuilt the permanent production-evidence change on current `main`:
+  - reads exact app/docs commits from `status.md`;
+  - resolves and logs public DNS evidence;
+  - fetches both custom-domain `/build.json` endpoints with bounded retries and cache busting;
+  - fails CI unless both expose the exact recorded commit;
+  - adds the public evidence job to every Quality run;
+  - avoids meaningless app redeployments for evidence-only and metadata-only changes.
 
 ## Validation and self-review
 
-- PR #19 final Quality run 30998009742: passed after two runtime findings from the first green review were fixed and rerun; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- PR #19 final Quality run 30998009742: passed after runtime findings from the first green review were fixed and rerun; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
 - PR #20 Quality run 30998402518: passed; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
 - PR #21 Quality run 31000279292: passed dependency audit, ESLint, TypeScript, app build, and SEO data; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
 - PR #22 Quality run 31001024829: passed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
 - PR #23 Quality run 31002086657: passed app, strict docs, and SEO jobs; final 24-file review was clean; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-- PR #24 diagnostic run 31003245723: app public build passed; documentation public build returned HTTP 404 through Cloudflare, precisely identifying the remaining delivery defect.
-- Official Pages deployment repair CI and final review: pending.
+- PR #24 diagnostic run 31003245723: app public build passed; documentation public build returned HTTP 404, precisely identifying the remaining delivery defect.
+- PR #25 Quality run 31003643559: dependency audit, ESLint, TypeScript, production app build, strict documentation build, and SEO-data validation all passed; final workflow/security/deployment review found no unresolved thread.
+- Permanent exact public-domain evidence, its final diff review, squash merge, and metadata closeout: pending on the active current-main pull request.
 - No credentials, raw provider exports, analytics IDs, private URLs, user filenames, book titles/content/history, source credentials, or cookies were committed.
 
 ## Delivery
 
 - Bootstrap and policy: pull requests #14–#17
-- Product rescue: `https://github.com/AutoArchive/webNR/pull/19`
-- Verifiable app deployment: `https://github.com/AutoArchive/webNR/pull/20`
-- Stable dependency maintenance: `https://github.com/AutoArchive/webNR/pull/21`
-- TXT-only format correction: `https://github.com/AutoArchive/webNR/pull/22`
-- Documentation/community repair: `https://github.com/AutoArchive/webNR/pull/23`
-- Permanent public evidence PR: `https://github.com/AutoArchive/webNR/pull/24` — intentionally blocked until docs custom-domain deployment is repaired
-- Current verified app deployment: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
-- Current generated docs artifact: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`; public docs deployment pending
-- Official Pages deployment repair branch: `seo/fix-documentation-pages-deployment`
-- Official Pages deployment repair PR/squash/public verification: pending
-- Final metadata-only closeout PR: pending
+- Product rescue: pull request #19, squash `d8325d3f906e3aead84a4aec98d15815daf57545`
+- Verifiable app deployment: pull request #20, squash `cba8cff1975d293947143f7efefc2b2db37d849a`
+- Stable dependency maintenance: pull request #21, squash `f86d7967f44ae57d83c558a63e322f52dd18373a`
+- TXT-only format correction: pull request #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
+- Documentation/community repair: pull request #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Documentation Pages API repair: pull request #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Permanent public evidence branch: `seo/verify-production-evidence-v2`
+- Permanent public evidence PR, validated head, squash commit, and final metadata-only closeout PR: pending
 - Branch cleanup: best-effort and non-blocking
 
 ## Decisions and follow-ups
 
 - A generated branch, workflow URL, HTTP 200, or merge is not deployment proof; public custom domains must expose the exact recorded commit.
-- Documentation now uses GitHub's official artifact/deployment API instead of relying on a `GITHUB_TOKEN` branch push to trigger another build.
+- Documentation uses GitHub's official artifact/deployment API rather than relying on a workflow-token branch push to trigger another build.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and tests exist.
-- Stable software is preferred over preview framework releases solely to silence build-chain advisories; any critical or unexpected high audit finding blocks CI.
+- Stable software is preferred over preview framework releases solely to silence build-chain advisories; any critical or unexpected high finding blocks CI.
 - Daily content must be real product, release, troubleshooting, compatibility, benchmark, or engineering knowledge; generic AI articles and thin pages are prohibited.
-- The cycle remains incomplete until the official docs deployment, permanent public-evidence PR, and final metadata-only closeout PR all pass expected checks, final review, and squash merge.
+- The cycle remains incomplete until the permanent public-evidence PR and final metadata-only closeout PR both pass expected checks, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,34 +3,36 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, format, documentation, CI, and community repairs are merged; the documentation custom domain is being migrated from stale branch publishing to the GitHub Pages deployment API before permanent production evidence and final closeout
-- Last data window: provider exports unavailable; repository, CI, deployment, dependency, audit, format, documentation, DNS, response-header, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #23
-- Last squash merge: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Active operating cycle: product, dependency, format, documentation, CI, deployment, and community repairs are merged; permanent public-domain evidence and final metadata closeout remain
+- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, audit, format, documentation, DNS, response-header, and public-artifact evidence collected on 2026-08-05
+- Last site-change pull request: #25
+- Last squash merge: `57b6123141dc6b3396f41afe03c47ffead6fe66f`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
-- Last successful attributable documentation artifact: `gh-pages/build.json` identifies `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`, but `https://www.webnovel.win/build.json` still returns 404 and is not yet a successful public deployment
-- Last public verification: `https://app.webnovel.win/build.json` exposes `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`; the documentation custom domain remains stale
+- Last successful attributable application deployment: `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Last successful attributable documentation deployment: `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Last public verification: the active production-evidence pull request must prove both `https://app.webnovel.win/build.json` and `https://www.webnovel.win/build.json` expose `57b6123141dc6b3396f41afe03c47ffead6fe66f` before these facts reach `main`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
-- Google Analytics 4: Google Drive is connected; no matching export is available. Neither the reader nor generated documentation loads Google Analytics.
-- Google Search Console: Google Drive is connected; no matching export is available.
-- Cloudflare: the connected accounts do not expose the `webnovel.win` zone. Public DNS and response evidence show both subdomains are proxied through Cloudflare, but this does not block origin deployment repair through GitHub.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, direct ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
-- Product delivery: pull requests #19, #20, #21, #22, and #23 passed every expected check and final self-review and were squash-merged.
-- Application: the public custom domain serves the current product/documentation merge commit.
-- Documentation origin: the generated `gh-pages` branch is current, but pushing it with a workflow `GITHUB_TOKEN` does not trigger the configured branch-based GitHub Pages build, leaving `www` stale.
-- Documentation deployment repair: active work switches Pages to workflow mode, uploads the strict MkDocs artifact through `actions/upload-pages-artifact`, deploys it through `actions/deploy-pages`, preserves the existing `www.webnovel.win` custom domain, and verifies its exact commit.
-- Autonomous schedule: enabled daily in `America/Los_Angeles`; at least one meaningful public production update and same-cycle repair of confirmed defects are required.
+- Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
+- Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through the custom domains without requiring provider analytics access.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public deployment evidence, and public SEO-data validation.
+- Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
+- Documentation deployment: pull request #25 passed Web, strict Documentation, and SEO-data CI, received a clean final review, and was squash-merged as `57b6123141dc6b3396f41afe03c47ffead6fe66f`; it uses the official GitHub Pages artifact/deployment API.
+- Privacy: the stale pull request that would have restored third-party reader analytics was closed as superseded.
+- Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
+- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, and structured issue forms replace obsolete links and unrelated generic AI articles.
+- Autonomous operation: at least one meaningful public production update and same-cycle repair of confirmed defects are required each local day.
 - Branch cleanup: best-effort and non-blocking.
 
 ## Active focus
 
-- Complete CI, final review, squash merge, GitHub Pages API deployment, and exact `www.webnovel.win/build.json` verification for the documentation repair.
-- Update the permanent production-evidence pull request to the resulting app/docs deployment commit and require both public domains to pass.
-- Complete a metadata-only closeout pull request with the complete PR, CI, squash, deployment, and verification record.
+- Pass a permanent custom-domain production-evidence job for the exact application and documentation commit.
+- Merge the production-evidence gate after complete final review.
+- Complete a metadata-only closeout pull request with the full PR, CI, squash, deployment, public-verification, analytics-availability, and submodule record.
+- Continue dependency maintenance after current-main rebases pass the permanent evidence gate.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified current facts or facts whose truth is enforced by the same pull request's required checks. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -107,3 +107,19 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) {
+    throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  }
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: {
+          accept: 'application/json',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+
+      if (!response.ok) {
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders,
+          };
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+
+    if (attempt < 4) {
+      await sleep(5_000);
+    }
+  }
+
+  throw new Error(
+    `${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`,
+  );
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') {
+    console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Production evidence failed:\n${failures.join('\n')}`);
+}


### PR DESCRIPTION
## Evidence

Pull request #25 migrated WebNR documentation to GitHub's official Pages artifact/deployment API and squash-merged as `57b6123141dc6b3396f41afe03c47ffead6fe66f`. The application deployment workflow is also triggered by that merge. Repository branches and workflow completion are not sufficient production proof: both custom domains must expose that exact commit.

## Coherent outcome

- record the expected exact application and documentation deployment commit in public operating status
- add `scripts/verify-production-builds.mjs` to resolve/log DNS and request both public `/build.json` endpoints with cache busting, bounded retries, response headers, and timeouts
- fail Quality unless both custom domains expose the exact recorded commit
- add a permanent `Production evidence` job to pull-request and main Quality runs
- avoid meaningless app deployments for evidence-only workflow/script changes
- preserve the complete same-day delivery record without committing analytics identifiers or user reading data

## Required checks

- dependency audit, ESLint, TypeScript, and production application build
- strict pinned documentation build and artifact assertions
- public SEO-data validation
- exact application and documentation custom-domain evidence
- complete final diff, workflow, privacy, deployment, and public-evidence review after all jobs succeed

## Acceptance

This pull request may merge only when its own `Production evidence` job proves:

- `https://app.webnovel.win/build.json` exposes `57b6123141dc6b3396f41afe03c47ffead6fe66f`
- `https://www.webnovel.win/build.json` exposes `57b6123141dc6b3396f41afe03c47ffead6fe66f`

This change is CI and operating metadata only, so the application deployment workflow is intentionally not retriggered by the merge.