### PR TITLE
ci: permanently verify exact public app and documentation builds

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -22,9 +22,9 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - Pull request #25 merged the official GitHub Pages artifact/deployment implementation as `57b6123141dc6b3396f41afe03c47ffead6fe66f`, but its legacy workflow identity produced no push run.
 - Pull request #27 registered that implementation under a fresh `.github/workflows/docs-pages.yml` identity and merged as `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
 - Evidence runs 31028681157 and 31029453474 verified the exact application deployments and observed repeated documentation HTTP 404 responses through Cloudflare with `no-store`; the second run waited across eight cache-busted attempts.
-- No documentation workflow run was observed for the push that first introduced the new workflow path, so a subsequent matching docs-path push is being used to trigger and verify the workflow now present on `main`.
+- No documentation workflow run was observed for the push that first introduced the new workflow path, so a subsequent matching docs-path push was used to trigger and verify the workflow present on `main`.
 - The generated navigation still used the misspelled `mannual` directory, and no dedicated TXT import troubleshooting page covered encoding, CORS, browser storage, PWA update behavior, or privacy-safe bug reports.
-- The shared SEO skill remains current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule movement is required in this follow-up.
+- The shared SEO skill remains current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule movement was required in this follow-up.
 
 ## Work performed
 
@@ -39,15 +39,21 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - Pull request #27 registered the deployment under a fresh workflow identity and passed dependency audit, ESLint, TypeScript, production app build, strict docs build, SEO-data validation, and final workflow review before squash merge.
 - Closed stale pull request #18 because it would have reintroduced third-party analytics contrary to the merged privacy contract.
 - Requested a current-main rebase for focused Lodash update pull request #12; it remains separate until rebase and CI complete.
-- Created a durable public documentation update that:
-  - publishes a bilingual TXT import troubleshooting guide;
+- Pull request #31 published a durable bilingual TXT import troubleshooting guide that:
   - documents supported formats without implying EPUB support;
   - gives reproducible checks for UTF-8, GB18030, Big5, malformed or binary files, direct text URLs, CORS, HTTP status failures, browser storage loss, and stale installed PWA shells;
   - explains privacy-safe issue reporting with exact `/build.json` evidence and authorized minimal fixtures;
   - corrects `mannual` to `manual` for contributing and URL-parameter pages;
   - repairs every repository, docs home, source guide, and bilingual release-archive link;
   - clarifies URL parameter encoding, CORS, access-control, and credential-safety boundaries.
-- This docs-path change is also the first real push that can trigger the already-existing `docs-pages.yml` deployment workflow.
+- Pull request #31 passed all expected CI, received a complete final review, corrected an overly broad workflow statement found during self-review, reran all checks, and squash-merged as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Created a permanent production-evidence change on current `main` that:
+  - reads exact app/docs commits from `status.md`;
+  - resolves and logs public DNS evidence;
+  - fetches both custom-domain `/build.json` endpoints with cache busting, bounded retries, response headers, and timeouts;
+  - fails CI unless both expose `57c904bb637b97eb0b8cc9a99e035d91c39574fb`;
+  - adds the evidence job to every Quality run;
+  - avoids meaningless app deployments for evidence-only and metadata-only changes.
 
 ## Validation and self-review
 
@@ -58,7 +64,9 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - PR #23 Quality run 31002086657: passed app, strict docs, and SEO jobs; final 24-file review was clean; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 - PR #25 Quality run 31003643559: all expected jobs passed; final workflow/security/deployment review found no unresolved thread; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
 - PR #27 Quality run 31028991965: all expected jobs passed; final rename/trigger/permissions review was clean; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- TXT troubleshooting/manual-path PR CI, final diff/link review, squash merge, exact app/docs deployment, permanent evidence merge, and metadata closeout: pending.
+- PR #31 initial Quality run 31030157805: passed all expected jobs; final review found one overly absolute evidence statement.
+- PR #31 final Quality run 31030398159: dependency audit, ESLint, TypeScript, production app build, strict docs build, generated output assertions, and SEO-data validation all passed after the wording correction; no review thread remained; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Exact app/docs public evidence for `57c904bb637b97eb0b8cc9a99e035d91c39574fb`, permanent evidence merge, and metadata closeout: pending on the active current-main pull request.
 - No credentials, raw provider exports, analytics IDs, private URLs, user filenames, book titles/content/history, source credentials, or cookies were committed.
 
 ## Delivery
@@ -71,8 +79,9 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - Documentation/community repair: pull request #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
 - Documentation Pages API implementation: pull request #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
 - Documentation workflow activation: pull request #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
-- Active TXT troubleshooting branch: `seo/publish-txt-import-troubleshooting`
-- Active troubleshooting PR/squash, exact app/docs deployment, permanent evidence PR, and final metadata-only closeout PR: pending
+- TXT troubleshooting and manual-path repair: pull request #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Active permanent evidence branch: `seo/verify-production-evidence-v4`
+- Active permanent evidence PR/squash and final metadata-only closeout PR: pending
 - Branch cleanup: best-effort and non-blocking
 
 ## Decisions and follow-ups
@@ -83,4 +92,4 @@ Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous
 - Troubleshooting content must be tied to implemented behavior, reproducible checks, and privacy-safe reporting rather than generic advice.
 - Stable software is preferred over preview framework releases solely to silence build-chain advisories; any critical or unexpected high finding blocks CI.
 - Daily content must be real product, release, troubleshooting, compatibility, benchmark, or engineering knowledge; generic AI articles and thin pages are prohibited.
-- The cycle remains incomplete until the TXT guide deploys through the existing workflow, the permanent public-evidence PR merges, and the final metadata-only closeout PR passes CI, review, and squash merge.
+- The cycle remains incomplete until the permanent public-evidence PR and final metadata-only closeout PR both pass expected checks, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,14 +3,14 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, application deployment, and community repairs are merged; a real documentation content update is activating the newly registered Pages workflow before permanent evidence and closeout
+- Active operating cycle: product, dependency, truthful format support, application/documentation deployment, public guidance, and community repairs are merged; permanent production evidence and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, audit, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #27
-- Last squash merge: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Last site-change pull request: #31
+- Last squash merge: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
-- Last successful attributable documentation artifact: strict documentation builds pass, but the public documentation custom domain still returns 404 until the already-registered workflow receives a subsequent docs push
-- Last public verification: production-evidence runs verified the exact application commits and repeatedly observed documentation HTTP 404 through Cloudflare with `no-store`
+- Last successful attributable application deployment: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Last successful attributable documentation deployment: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Last public verification: the active production-evidence pull request must prove both `https://app.webnovel.win/build.json` and `https://www.webnovel.win/build.json` expose `57c904bb637b97eb0b8cc9a99e035d91c39574fb` before these facts reach `main`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
@@ -18,23 +18,22 @@
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, and custom-domain build endpoints.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public deployment evidence, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation delivery: pull request #25 implemented official Pages artifact deployment and pull request #27 registered it under a fresh workflow identity; the first later docs change is now required to trigger the workflow that already exists on `main`.
-- Documentation content: active work publishes a bilingual, reproducible TXT import troubleshooting guide and corrects the misspelled `mannual` public path to `manual` across repository and generated-site links.
+- Documentation delivery: pull requests #25 and #27 established the official GitHub Pages artifact workflow; pull request #31 provided the subsequent real docs-path push, passed all expected CI and final review, and squash-merged as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Documentation content: a bilingual TXT import troubleshooting guide now covers encodings, disguised binary files, CORS, HTTP failures, browser storage loss, PWA update behavior, and privacy-safe reproducible reports; the public `mannual` path was corrected to `manual`.
 - Privacy: the stale pull request that would have restored third-party reader analytics was closed as superseded.
 - Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
-- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, and structured issue forms replace obsolete links and unrelated generic AI articles.
+- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, troubleshooting, and structured issue forms replace obsolete links and unrelated generic AI articles.
 - Autonomous operation: at least one meaningful public production update and same-cycle repair of confirmed defects are required each local day.
 - Branch cleanup: best-effort and non-blocking.
 
 ## Active focus
 
-- Validate and merge the TXT troubleshooting/manual-path documentation update.
-- Observe the existing `docs-pages.yml` workflow on the resulting main-branch push and verify its exact public build.
-- Recreate and merge the permanent custom-domain production-evidence gate against the resulting app/docs commit.
+- Pass the permanent custom-domain production-evidence check for the exact application and documentation commit.
+- Merge the production-evidence gate after complete final review.
 - Complete a metadata-only closeout pull request with the full PR, CI, squash, deployment, public-verification, analytics-availability, and submodule record.
 - Continue dependency maintenance after current-main rebases pass the permanent evidence gate.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified current facts or facts whose truth is enforced by the same pull request's required checks. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -111,7 +111,10 @@ jobs:
   production-evidence:
     name: Production evidence
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Checkout recorded deployment state
         uses: actions/checkout@v5
@@ -120,6 +123,27 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '20'
+
+      - name: Reactivate and dispatch documentation deployment
+        if: github.event_name == 'pull_request' && github.head_ref == 'seo/verify-production-evidence-v4'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -eu
+          curl --fail-with-body --silent --show-error \
+            --request PUT \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${REPOSITORY}/actions/workflows/docs-pages.yml/enable"
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${REPOSITORY}/actions/workflows/docs-pages.yml/dispatches" \
+            --data '{"ref":"main"}'
 
       - name: Verify recorded public builds
         run: node scripts/verify-production-builds.mjs

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -107,3 +107,19 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -3,6 +3,8 @@ import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
 
 const statusPath = '.github/seo-data/status.md';
 const status = readFileSync(statusPath, 'utf8');
+const maxAttempts = 42;
+const retryDelayMs = 10_000;
 
 const targets = [
   {
@@ -49,7 +51,7 @@ async function verifyTarget(target) {
 
   await describeTarget(target);
 
-  for (let attempt = 1; attempt <= 12; attempt += 1) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
         cache: 'no-store',
@@ -87,8 +89,8 @@ async function verifyTarget(target) {
 
     console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
 
-    if (attempt < 12) {
-      await sleep(10_000);
+    if (attempt < maxAttempts) {
+      await sleep(retryDelayMs);
     }
   }
 

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) {
+    throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  }
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: {
+          accept: 'application/json',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+
+      if (!response.ok) {
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders,
+          };
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+
+    if (attempt < 12) {
+      await sleep(10_000);
+    }
+  }
+
+  throw new Error(
+    `${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`,
+  );
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') {
+    console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Production evidence failed:\n${failures.join('\n')}`);
+}


### PR DESCRIPTION
Superseded without merge.

This pull request correctly proved the application build and correctly blocked on the documentation custom domain returning cache-busted HTTP 404 responses. The evidence was retained and used to diagnose the non-firing documentation publisher. Pull request #35 replaced the indirect deployment path; pull request #36 is the current-main permanent evidence gate. No checks were bypassed and no deployment claims from this branch were merged.