### PR TITLE
ci: permanently verify exact public app and documentation builds

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Establish autonomous operation and complete a same-day product rescue for WebNR: repair first use, privacy, accessibility, PWA behavior, crawlability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production deployment. Publish at least one meaningful user-visible update and close only after exact public application and documentation builds are verified.
+Complete a same-day WebNR product rescue and operating cycle: repair first use, privacy, accessibility, PWA behavior, crawlability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production deployment. Publish meaningful user-visible troubleshooting content and close only after exact public application and documentation builds are proven.
 
 ## Data window
 
@@ -10,57 +10,49 @@ Establish autonomous operation and complete a same-day product rescue for WebNR:
 - Analytics target: 28 finalized days with a 3-day lag
 - Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no GA4 or Search Console export
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, public Actions identity, DNS, response headers, custom-domain build endpoints, and visible public content
+- Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, GitHub workflow identity, DNS, response headers, custom-domain build endpoints, and visible public content
 
 ## Evidence collected
 
-- The former application had no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
-- The former dependency stack used Next.js 15.2.4, deprecated lint and decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
+- The original application had no reachable first-use import path, loaded analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
+- The original dependency stack used Next.js 15.2.4, deprecated lint and decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
 - EPUB was accepted and advertised although no EPUB parser existed.
-- The former documentation workflow used an invalid checkout option, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, speculative generic content, and no exact public build identity.
-- Pull request #31 merged the bilingual TXT troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb` after all expected CI and two complete final reviews.
-- Production-evidence job 92390516464 verified `https://app.webnovel.win/build.json` at exact commit `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- The same job resolved both custom domains to Cloudflare and made twelve cache-busted requests to `https://www.webnovel.win/build.json`; every response was HTTP 404 with `cache-control: no-store`, so the failure was not a cached false negative.
-- Pull request #32 correctly remained unmerged because its permanent `Production evidence` check failed only on the missing documentation deployment; its application, documentation, and SEO jobs passed.
-- The public GitHub Actions UI still associated the displayed documentation workflow with the former `blank.yml` identity. The high-similarity workflow move in pull request #27 did not produce an independently executing documentation deployment identity.
+- The original documentation workflow had broken checkout configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete links, generic AI content, and no exact public build identity.
+- Pull request #31 merged a bilingual TXT import troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb` after all expected CI and two complete final reviews.
+- Production-evidence job 92390516464 verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb` and observed twelve cache-busted documentation HTTP 404 responses with `cache-control: no-store`.
+- Pull request #32 correctly remained unmerged because its permanent evidence check proved the application but could not prove documentation deployment.
+- The displayed documentation workflow remained associated with the former `blank.yml` identity, confirming that a high-similarity workflow move had not created an independently executing deployment identity.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
 
-- Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, autonomous task, and nonblocking branch-cleanup policy.
-- Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, Service Worker updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Pull request #20 added exact application build identity, generated-artifact assertions, source-SHA deployment messages, and live verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- Pull request #21 upgraded to supported Next.js 15.5.22, repaired browser decoding and tooling, regenerated the npm lockfile, and added a dependency-audit boundary; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-- Pull request #22 stopped accepting and advertising EPUB because no EPUB parser existed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-- Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published truthful bilingual guidance, security, roadmap, contribution and issue-reporting content, and deleted unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, daily autonomous operation, and nonblocking branch-cleanup policy.
+- Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, PWA updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Pull request #20 added exact application build identity and production verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Pull request #21 upgraded to supported Next.js 15.5.22, repaired browser decoding and tooling, regenerated the lockfile, and added dependency-audit enforcement; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- Pull request #22 stopped accepting and advertising unsupported EPUB; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+- Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published bilingual product/security/roadmap/contribution content, added structured issue forms, and removed unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 - Pull request #25 implemented official GitHub Pages artifact deployment; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
-- Pull request #27 moved the intended documentation workflow to `.github/workflows/docs-pages.yml`; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- Pull request #31 published a substantial bilingual TXT import troubleshooting guide, corrected `mannual` to `manual`, and repaired all current repository and generated-documentation links; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- The guide documents actual supported inputs, UTF-8/GB18030/Big5 failures, binary containers renamed as TXT, CORS, redirects, HTTP failures, browser storage loss, safe PWA refresh steps, and privacy-safe authorized reproduction. It explicitly rejects bypassing login, payment, DRM, robots, rate limits, or access controls.
-- Opened pull request #32 with a permanent exact-build verifier; its failed documentation evidence was retained as a blocking diagnosis rather than bypassed.
-- Created a focused independent documentation deployer in `.github/workflows/publish-docs-pages.yml` while retaining the prior workflow, so GitHub cannot classify this change as another workflow rename.
-- The independent deployer:
-  - triggers only after a successful `Quality` workflow on `main`, or by manual recovery dispatch;
-  - selects and validates the exact triggering source SHA;
-  - skips commits unrelated to documentation delivery;
-  - checks out the verified source with full history and recursive submodules;
-  - builds with pinned dependencies and `mkdocs build --strict`;
-  - validates exact build identity, the bilingual TXT troubleshooting page, canonical manual pages, privacy boundaries, and current repository links;
-  - publishes through official Pages artifact/deployment actions with Pages and OIDC permissions;
-  - waits until the custom domain exposes both the exact commit and the intended bilingual guide.
+- Pull request #27 attempted to move documentation delivery to a new workflow path; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
+- Pull request #31 published the bilingual TXT troubleshooting guide, covering real TXT/URL inputs, UTF-8/GB18030/Big5 failures, binary files renamed as TXT, CORS, redirects, HTTP errors, browser storage loss, safe PWA refresh, and privacy-safe authorized reproduction; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Pull request #33 added a genuinely independent documentation Pages workflow while retaining the prior workflow, passed all expected CI, received a complete security review, and squash-merged as `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
+- The final #33 security review required the privileged `workflow_run` path to accept only a successful same-repository `push` on the default branch. It rejects fork/PR sources, validates the 40-character source SHA, and makes manual recovery resolve the current default-branch commit instead of an arbitrary selected ref.
+- Created a current-main permanent evidence gate that adds a required `Production evidence` job, verifies DNS and cache-busted public build identities for both domains, and prevents evidence-only changes from triggering redundant application deployment.
 
 ## Validation and self-review
 
-- PR #19 final Quality run 30998009742 passed after findings from the first green review were fixed and rerun.
+- PR #19 final Quality run 30998009742 passed after initial review findings were fixed and rerun.
 - PR #20 Quality run 30998402518 passed.
 - PR #21 Quality run 31000279292 passed dependency audit, ESLint, TypeScript, application build, and SEO-data validation.
 - PR #22 Quality run 31001024829 passed.
 - PR #23 Quality run 31002086657 passed application, strict documentation, and SEO jobs; final 24-file review was clean.
-- PR #25 Quality run 31003643559 passed all expected jobs and final workflow/security review.
-- PR #27 Quality run 31028991965 passed all expected jobs and final trigger/permissions review.
-- PR #31 final Quality run 31030398159 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation; the final diff was reviewed again after a wording-only evidence correction.
-- PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data. Its Production evidence job verified the application and correctly failed after twelve documentation HTTP 404 responses.
-- PR #33 initial Documentation quality passed. Its initial SEO-data failure was caused solely by noncanonical daily-report headings; this commit restores the required `Evidence collected`, `Work performed`, `Validation and self-review`, `Delivery`, and `Decisions and follow-ups` sections before rerunning all checks.
+- PR #25 Quality run 31003643559 passed all expected jobs and workflow/security review.
+- PR #27 Quality run 31028991965 passed all expected jobs and trigger/permissions review.
+- PR #31 final Quality run 31030398159 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
+- PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data; Production evidence correctly failed only on documentation HTTP 404.
+- PR #33 initial SEO-data failure exposed noncanonical report headings and was fixed on the same branch. Final Quality run 31031650857 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation after the privileged-workflow security hardening.
+- PR #33 had no unresolved review threads; final diff, source trust, changed-file detection, permissions, Pages artifact, public verification, privacy boundary, and mergeability were reviewed before squash merge.
+- The permanent evidence branch records application and documentation commit `e051c7f5cd6cc41eef84965404cafb493b8f84df`; those statements cannot reach `main` unless the same PR's required evidence job proves both public endpoints.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
@@ -69,23 +61,24 @@ Establish autonomous operation and complete a same-day product rescue for WebNR:
 - Product rescue: #19, squash `d8325d3f906e3aead84a4aec98d15815daf57545`
 - Verifiable application deployment: #20, squash `cba8cff1975d293947143f7efefc2b2db37d849a`
 - Stable dependency maintenance: #21, squash `f86d7967f44ae57d83c558a63e322f52dd18373a`
-- Truthful TXT-only format boundary: #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
+- Truthful TXT-only boundary: #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
 - Documentation and community repair: #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
-- Official documentation Pages implementation: #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
-- Documentation workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Official Pages implementation: #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
 - Bilingual TXT troubleshooting and canonical manual paths: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
-- Permanent evidence gate: #32, open and intentionally blocked by missing documentation deployment
-- Independent documentation deployer: #33, open; CI rerun, final review, squash merge, workflow execution, and public verification pending
+- Independent documentation deployer: #33, squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Superseded evidence diagnosis: #32 remains open until the current-main evidence PR is established, then will be closed without merge
+- Current-main permanent evidence PR: pending creation, CI, final review, and squash merge
 - Final metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
 
-- A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Public custom domains must expose the exact recorded commit and intended content.
-- Failed evidence checks remain blocking evidence, not inconveniences to bypass.
-- A `workflow_run` deployer may check out only the successful `Quality` run's `main` commit; it must not execute a pull-request head or untrusted event content.
+- A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Both public custom domains must expose the exact recorded commit.
+- Failed evidence checks remain blocking evidence and must not be bypassed.
+- Privileged `workflow_run` deployment may accept only successful same-repository default-branch pushes and must not execute pull-request or fork code.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
-- After deployment closeout, next product priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a real secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the independent documentation deployer succeeds, pull request #32 or its current-main replacement proves both public builds, and the metadata-only closeout passes CI, final review, and squash merge.
+- After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
+- The cycle remains incomplete until the permanent evidence PR proves `e051c7f5cd6cc41eef84965404cafb493b8f84df` on both domains and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,39 +3,37 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, public guidance, application deployment, and community repairs are merged; documentation production is being repaired through a genuinely independent workflow before permanent evidence and closeout
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and independent application/documentation delivery are merged; permanent public evidence and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #31
-- Last squash merge: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Last site-change pull request: #33
+- Last squash merge: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
-- Last successful attributable documentation artifact: strict documentation builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
-- Last public verification: pull request #32 production-evidence job verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb`; twelve cache-busted documentation requests returned HTTP 404 through Cloudflare
+- Last successful attributable application deployment: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Last successful attributable documentation deployment: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Last public verification: this pull request cannot merge unless its required `Production evidence` job proves both public `/build.json` endpoints expose `e051c7f5cd6cc41eef84965404cafb493b8f84df`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, and custom-domain build endpoints.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks use DNS, response headers, cache-busted custom-domain requests, and exact build identities.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, exact public production evidence, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation content: pull request #31 passed all expected CI and final review and merged the bilingual TXT import troubleshooting guide plus canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Documentation deployment diagnosis: the public Actions UI still associates the displayed documentation workflow with the old `blank.yml` identity, and no production deployment from the high-similarity rename reached the custom domain.
-- Documentation deployment repair: active work adds a separate workflow file while retaining the prior file, so GitHub cannot classify it as another rename. It runs only after successful `Quality` completion on `main`, selects the exact verified source commit, deploys only when documentation-delivery files changed, and verifies both build identity and the public troubleshooting page.
-- Privacy: the stale pull request that would have restored third-party reader analytics was closed as superseded.
-- Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
-- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, troubleshooting, and structured issue forms replace obsolete links and unrelated generic AI articles.
+- Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Documentation deployment: pull request #33 merged an independently registered, security-reviewed Pages workflow as `e051c7f5cd6cc41eef84965404cafb493b8f84df`; it accepts only successful same-repository default-branch Quality pushes or a maintainer-dispatched current default-branch commit.
+- Privacy: the reader and generated documentation do not load third-party analytics; operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, or credentials.
+- Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
+- Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
 - Autonomous operation: at least one meaningful public production update and same-cycle repair of confirmed defects are required each local day.
-- Branch cleanup: best-effort and non-blocking.
+- Branch cleanup: best-effort and nonblocking.
 
 ## Active focus
 
-- Validate and merge the independent documentation deployer after complete CI and final security/workflow review.
-- Observe its `workflow_run` execution after the successful `Quality` push on `main` and verify the exact custom-domain build plus troubleshooting page.
-- Update or recreate the permanent production-evidence pull request against the repaired deployment.
-- Complete the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
-- Evaluate remaining focused Dependabot pull requests after the permanent evidence gate; do not blindly merge Next.js 16 major-upgrade proposals.
+- Pass the permanent custom-domain production-evidence check for exact application and documentation commit `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
+- Complete a clean final review and squash-merge the evidence gate without triggering a redundant production deployment.
+- Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
+- Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified facts or facts whose truth is enforced by the same pull request's required public-evidence check. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -107,3 +107,19 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+const maxAttempts = 42;
+const retryDelayMs = 10_000;
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) {
+    throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  }
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: {
+          accept: 'application/json',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+
+      if (!response.ok) {
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders,
+          };
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+
+    if (attempt < maxAttempts) {
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw new Error(
+    `${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`,
+  );
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') {
+    console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Production evidence failed:\n${failures.join('\n')}`);
+}


### PR DESCRIPTION
Superseded without merge.

This pull request correctly verified application commit `e051c7f5cd6cc41eef84965404cafb493b8f84df` and correctly failed after forty-two cache-busted documentation requests returned HTTP 404 with `cache-control: no-store`. That evidence demonstrated the indirect `workflow_run` publisher had not executed. Pull request #35 replaced it with a direct reviewed-main push publisher; pull request #36 is the current-main permanent evidence gate. No failed check was bypassed.