### PR TITLE
fix: register an independent documentation Pages deployer

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -12,7 +12,20 @@ Establish autonomous operation and complete a same-day product rescue for WebNR:
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
 - Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, public Actions identity, DNS, response headers, custom-domain build endpoints, and visible public content
 
-## Delivered product and content work
+## Evidence collected
+
+- The former application had no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
+- The former dependency stack used Next.js 15.2.4, deprecated lint and decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
+- EPUB was accepted and advertised although no EPUB parser existed.
+- The former documentation workflow used an invalid checkout option, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, speculative generic content, and no exact public build identity.
+- Pull request #31 merged the bilingual TXT troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb` after all expected CI and two complete final reviews.
+- Production-evidence job 92390516464 verified `https://app.webnovel.win/build.json` at exact commit `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- The same job resolved both custom domains to Cloudflare and made twelve cache-busted requests to `https://www.webnovel.win/build.json`; every response was HTTP 404 with `cache-control: no-store`, so the failure was not a cached false negative.
+- Pull request #32 correctly remained unmerged because its permanent `Production evidence` check failed only on the missing documentation deployment; its application, documentation, and SEO jobs passed.
+- The public GitHub Actions UI still associated the displayed documentation workflow with the former `blank.yml` identity. The high-similarity workflow move in pull request #27 did not produce an independently executing documentation deployment identity.
+- The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
+
+## Work performed
 
 - Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, autonomous task, and nonblocking branch-cleanup policy.
 - Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, Service Worker updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
@@ -22,57 +35,57 @@ Establish autonomous operation and complete a same-day product rescue for WebNR:
 - Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published truthful bilingual guidance, security, roadmap, contribution and issue-reporting content, and deleted unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 - Pull request #25 implemented official GitHub Pages artifact deployment; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
 - Pull request #27 moved the intended documentation workflow to `.github/workflows/docs-pages.yml`; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- Pull request #31 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, SEO-data validation, and two complete final reviews. It published a substantial bilingual TXT import troubleshooting guide, corrected `mannual` to `manual`, repaired all current links, and merged as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Pull request #31 published a substantial bilingual TXT import troubleshooting guide, corrected `mannual` to `manual`, and repaired all current repository and generated-documentation links; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- The guide documents actual supported inputs, UTF-8/GB18030/Big5 failures, binary containers renamed as TXT, CORS, redirects, HTTP failures, browser storage loss, safe PWA refresh steps, and privacy-safe authorized reproduction. It explicitly rejects bypassing login, payment, DRM, robots, rate limits, or access controls.
+- Opened pull request #32 with a permanent exact-build verifier; its failed documentation evidence was retained as a blocking diagnosis rather than bypassed.
+- Created a focused independent documentation deployer in `.github/workflows/publish-docs-pages.yml` while retaining the prior workflow, so GitHub cannot classify this change as another workflow rename.
+- The independent deployer:
+  - triggers only after a successful `Quality` workflow on `main`, or by manual recovery dispatch;
+  - selects and validates the exact triggering source SHA;
+  - skips commits unrelated to documentation delivery;
+  - checks out the verified source with full history and recursive submodules;
+  - builds with pinned dependencies and `mkdocs build --strict`;
+  - validates exact build identity, the bilingual TXT troubleshooting page, canonical manual pages, privacy boundaries, and current repository links;
+  - publishes through official Pages artifact/deployment actions with Pages and OIDC permissions;
+  - waits until the custom domain exposes both the exact commit and the intended bilingual guide.
 
-## User-visible knowledge delivered by pull request #31
+## Validation and self-review
 
-The TXT troubleshooting guide is tied to current implementation rather than generic search content. It covers:
-
-- actual supported inputs: local plain `.txt` files and permitted HTTP/HTTPS text URLs;
-- UTF-8, GB18030, Big5, malformed bytes, mixed encoding, and binary containers renamed as TXT;
-- CORS, direct-text endpoints, redirects, HTTP 401/403/404, content-type failures, timeouts, and large requests;
-- the explicit boundary that WebNR does not operate a public proxy or bypass login, payment, DRM, robots, rate limits, or access controls;
-- browser-profile storage loss and the need to retain original files until backup/restore exists;
-- safe PWA refresh steps that do not begin by clearing site data;
-- privacy-safe bug reports using the public `/build.json` identity and synthetic, public-domain, self-owned, or explicitly authorized fixtures.
-
-## Production evidence and confirmed deployment defect
-
-- Application deployment for pull request #31 succeeded. Production-evidence job 92390516464 observed `https://app.webnovel.win/build.json` at exact commit `57c904bb637b97eb0b8cc9a99e035d91c39574fb` through Cloudflare.
-- The same job resolved both custom domains to Cloudflare addresses and made twelve cache-busted documentation requests over approximately two minutes.
-- Every request to `https://www.webnovel.win/build.json` returned HTTP 404 with `cache-control: no-store`; this was not a cached false negative.
-- Therefore pull request #32, which introduces a permanent exact-build gate, correctly failed its `Production evidence` job and remains unmerged. Application, documentation, and SEO build jobs all passed.
-- The public GitHub Actions UI still associates the displayed documentation workflow identity with the former `blank.yml` path. The high-similarity workflow move in pull request #27 did not produce an independently executing documentation deployment identity.
-
-## Same-cycle repair
-
-A focused repair adds `.github/workflows/publish-docs-pages.yml` as a genuinely separate file while retaining the prior workflow, preventing another rename classification. The new workflow:
-
-- triggers from a successful `Quality` `workflow_run` on `main`, so it exists on the default branch before its event is evaluated;
-- accepts manual dispatch for recovery;
-- derives and validates the exact triggering `main` commit rather than deploying the workflow file's incidental checkout commit;
-- checks the triggering commit's diff and skips metadata-only or unrelated changes;
-- treats documentation content, MkDocs configuration, pinned documentation dependencies, and its own workflow path as deployment inputs;
-- checks out the verified source with full history and recursive submodules;
-- configures Pages for workflow publishing, builds with pinned dependencies and `mkdocs build --strict`, and uploads through official Pages actions;
-- verifies generated index, build identity, bilingual troubleshooting page, canonical manual pages, privacy boundary, and repository references before upload;
-- deploys with Pages and OIDC permissions through the `github-pages` environment;
-- waits for the custom domain to expose both the exact commit and the actual bilingual troubleshooting content.
-
-## Validation state
-
-- All merged product and content pull requests used real non-draft PRs, complete expected CI, final self-review, and squash merge.
-- Shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
+- PR #19 final Quality run 30998009742 passed after findings from the first green review were fixed and rerun.
+- PR #20 Quality run 30998402518 passed.
+- PR #21 Quality run 31000279292 passed dependency audit, ESLint, TypeScript, application build, and SEO-data validation.
+- PR #22 Quality run 31001024829 passed.
+- PR #23 Quality run 31002086657 passed application, strict documentation, and SEO jobs; final 24-file review was clean.
+- PR #25 Quality run 31003643559 passed all expected jobs and final workflow/security review.
+- PR #27 Quality run 31028991965 passed all expected jobs and final trigger/permissions review.
+- PR #31 final Quality run 31030398159 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation; the final diff was reviewed again after a wording-only evidence correction.
+- PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data. Its Production evidence job verified the application and correctly failed after twelve documentation HTTP 404 responses.
+- PR #33 initial Documentation quality passed. Its initial SEO-data failure was caused solely by noncanonical daily-report headings; this commit restores the required `Evidence collected`, `Work performed`, `Validation and self-review`, `Delivery`, and `Decisions and follow-ups` sections before rerunning all checks.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
-- The independent workflow repair still requires PR CI, complete workflow/security review, squash merge, successful `workflow_run` execution, exact public documentation verification, a rerun or update of the permanent evidence gate, and final metadata closeout.
 
-## Decisions and next steps
+## Delivery
+
+- Bootstrap and policy: pull requests #14–#17
+- Product rescue: #19, squash `d8325d3f906e3aead84a4aec98d15815daf57545`
+- Verifiable application deployment: #20, squash `cba8cff1975d293947143f7efefc2b2db37d849a`
+- Stable dependency maintenance: #21, squash `f86d7967f44ae57d83c558a63e322f52dd18373a`
+- Truthful TXT-only format boundary: #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
+- Documentation and community repair: #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
+- Official documentation Pages implementation: #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Documentation workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Bilingual TXT troubleshooting and canonical manual paths: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Permanent evidence gate: #32, open and intentionally blocked by missing documentation deployment
+- Independent documentation deployer: #33, open; CI rerun, final review, squash merge, workflow execution, and public verification pending
+- Final metadata-only closeout: pending
+- Branch cleanup: best-effort and nonblocking
+
+## Decisions and follow-ups
 
 - A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Public custom domains must expose the exact recorded commit and intended content.
 - Failed evidence checks remain blocking evidence, not inconveniences to bypass.
+- A `workflow_run` deployer may check out only the successful `Quality` run's `main` commit; it must not execute a pull-request head or untrusted event content.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
-- Next product priorities after closeout are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a real secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
-
-The cycle remains incomplete until the independent documentation deployer succeeds, pull request #32 or its current-main replacement proves both public builds, and the metadata-only closeout passes CI, final review, and squash merge.
+- After deployment closeout, next product priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a real secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
+- The cycle remains incomplete until the independent documentation deployer succeeds, pull request #32 or its current-main replacement proves both public builds, and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,85 +2,77 @@
 
 ## Scope
 
-Complete a same-day rescue and maintenance cycle for WebNR: establish autonomous operations, repair first use, privacy, accessibility, PWA behavior, crawlability, dependencies, truthful format support, application/documentation deployment, public guidance, and community infrastructure; close out only after both production domains expose exact verified builds.
+Establish autonomous operation and complete a same-day product rescue for WebNR: repair first use, privacy, accessibility, PWA behavior, crawlability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production deployment. Publish at least one meaningful user-visible update and close only after exact public application and documentation builds are verified.
 
 ## Data window
 
 - Local operating date: 2026-08-05 (`America/Los_Angeles`)
 - Analytics target: 28 finalized days with a 3-day lag
-- Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no matching GA4 or Search Console exports
+- Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no GA4 or Search Console export
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs/logs, dependency metadata, deployment artifacts, DNS/response evidence, workflow history, public build endpoints, and generated app/docs output
+- Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, public Actions identity, DNS, response headers, custom-domain build endpoints, and visible public content
 
-## Evidence collected
+## Delivered product and content work
 
-- The former app had no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
-- The former dependency stack used Next.js 15.2.4, deprecated lint/decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
-- EPUB was falsely advertised even though no EPUB parser existed.
-- The former documentation workflow used an invalid checkout option, unpinned dependencies, no strict PR build, Google Analytics, obsolete repository links, speculative content, and no exact public build identity.
-- Pull requests #19 through #23 repaired those product, dependency, format, documentation, CI, and community defects and were squash-merged after complete expected CI and final self-review.
-- Pull request #25 merged the official GitHub Pages artifact/deployment implementation as `57b6123141dc6b3396f41afe03c47ffead6fe66f`, but its legacy workflow identity produced no push run.
-- Pull request #27 registered that implementation under a fresh `.github/workflows/docs-pages.yml` identity and merged as `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- Evidence runs 31028681157 and 31029453474 verified the exact application deployments and observed repeated documentation HTTP 404 responses through Cloudflare with `no-store`; the second run waited across eight cache-busted attempts.
-- No documentation workflow run was observed for the push that first introduced the new workflow path, so a subsequent matching docs-path push is being used to trigger and verify the workflow now present on `main`.
-- The generated navigation still used the misspelled `mannual` directory, and no dedicated TXT import troubleshooting page covered encoding, CORS, browser storage, PWA update behavior, or privacy-safe bug reports.
-- The shared SEO skill remains current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule movement is required in this follow-up.
+- Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, autonomous task, and nonblocking branch-cleanup policy.
+- Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, Service Worker updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Pull request #20 added exact application build identity, generated-artifact assertions, source-SHA deployment messages, and live verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Pull request #21 upgraded to supported Next.js 15.5.22, repaired browser decoding and tooling, regenerated the npm lockfile, and added a dependency-audit boundary; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- Pull request #22 stopped accepting and advertising EPUB because no EPUB parser existed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+- Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published truthful bilingual guidance, security, roadmap, contribution and issue-reporting content, and deleted unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Pull request #25 implemented official GitHub Pages artifact deployment; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
+- Pull request #27 moved the intended documentation workflow to `.github/workflows/docs-pages.yml`; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
+- Pull request #31 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, SEO-data validation, and two complete final reviews. It published a substantial bilingual TXT import troubleshooting guide, corrected `mannual` to `manual`, repaired all current links, and merged as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
 
-## Work performed
+## User-visible knowledge delivered by pull request #31
 
-- Added and pinned `AutoArchive/seo-skill`, public-safe operating data, and a daily external operator requiring meaningful public progress and same-cycle repair of confirmed defects.
-- Pull request #19 delivered visible TXT/URL import, first-use onboarding, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, repaired PWA caching, metadata, JSON-LD, robots, sitemap, and a single static-export configuration.
-- Pull request #20 added exact app build identity, artifact/privacy assertions, source-SHA deployment messages, and public verification.
-- Pull request #21 upgraded to stable Next.js 15.5.22, repaired browser decoding and tooling, regenerated/secured the npm lockfile, and added a permanent dependency-audit boundary.
-- Pull request #22 rejected unsupported local formats and removed false EPUB claims from UI, metadata, structured data, and install metadata.
-- Pull request #23 pinned the MkDocs toolchain, added strict docs CI, removed analytics and obsolete links, published truthful bilingual guidance/security/roadmap/contribution content, added structured community forms, updated Actions, and deleted unrelated generic AI articles.
-- Pull requests #24, #26, and #30 were intentionally not merged after their exact public evidence jobs exposed the unresolved documentation deployment sequence.
-- Pull request #25 migrated documentation delivery to the official GitHub Pages artifact/deployment API.
-- Pull request #27 registered the deployment under a fresh workflow identity and passed dependency audit, ESLint, TypeScript, production app build, strict docs build, SEO-data validation, and final workflow review before squash merge.
-- Closed stale pull request #18 because it would have reintroduced third-party analytics contrary to the merged privacy contract.
-- Requested a current-main rebase for focused Lodash update pull request #12; it remains separate until rebase and CI complete.
-- Created a durable public documentation update that:
-  - publishes a bilingual TXT import troubleshooting guide;
-  - documents supported formats without implying EPUB support;
-  - gives reproducible checks for UTF-8, GB18030, Big5, malformed or binary files, direct text URLs, CORS, HTTP status failures, browser storage loss, and stale installed PWA shells;
-  - explains privacy-safe issue reporting with exact `/build.json` evidence and authorized minimal fixtures;
-  - corrects `mannual` to `manual` for contributing and URL-parameter pages;
-  - repairs every repository, docs home, source guide, and bilingual release-archive link;
-  - clarifies URL parameter encoding, CORS, access-control, and credential-safety boundaries.
-- This docs-path change is also the first real push that can trigger the already-existing `docs-pages.yml` deployment workflow.
+The TXT troubleshooting guide is tied to current implementation rather than generic search content. It covers:
 
-## Validation and self-review
+- actual supported inputs: local plain `.txt` files and permitted HTTP/HTTPS text URLs;
+- UTF-8, GB18030, Big5, malformed bytes, mixed encoding, and binary containers renamed as TXT;
+- CORS, direct-text endpoints, redirects, HTTP 401/403/404, content-type failures, timeouts, and large requests;
+- the explicit boundary that WebNR does not operate a public proxy or bypass login, payment, DRM, robots, rate limits, or access controls;
+- browser-profile storage loss and the need to retain original files until backup/restore exists;
+- safe PWA refresh steps that do not begin by clearing site data;
+- privacy-safe bug reports using the public `/build.json` identity and synthetic, public-domain, self-owned, or explicitly authorized fixtures.
 
-- PR #19 final Quality run 30998009742: passed after runtime findings from the first green review were fixed and rerun; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- PR #20 Quality run 30998402518: passed; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- PR #21 Quality run 31000279292: passed dependency audit, ESLint, TypeScript, app build, and SEO data; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-- PR #22 Quality run 31001024829: passed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-- PR #23 Quality run 31002086657: passed app, strict docs, and SEO jobs; final 24-file review was clean; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-- PR #25 Quality run 31003643559: all expected jobs passed; final workflow/security/deployment review found no unresolved thread; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
-- PR #27 Quality run 31028991965: all expected jobs passed; final rename/trigger/permissions review was clean; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- TXT troubleshooting/manual-path PR CI, final diff/link review, squash merge, exact app/docs deployment, permanent evidence merge, and metadata closeout: pending.
-- No credentials, raw provider exports, analytics IDs, private URLs, user filenames, book titles/content/history, source credentials, or cookies were committed.
+## Production evidence and confirmed deployment defect
 
-## Delivery
+- Application deployment for pull request #31 succeeded. Production-evidence job 92390516464 observed `https://app.webnovel.win/build.json` at exact commit `57c904bb637b97eb0b8cc9a99e035d91c39574fb` through Cloudflare.
+- The same job resolved both custom domains to Cloudflare addresses and made twelve cache-busted documentation requests over approximately two minutes.
+- Every request to `https://www.webnovel.win/build.json` returned HTTP 404 with `cache-control: no-store`; this was not a cached false negative.
+- Therefore pull request #32, which introduces a permanent exact-build gate, correctly failed its `Production evidence` job and remains unmerged. Application, documentation, and SEO build jobs all passed.
+- The public GitHub Actions UI still associates the displayed documentation workflow identity with the former `blank.yml` path. The high-similarity workflow move in pull request #27 did not produce an independently executing documentation deployment identity.
 
-- Bootstrap and policy: pull requests #14–#17
-- Product rescue: pull request #19, squash `d8325d3f906e3aead84a4aec98d15815daf57545`
-- Verifiable app deployment: pull request #20, squash `cba8cff1975d293947143f7efefc2b2db37d849a`
-- Stable dependency maintenance: pull request #21, squash `f86d7967f44ae57d83c558a63e322f52dd18373a`
-- TXT-only format correction: pull request #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
-- Documentation/community repair: pull request #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
-- Documentation Pages API implementation: pull request #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
-- Documentation workflow activation: pull request #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
-- Active TXT troubleshooting branch: `seo/publish-txt-import-troubleshooting`
-- Active troubleshooting PR/squash, exact app/docs deployment, permanent evidence PR, and final metadata-only closeout PR: pending
-- Branch cleanup: best-effort and non-blocking
+## Same-cycle repair
 
-## Decisions and follow-ups
+A focused repair adds `.github/workflows/publish-docs-pages.yml` as a genuinely separate file while retaining the prior workflow, preventing another rename classification. The new workflow:
 
-- A generated branch, workflow URL, HTTP 200, or merge is not deployment proof; public custom domains must expose the exact recorded commit.
-- When no run is observed for a workflow-creation push, use a later matching event and verify its execution rather than assuming deployment.
-- Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and tests exist.
-- Troubleshooting content must be tied to implemented behavior, reproducible checks, and privacy-safe reporting rather than generic advice.
-- Stable software is preferred over preview framework releases solely to silence build-chain advisories; any critical or unexpected high finding blocks CI.
-- Daily content must be real product, release, troubleshooting, compatibility, benchmark, or engineering knowledge; generic AI articles and thin pages are prohibited.
-- The cycle remains incomplete until the TXT guide deploys through the existing workflow, the permanent public-evidence PR merges, and the final metadata-only closeout PR passes CI, review, and squash merge.
+- triggers from a successful `Quality` `workflow_run` on `main`, so it exists on the default branch before its event is evaluated;
+- accepts manual dispatch for recovery;
+- derives and validates the exact triggering `main` commit rather than deploying the workflow file's incidental checkout commit;
+- checks the triggering commit's diff and skips metadata-only or unrelated changes;
+- treats documentation content, MkDocs configuration, pinned documentation dependencies, and its own workflow path as deployment inputs;
+- checks out the verified source with full history and recursive submodules;
+- configures Pages for workflow publishing, builds with pinned dependencies and `mkdocs build --strict`, and uploads through official Pages actions;
+- verifies generated index, build identity, bilingual troubleshooting page, canonical manual pages, privacy boundary, and repository references before upload;
+- deploys with Pages and OIDC permissions through the `github-pages` environment;
+- waits for the custom domain to expose both the exact commit and the actual bilingual troubleshooting content.
+
+## Validation state
+
+- All merged product and content pull requests used real non-draft PRs, complete expected CI, final self-review, and squash merge.
+- Shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
+- No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
+- The independent workflow repair still requires PR CI, complete workflow/security review, squash merge, successful `workflow_run` execution, exact public documentation verification, a rerun or update of the permanent evidence gate, and final metadata closeout.
+
+## Decisions and next steps
+
+- A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Public custom domains must expose the exact recorded commit and intended content.
+- Failed evidence checks remain blocking evidence, not inconveniences to bypass.
+- Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
+- Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
+- Next product priorities after closeout are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a real secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
+- Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
+
+The cycle remains incomplete until the independent documentation deployer succeeds, pull request #32 or its current-main replacement proves both public builds, and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,14 +3,14 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, application deployment, and community repairs are merged; a real documentation content update is activating the newly registered Pages workflow before permanent evidence and closeout
-- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, audit, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #27
-- Last squash merge: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Active operating cycle: product, dependency, truthful format support, public guidance, application deployment, and community repairs are merged; documentation production is being repaired through a genuinely independent workflow before permanent evidence and closeout
+- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
+- Last site-change pull request: #31
+- Last squash merge: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
-- Last successful attributable documentation artifact: strict documentation builds pass, but the public documentation custom domain still returns 404 until the already-registered workflow receives a subsequent docs push
-- Last public verification: production-evidence runs verified the exact application commits and repeatedly observed documentation HTTP 404 through Cloudflare with `no-store`
+- Last successful attributable application deployment: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Last successful attributable documentation artifact: strict documentation builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
+- Last public verification: pull request #32 production-evidence job verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb`; twelve cache-busted documentation requests returned HTTP 404 through Cloudflare
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
@@ -20,21 +20,22 @@
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, and custom-domain build endpoints.
 - Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation delivery: pull request #25 implemented official Pages artifact deployment and pull request #27 registered it under a fresh workflow identity; the first later docs change is now required to trigger the workflow that already exists on `main`.
-- Documentation content: active work publishes a bilingual, reproducible TXT import troubleshooting guide and corrects the misspelled `mannual` public path to `manual` across repository and generated-site links.
+- Documentation content: pull request #31 passed all expected CI and final review and merged the bilingual TXT import troubleshooting guide plus canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Documentation deployment diagnosis: the public Actions UI still associates the displayed documentation workflow with the old `blank.yml` identity, and no production deployment from the high-similarity rename reached the custom domain.
+- Documentation deployment repair: active work adds a separate workflow file while retaining the prior file, so GitHub cannot classify it as another rename. It runs only after successful `Quality` completion on `main`, selects the exact verified source commit, deploys only when documentation-delivery files changed, and verifies both build identity and the public troubleshooting page.
 - Privacy: the stale pull request that would have restored third-party reader analytics was closed as superseded.
 - Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
-- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, and structured issue forms replace obsolete links and unrelated generic AI articles.
+- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, troubleshooting, and structured issue forms replace obsolete links and unrelated generic AI articles.
 - Autonomous operation: at least one meaningful public production update and same-cycle repair of confirmed defects are required each local day.
 - Branch cleanup: best-effort and non-blocking.
 
 ## Active focus
 
-- Validate and merge the TXT troubleshooting/manual-path documentation update.
-- Observe the existing `docs-pages.yml` workflow on the resulting main-branch push and verify its exact public build.
-- Recreate and merge the permanent custom-domain production-evidence gate against the resulting app/docs commit.
-- Complete a metadata-only closeout pull request with the full PR, CI, squash, deployment, public-verification, analytics-availability, and submodule record.
-- Continue dependency maintenance after current-main rebases pass the permanent evidence gate.
+- Validate and merge the independent documentation deployer after complete CI and final security/workflow review.
+- Observe its `workflow_run` execution after the successful `Quality` push on `main` and verify the exact custom-domain build plus troubleshooting page.
+- Update or recreate the permanent production-evidence pull request against the repaired deployment.
+- Complete the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
+- Evaluate remaining focused Dependabot pull requests after the permanent evidence gate; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
 This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.

--- a/.github/workflows/publish-docs-pages.yml
+++ b/.github/workflows/publish-docs-pages.yml
@@ -24,33 +24,47 @@ jobs:
     name: Select verified documentation source
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == github.event.repository.default_branch &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       source_sha: ${{ steps.source.outputs.sha }}
       should_deploy: ${{ steps.changes.outputs.should_deploy }}
     steps:
-      - name: Select source commit
+      - name: Select trusted source commit
         id: source
         env:
           EVENT_NAME: ${{ github.event_name }}
           WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
-          DEFAULT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          set -eu
+          set -euo pipefail
           if [ "${EVENT_NAME}" = 'workflow_run' ]; then
             source_sha="${WORKFLOW_RUN_SHA}"
           else
-            source_sha="${DEFAULT_SHA}"
+            source_sha="$(
+              curl --fail-with-body --silent --show-error \
+                --header 'Accept: application/vnd.github+json' \
+                --header "Authorization: Bearer ${GH_TOKEN}" \
+                --header 'X-GitHub-Api-Version: 2022-11-28' \
+                "https://api.github.com/repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" \
+              | python3 -c 'import json, sys; print(json.load(sys.stdin)["sha"])'
+            )"
           fi
-          case "${source_sha}" in
-            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
-            *) echo "Invalid source commit: ${source_sha}" >&2; exit 1 ;;
-          esac
+          if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid source commit: ${source_sha}" >&2
+            exit 1
+          fi
           printf 'sha=%s\n' "${source_sha}" >> "${GITHUB_OUTPUT}"
 
-      - name: Checkout source history
+      - name: Checkout trusted source history
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.source.outputs.sha }}
@@ -62,7 +76,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           SOURCE_SHA: ${{ steps.source.outputs.sha }}
         run: |
-          set -eu
+          set -euo pipefail
           if [ "${EVENT_NAME}" = 'workflow_dispatch' ]; then
             should_deploy=true
           elif git diff --quiet "${SOURCE_SHA}^" "${SOURCE_SHA}" -- \

--- a/.github/workflows/publish-docs-pages.yml
+++ b/.github/workflows/publish-docs-pages.yml
@@ -1,0 +1,203 @@
+name: Publish WebNR documentation
+
+on:
+  workflow_run:
+    workflows:
+      - Quality
+    types:
+      - completed
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: webnr-documentation-production
+  cancel-in-progress: false
+
+jobs:
+  select-source:
+    name: Select verified documentation source
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+      should_deploy: ${{ steps.changes.outputs.should_deploy }}
+    steps:
+      - name: Select source commit
+        id: source
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          if [ "${EVENT_NAME}" = 'workflow_run' ]; then
+            source_sha="${WORKFLOW_RUN_SHA}"
+          else
+            source_sha="${DEFAULT_SHA}"
+          fi
+          case "${source_sha}" in
+            [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+            *) echo "Invalid source commit: ${source_sha}" >&2; exit 1 ;;
+          esac
+          printf 'sha=%s\n' "${source_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout source history
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.source.outputs.sha }}
+          fetch-depth: 2
+
+      - name: Detect documentation delivery changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          set -eu
+          if [ "${EVENT_NAME}" = 'workflow_dispatch' ]; then
+            should_deploy=true
+          elif git diff --quiet "${SOURCE_SHA}^" "${SOURCE_SHA}" -- \
+            docs \
+            mkdocs.yml \
+            .github/requirements-docs.txt \
+            .github/workflows/publish-docs-pages.yml; then
+            should_deploy=false
+          else
+            should_deploy=true
+          fi
+          printf 'should_deploy=%s\n' "${should_deploy}" >> "${GITHUB_OUTPUT}"
+          printf 'Documentation deployment selected: %s\n' "${should_deploy}"
+
+  build:
+    name: Build documentation artifact
+    needs: select-source
+    if: needs.select-source.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout verified source
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.select-source.outputs.source_sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: .github/requirements-docs.txt
+
+      - name: Install pinned documentation dependencies
+        run: pip install --requirement .github/requirements-docs.txt
+
+      - name: Configure repository Pages for workflow publishing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request PUT \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${REPOSITORY}/pages" \
+            --data '{"build_type":"workflow"}'
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Write exact documentation build identity
+        env:
+          BUILD_SHA: ${{ needs.select-source.outputs.source_sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          payload = {
+              "commit": os.environ["BUILD_SHA"],
+              "builtAt": datetime.now(timezone.utc).isoformat(),
+              "source": "github-pages-workflow",
+          }
+          Path("docs/build.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Build documentation strictly
+        run: mkdocs build --strict
+
+      - name: Validate documentation artifact
+        env:
+          BUILD_SHA: ${{ needs.select-source.outputs.source_sha }}
+        run: |
+          set -eu
+          test -f site/index.html
+          test -f site/build.json
+          test -f site/troubleshooting/txt-import/index.html
+          test -f site/manual/contributing/index.html
+          test -f site/manual/url-params/index.html
+          grep -Fq "${BUILD_SHA}" site/build.json
+          grep -Fq 'TXT import troubleshooting' site/troubleshooting/txt-import/index.html
+          grep -Fq 'TXT 导入排障' site/troubleshooting/txt-import/index.html
+          grep -Fq 'AutoArchive/webNR' site/index.html
+          if grep -R -Fq 'googletagmanager.com' site; then
+            echo 'Unexpected Google Analytics loader in documentation artifact' >&2
+            exit 1
+          fi
+          if grep -R -E -q 'yourusername/webnr|yunwei37/webNR' site; then
+            echo 'Obsolete repository reference in documentation artifact' >&2
+            exit 1
+          fi
+
+      - name: Upload documentation Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    name: Deploy and verify documentation
+    needs:
+      - select-source
+      - build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy documentation to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+      - name: Verify exact documentation deployment
+        env:
+          BUILD_SHA: ${{ needs.select-source.outputs.source_sha }}
+          PRODUCTION_BUILD_URL: https://www.webnovel.win/build.json
+          TROUBLESHOOTING_URL: https://www.webnovel.win/troubleshooting/txt-import/
+        run: |
+          set -u
+          for attempt in $(seq 1 30); do
+            build_response="$(curl --fail --silent --show-error --max-time 15 "${PRODUCTION_BUILD_URL}?commit=${BUILD_SHA}&attempt=${attempt}" || true)"
+            guide_response="$(curl --fail --silent --show-error --max-time 15 "${TROUBLESHOOTING_URL}?commit=${BUILD_SHA}&attempt=${attempt}" || true)"
+            if printf '%s' "${build_response}" | grep -Fq "\"commit\": \"${BUILD_SHA}\"" \
+              && printf '%s' "${guide_response}" | grep -Fq 'TXT import troubleshooting' \
+              && printf '%s' "${guide_response}" | grep -Fq 'TXT 导入排障'; then
+              printf 'Verified documentation commit and troubleshooting guide for %s\n' "${BUILD_SHA}"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Documentation did not expose expected commit and guide for ${BUILD_SHA}" >&2
+          exit 1


### PR DESCRIPTION
## Evidence

Pull request #31 merged the bilingual TXT troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`. The application deployed that exact commit, but permanent evidence job 92390516464 made twelve cache-busted documentation requests and every request returned Cloudflare HTTP 404 with `cache-control: no-store`.

The public Actions UI still associates the displayed documentation workflow with the former `blank.yml` path. The high-similarity move performed in pull request #27 did not result in an independently executing documentation workflow identity.

## Coherent repair

- add `.github/workflows/publish-docs-pages.yml` as a genuinely separate file while retaining the previous workflow, preventing another rename classification
- trigger after a successful `Quality` workflow on `main`, when the new workflow is already present on the default branch
- select and validate the exact triggering source commit
- inspect the source commit diff and skip metadata-only or unrelated changes
- build with pinned dependencies and strict MkDocs validation
- assert the exact build identity, bilingual TXT troubleshooting page, canonical manual pages, privacy boundary, and current repository references
- publish through official Pages artifact/deployment actions with Pages and OIDC permissions
- verify the custom domain exposes both the exact commit and the actual bilingual troubleshooting content
- preserve manual dispatch for recovery

## Security review boundary

The `workflow_run` trigger accepts only successful `Quality` runs whose head branch is `main`. It never checks out a pull-request head or executes untrusted event text. The selected SHA must be a 40-character hexadecimal commit, and deployment occurs only for documentation-delivery changes. No secrets beyond GitHub's scoped token and Pages OIDC are introduced.

## Required checks

- dependency audit, ESLint, TypeScript, and production app build
- strict pinned documentation build and generated-output assertions
- SEO-data validation
- complete final review of trigger trust, source selection, changed-file detection, permissions, artifact checks, deployment, public verification, and privacy boundary

## Post-merge acceptance

After this PR squash-merges, the successful `Quality` push run must trigger the new independent workflow. The workflow must deploy the exact squash commit and verify `https://www.webnovel.win/build.json` plus the bilingual TXT troubleshooting page. The permanent evidence PR remains blocked until both public custom domains expose the exact recorded commit.
