### PR TITLE
ci: permanently verify exact public app and documentation builds

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -10,7 +10,7 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - Analytics target: 28 finalized days with a 3-day lag
 - Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no matching GA4 or Search Console exports
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs/logs, dependency metadata, deployment artifacts, DNS/response evidence, public build endpoints, and generated app/docs output
+- Evidence used: repository source, pull requests, CI jobs/logs, dependency metadata, deployment artifacts, DNS/response evidence, workflow history, public build endpoints, and generated app/docs output
 
 ## Evidence collected
 
@@ -20,8 +20,9 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - The former documentation workflow used an invalid checkout option, unpinned dependencies, no strict PR build, Google Analytics, obsolete repository links, speculative content, and no exact public build identity.
 - Pull requests #19 through #23 repaired those product, dependency, format, documentation, CI, and community defects and were squash-merged after complete expected CI and final self-review.
 - Pull request #25 passed pull-request CI and merged the official GitHub Pages artifact/deployment implementation as `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
-- Production-evidence run 31028681157 verified `https://app.webnovel.win/build.json` at `57b6123141dc6b3396f41afe03c47ffead6fe66f`, while four cache-busted documentation requests returned HTTP 404 through Cloudflare.
+- Production-evidence run 31028681157 verified the application at that commit, while four cache-busted documentation requests returned HTTP 404 through Cloudflare.
 - The public Actions history for the legacy `.github/workflows/blank.yml` identity contained no new push run after pull request #25, proving that the deployment implementation was not executed.
+- Pull request #27 registered the same official deployment under a fresh `.github/workflows/docs-pages.yml` identity and merged as `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
 - The shared SEO skill remains current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule movement is required in this follow-up.
 
 ## Work performed
@@ -32,16 +33,20 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - Pull request #21 upgraded to stable Next.js 15.5.22, repaired browser decoding and tooling, regenerated/secured the npm lockfile, and added a permanent dependency-audit boundary.
 - Pull request #22 rejected unsupported local formats and removed false EPUB claims from UI, metadata, structured data, and install metadata.
 - Pull request #23 pinned the MkDocs toolchain, added strict docs CI, removed analytics and obsolete links, published truthful bilingual guidance/security/roadmap/contribution content, added structured community forms, updated Actions, and deleted unrelated generic AI articles.
-- Pull request #24 diagnosed the stale documentation custom domain and was closed when superseded by a current-main evidence implementation.
+- Pull request #24 diagnosed the stale documentation custom domain and was closed when superseded.
 - Pull request #25 migrated documentation delivery to the official GitHub Pages artifact/deployment API.
 - Closed stale pull request #18 because it would have reintroduced third-party analytics contrary to the merged privacy contract.
 - Requested a current-main rebase for focused Lodash update pull request #12; it remains separate until rebase and CI complete.
-- Opened pull request #26 with a permanent public build verifier. Its Web, Documentation, and SEO-data jobs progressed successfully, while its evidence job correctly failed because the docs endpoint remained 404; it was not merged.
-- Created a focused workflow-activation repair that:
-  - registers the deployment under a fresh `.github/workflows/docs-pages.yml` identity;
-  - includes the new workflow path in its own push trigger;
-  - preserves official Pages API deployment, strict MkDocs builds, privacy/URL assertions, exact build identity, and public verification;
-  - removes the inactive legacy `blank.yml` workflow identity.
+- Pull request #26 added an initial permanent public build verifier; its evidence job correctly failed on the missing docs deployment, and the PR was closed as superseded.
+- Pull request #27 renamed the inactive legacy workflow identity to a fresh self-triggering path while preserving Pages REST configuration, strict MkDocs builds, privacy and repository-reference assertions, artifact upload, OIDC deployment, exact build identity, and public verification.
+- Pull request #27 Quality run 31028991965 passed dependency audit, ESLint, TypeScript, production app build, strict documentation build, and SEO-data validation; complete final diff review found no unresolved thread or permission regression.
+- Opened the final permanent production-evidence change on current `main`:
+  - reads exact app/docs commits from `status.md`;
+  - resolves and logs public DNS evidence;
+  - fetches both custom-domain `/build.json` endpoints with cache busting, bounded retries, response headers, and timeouts;
+  - fails CI unless both expose `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`;
+  - adds the evidence job to every Quality run;
+  - avoids meaningless app deployments for evidence-only and metadata-only changes.
 
 ## Validation and self-review
 
@@ -51,9 +56,10 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - PR #22 Quality run 31001024829: passed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
 - PR #23 Quality run 31002086657: passed app, strict docs, and SEO jobs; final 24-file review was clean; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 - PR #24 diagnostic run 31003245723: app public build passed; documentation public build returned HTTP 404.
-- PR #25 Quality run 31003643559: dependency audit, ESLint, TypeScript, production app build, strict documentation build, and SEO-data validation all passed; final workflow/security/deployment review found no unresolved thread.
-- PR #26 evidence job: application commit verified; documentation returned HTTP 404 with Cloudflare `no-store` responses, proving the failure was not a cached false negative.
-- Fresh workflow activation CI, final review, squash merge, exact deployment, permanent evidence merge, and metadata closeout: pending.
+- PR #25 Quality run 31003643559: all expected jobs passed; final workflow/security/deployment review found no unresolved thread; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
+- PR #26 evidence run 31028681157: app commit verified; docs returned HTTP 404 with Cloudflare `no-store` responses.
+- PR #27 Quality run 31028991965: all expected jobs passed; final rename/trigger/permissions review was clean; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
+- Exact app/docs public evidence for `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`, permanent evidence merge, and metadata closeout: pending on the active current-main pull request.
 - No credentials, raw provider exports, analytics IDs, private URLs, user filenames, book titles/content/history, source credentials, or cookies were committed.
 
 ## Delivery
@@ -65,16 +71,16 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - TXT-only format correction: pull request #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
 - Documentation/community repair: pull request #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
 - Documentation Pages API implementation: pull request #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
-- Failed-but-informative permanent evidence PR: #26, not mergeable until docs deploys
-- Active workflow-activation branch: `seo/activate-documentation-pages-workflow`
-- Active workflow-activation PR/squash, exact app/docs deployment, permanent evidence PR, and final metadata-only closeout PR: pending
+- Documentation workflow activation: pull request #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Active permanent evidence branch: `seo/verify-production-evidence-v3`
+- Active permanent evidence PR/squash and final metadata-only closeout PR: pending
 - Branch cleanup: best-effort and non-blocking
 
 ## Decisions and follow-ups
 
 - A generated branch, workflow URL, HTTP 200, or merge is not deployment proof; public custom domains must expose the exact recorded commit.
-- A correct deployment implementation is insufficient if its workflow identity is inactive; workflow execution itself must be observed and its public result verified.
+- A correct deployment implementation is insufficient if its workflow identity is inactive; workflow execution itself and public output must be verified.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and tests exist.
 - Stable software is preferred over preview framework releases solely to silence build-chain advisories; any critical or unexpected high finding blocks CI.
 - Daily content must be real product, release, troubleshooting, compatibility, benchmark, or engineering knowledge; generic AI articles and thin pages are prohibited.
-- The cycle remains incomplete until the fresh docs workflow, permanent public-evidence PR, and final metadata-only closeout PR all pass expected checks, final review, and squash merge.
+- The cycle remains incomplete until the permanent public-evidence PR and final metadata-only closeout PR both pass expected checks, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,25 +3,24 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, format, documentation, CI, and community repairs are merged; a fresh workflow identity is being registered because the legacy documentation workflow did not trigger after pull request #25
-- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, audit, format, documentation, DNS, response-header, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #25
-- Last squash merge: `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Active operating cycle: product, dependency, format, documentation, CI, deployment, and community repairs are merged; permanent public-domain evidence and final metadata closeout remain
+- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, audit, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
+- Last site-change pull request: #27
+- Last squash merge: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `57b6123141dc6b3396f41afe03c47ffead6fe66f`
-- Last successful attributable documentation artifact: the strict generated artifact is current, but `https://www.webnovel.win/build.json` still returns 404 and is not a successful public deployment
-- Last public verification: production-evidence run 31028681157 verified the app commit `57b6123141dc6b3396f41afe03c47ffead6fe66f` and repeatedly observed documentation HTTP 404 through Cloudflare
+- Last successful attributable application deployment: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Last successful attributable documentation deployment: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Last public verification: the active production-evidence pull request must prove both `https://app.webnovel.win/build.json` and `https://www.webnovel.win/build.json` expose `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7` before these facts reach `main`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment diagnosis continues through DNS, response headers, and custom-domain build endpoints.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, and custom-domain build endpoints.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public deployment evidence, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation deployment repair: pull request #25 passed all pull-request CI and final review and merged the official Pages artifact/deployment implementation, but the legacy `.github/workflows/blank.yml` workflow identity produced no push run.
-- Workflow activation repair: active work replaces the inactive legacy workflow path with a newly registered `.github/workflows/docs-pages.yml` identity whose trigger includes its own file path.
+- Documentation delivery: pull request #25 implemented the official Pages artifact/deployment flow; pull request #27 registered it under a fresh active workflow identity and squash-merged as `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7` after all expected CI and a clean final review.
 - Privacy: the stale pull request that would have restored third-party reader analytics was closed as superseded.
 - Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, and structured issue forms replace obsolete links and unrelated generic AI articles.
@@ -30,11 +29,10 @@
 
 ## Active focus
 
-- Merge the newly registered documentation workflow after complete CI and final review.
-- Wait for its exact squash commit to deploy through the app and documentation workflows and verify both public build endpoints.
-- Recreate and merge the permanent public-domain evidence gate on the resulting current `main`.
+- Pass the permanent custom-domain production-evidence check for the exact application and documentation commit.
+- Merge the production-evidence gate after complete final review.
 - Complete a metadata-only closeout pull request with the full PR, CI, squash, deployment, public-verification, analytics-availability, and submodule record.
 - Continue dependency maintenance after current-main rebases pass the permanent evidence gate.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified current facts or facts whose truth is enforced by the same pull request's required checks. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -107,3 +107,19 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) {
+    throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  }
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= 8; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: {
+          accept: 'application/json',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+
+      if (!response.ok) {
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders,
+          };
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+
+    if (attempt < 8) {
+      await sleep(10_000);
+    }
+  }
+
+  throw new Error(
+    `${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`,
+  );
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') {
+    console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Production evidence failed:\n${failures.join('\n')}`);
+}


### PR DESCRIPTION
## Evidence

Pull request #27 registered the official documentation Pages deployment under a fresh workflow identity and squash-merged as `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`. Both the application and documentation workflows are expected to publish that exact commit. Repository merge state and workflow existence are not accepted as production proof.

## Coherent outcome

- record the exact application and documentation deployment target
- resolve and log DNS for both custom domains
- fetch both public `/build.json` endpoints with cache busting, response-header capture, bounded retries, and timeouts
- fail Quality unless both domains expose `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
- retain the check permanently for every pull request and main Quality run
- avoid meaningless app redeployments for evidence-only workflow/script changes
- record all same-day diagnostic and delivery facts without user-level reading data or private analytics identifiers

## Required checks

- dependency audit, ESLint, TypeScript, and production application build
- strict pinned documentation build and artifact assertions
- public SEO-data validation
- exact public application and documentation evidence
- complete final review of all five files, workflow effects, privacy boundary, retries, expected commits, and mergeability

## Acceptance

This PR may merge only when its own `Production evidence` job proves both public custom domains expose `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`. The merge itself is evidence-only and intentionally does not trigger another application deployment.