### PR TITLE
fix: publish documentation directly from reviewed main pushes

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Establish autonomous operation and complete a same-day product rescue for WebNR: repair first use, privacy, accessibility, PWA behavior, crawlability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production deployment. Publish at least one meaningful user-visible update and close only after exact public application and documentation builds are verified.
+Complete a same-day WebNR product rescue and operating cycle: repair first use, privacy, accessibility, PWA behavior, crawlability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production deployment. Publish meaningful user-visible troubleshooting content and close only after exact public application and documentation builds are proven.
 
 ## Data window
 
@@ -10,57 +10,52 @@ Establish autonomous operation and complete a same-day product rescue for WebNR:
 - Analytics target: 28 finalized days with a 3-day lag
 - Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no GA4 or Search Console export
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, public Actions identity, DNS, response headers, custom-domain build endpoints, and visible public content
+- Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, GitHub workflow identity, DNS, response headers, custom-domain build endpoints, and visible public content
 
 ## Evidence collected
 
-- The former application had no reachable first-use import path, loaded Google Analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
-- The former dependency stack used Next.js 15.2.4, deprecated lint and decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
+- The original application had no reachable first-use import path, loaded analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
+- The original dependency stack used Next.js 15.2.4, deprecated lint and decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
 - EPUB was accepted and advertised although no EPUB parser existed.
-- The former documentation workflow used an invalid checkout option, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, speculative generic content, and no exact public build identity.
-- Pull request #31 merged the bilingual TXT troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb` after all expected CI and two complete final reviews.
-- Production-evidence job 92390516464 verified `https://app.webnovel.win/build.json` at exact commit `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- The same job resolved both custom domains to Cloudflare and made twelve cache-busted requests to `https://www.webnovel.win/build.json`; every response was HTTP 404 with `cache-control: no-store`, so the failure was not a cached false negative.
-- Pull request #32 correctly remained unmerged because its permanent `Production evidence` check failed only on the missing documentation deployment; its application, documentation, and SEO jobs passed.
-- The public GitHub Actions UI still associated the displayed documentation workflow with the former `blank.yml` identity. The high-similarity workflow move in pull request #27 did not produce an independently executing documentation deployment identity.
+- The original documentation workflow had broken checkout configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete links, generic AI content, and no exact public build identity.
+- Pull request #31 merged a bilingual TXT import troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb` after all expected CI and two complete final reviews.
+- Pull request #32 production evidence verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb` but observed twelve cache-busted documentation HTTP 404 responses with `cache-control: no-store`.
+- Pull request #33 added a separate security-reviewed `workflow_run` documentation deployer and squash-merged as `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
+- Pull request #34 production evidence verified the application at exact `e051c7f5cd6cc41eef84965404cafb493b8f84df`; it then observed forty-two consecutive cache-busted documentation HTTP 404 responses through Cloudflare between 17:53 and 18:00 UTC.
+- The forty-two failures prove that the indirect documentation workflow did not publish, rather than merely requiring more propagation time.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
 
-- Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, autonomous task, and nonblocking branch-cleanup policy.
-- Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, Service Worker updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Pull request #20 added exact application build identity, generated-artifact assertions, source-SHA deployment messages, and live verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- Pull request #21 upgraded to supported Next.js 15.5.22, repaired browser decoding and tooling, regenerated the npm lockfile, and added a dependency-audit boundary; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-- Pull request #22 stopped accepting and advertising EPUB because no EPUB parser existed; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-- Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published truthful bilingual guidance, security, roadmap, contribution and issue-reporting content, and deleted unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, daily autonomous operation, and nonblocking branch-cleanup policy.
+- Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, PWA updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Pull request #20 added exact application build identity and production verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Pull request #21 upgraded to supported Next.js 15.5.22, repaired browser decoding and tooling, regenerated the lockfile, and added dependency-audit enforcement; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- Pull request #22 stopped accepting and advertising unsupported EPUB; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+- Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published bilingual product/security/roadmap/contribution content, added structured issue forms, and removed unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 - Pull request #25 implemented official GitHub Pages artifact deployment; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
-- Pull request #27 moved the intended documentation workflow to `.github/workflows/docs-pages.yml`; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- Pull request #31 published a substantial bilingual TXT import troubleshooting guide, corrected `mannual` to `manual`, and repaired all current repository and generated-documentation links; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- The guide documents actual supported inputs, UTF-8/GB18030/Big5 failures, binary containers renamed as TXT, CORS, redirects, HTTP failures, browser storage loss, safe PWA refresh steps, and privacy-safe authorized reproduction. It explicitly rejects bypassing login, payment, DRM, robots, rate limits, or access controls.
-- Opened pull request #32 with a permanent exact-build verifier; its failed documentation evidence was retained as a blocking diagnosis rather than bypassed.
-- Created a focused independent documentation deployer in `.github/workflows/publish-docs-pages.yml` while retaining the prior workflow, so GitHub cannot classify this change as another workflow rename.
-- The independent deployer:
-  - triggers only after a successful `Quality` workflow on `main`, or by manual recovery dispatch;
-  - selects and validates the exact triggering source SHA;
-  - skips commits unrelated to documentation delivery;
-  - checks out the verified source with full history and recursive submodules;
-  - builds with pinned dependencies and `mkdocs build --strict`;
-  - validates exact build identity, the bilingual TXT troubleshooting page, canonical manual pages, privacy boundaries, and current repository links;
-  - publishes through official Pages artifact/deployment actions with Pages and OIDC permissions;
-  - waits until the custom domain exposes both the exact commit and the intended bilingual guide.
+- Pull request #27 attempted to move documentation delivery to a new workflow path; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
+- Pull request #31 published the bilingual TXT troubleshooting guide, covering real TXT/URL inputs, UTF-8/GB18030/Big5 failures, binary files renamed as TXT, CORS, redirects, HTTP errors, browser storage loss, safe PWA refresh, and privacy-safe authorized reproduction; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Pull request #33 added a genuinely independent but indirect documentation Pages workflow; squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
+- Kept pull requests #32 and #34 blocked after their required evidence jobs failed; no check was bypassed and no false deployment claim was merged.
+- Prepared a focused replacement that changes documentation publication to a direct `push` workflow on the default branch, restricted to documentation content, MkDocs configuration, pinned documentation dependencies, and its own workflow file.
+- The direct publisher selects the exact default-branch commit, builds with pinned dependencies and `mkdocs build --strict`, validates the build identity and bilingual guide, uploads through official Pages actions, deploys through the `github-pages` environment, and verifies both the public build identity and guide content.
+- Updated the application publisher to ignore documentation-only paths so the repair does not replace the already verified application build with an unrelated documentation commit.
 
 ## Validation and self-review
 
-- PR #19 final Quality run 30998009742 passed after findings from the first green review were fixed and rerun.
+- PR #19 final Quality run 30998009742 passed after initial review findings were fixed and rerun.
 - PR #20 Quality run 30998402518 passed.
 - PR #21 Quality run 31000279292 passed dependency audit, ESLint, TypeScript, application build, and SEO-data validation.
 - PR #22 Quality run 31001024829 passed.
 - PR #23 Quality run 31002086657 passed application, strict documentation, and SEO jobs; final 24-file review was clean.
-- PR #25 Quality run 31003643559 passed all expected jobs and final workflow/security review.
-- PR #27 Quality run 31028991965 passed all expected jobs and final trigger/permissions review.
-- PR #31 final Quality run 31030398159 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation; the final diff was reviewed again after a wording-only evidence correction.
-- PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data. Its Production evidence job verified the application and correctly failed after twelve documentation HTTP 404 responses.
-- PR #33 initial Documentation quality passed. Its initial SEO-data failure was caused solely by noncanonical daily-report headings; this commit restores the required `Evidence collected`, `Work performed`, `Validation and self-review`, `Delivery`, and `Decisions and follow-ups` sections before rerunning all checks.
+- PR #25 Quality run 31003643559 passed all expected jobs and workflow/security review.
+- PR #27 Quality run 31028991965 passed all expected jobs and trigger/permissions review.
+- PR #31 final Quality run 31030398159 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
+- PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data; Production evidence correctly failed only on documentation HTTP 404.
+- PR #33 final Quality run 31031650857 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation after privileged-workflow security hardening.
+- PR #34 run 31032106290 passed Web quality, Documentation quality, and SEO data; Production evidence verified application `e051c7f5cd6cc41eef84965404cafb493b8f84df` and correctly failed after forty-two documentation HTTP 404 responses.
+- The direct-push replacement still requires complete PR CI, final workflow/security review, squash merge, exact public documentation verification, a current-main evidence gate, and metadata closeout.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
@@ -69,23 +64,25 @@ Establish autonomous operation and complete a same-day product rescue for WebNR:
 - Product rescue: #19, squash `d8325d3f906e3aead84a4aec98d15815daf57545`
 - Verifiable application deployment: #20, squash `cba8cff1975d293947143f7efefc2b2db37d849a`
 - Stable dependency maintenance: #21, squash `f86d7967f44ae57d83c558a63e322f52dd18373a`
-- Truthful TXT-only format boundary: #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
+- Truthful TXT-only boundary: #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
 - Documentation and community repair: #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
-- Official documentation Pages implementation: #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
-- Documentation workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
+- Official Pages implementation: #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
+- Workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
 - Bilingual TXT troubleshooting and canonical manual paths: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
-- Permanent evidence gate: #32, open and intentionally blocked by missing documentation deployment
-- Independent documentation deployer: #33, open; CI rerun, final review, squash merge, workflow execution, and public verification pending
-- Final metadata-only closeout: pending
+- Indirect documentation deployer: #33, squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Evidence diagnoses: #32 and #34 remain open and intentionally blocked by missing documentation production
+- Direct default-branch documentation publisher: pending PR, CI, final review, squash merge, and public verification
+- Final permanent evidence gate and metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
 
-- A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Public custom domains must expose the exact recorded commit and intended content.
-- Failed evidence checks remain blocking evidence, not inconveniences to bypass.
-- A `workflow_run` deployer may check out only the successful `Quality` run's `main` commit; it must not execute a pull-request head or untrusted event content.
+- A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Both public custom domains must expose recorded exact commits.
+- Failed evidence checks remain blocking evidence and must not be bypassed.
+- Direct default-branch push deployment is preferable here because the exact commit has already passed PR CI and final review before merge, while the indirect `workflow_run` path did not execute reliably.
+- Documentation-only changes must not trigger redundant application deployment.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
-- After deployment closeout, next product priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a real secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the independent documentation deployer succeeds, pull request #32 or its current-main replacement proves both public builds, and the metadata-only closeout passes CI, final review, and squash merge.
+- After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
+- The cycle remains incomplete until the direct publisher deploys and verifies documentation, a permanent evidence PR proves both domains, and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,39 +3,40 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, public guidance, application deployment, and community repairs are merged; documentation production is being repaired through a genuinely independent workflow before permanent evidence and closeout
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application deployment are merged; documentation production and final closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #31
-- Last squash merge: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Last site-change pull request: #33
+- Last squash merge: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
-- Last successful attributable documentation artifact: strict documentation builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
-- Last public verification: pull request #32 production-evidence job verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb`; twelve cache-busted documentation requests returned HTTP 404 through Cloudflare
+- Last successful attributable application deployment: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Last successful attributable documentation artifact: strict builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
+- Last public verification: pull request #34 production-evidence job verified the application at `e051c7f5cd6cc41eef84965404cafb493b8f84df`; forty-two cache-busted documentation requests returned HTTP 404 through Cloudflare
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, and custom-domain build endpoints.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, cache-busted custom-domain requests, and exact build identities.
 - Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation content: pull request #31 passed all expected CI and final review and merged the bilingual TXT import troubleshooting guide plus canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Documentation deployment diagnosis: the public Actions UI still associates the displayed documentation workflow with the old `blank.yml` identity, and no production deployment from the high-similarity rename reached the custom domain.
-- Documentation deployment repair: active work adds a separate workflow file while retaining the prior file, so GitHub cannot classify it as another rename. It runs only after successful `Quality` completion on `main`, selects the exact verified source commit, deploys only when documentation-delivery files changed, and verifies both build identity and the public troubleshooting page.
-- Privacy: the stale pull request that would have restored third-party reader analytics was closed as superseded.
-- Application: local TXT and supported text-URL import are exposed through first-use onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
-- Content and community: current bilingual product guidance, security policy, roadmap, contribution policy, release archive, troubleshooting, and structured issue forms replace obsolete links and unrelated generic AI articles.
+- Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Documentation deployment diagnosis: pull request #33 registered a separate `workflow_run` deployer, but no deployment reached the public custom domain after its merge. Pull request #34 proved this was not propagation delay by observing forty-two consecutive `404 no-store` responses.
+- Documentation deployment repair: active work replaces the indirect trigger with a default-branch `push` workflow restricted to documentation-delivery paths. The exact reviewed squash commit will directly build, deploy, and verify the public documentation.
+- Application deployment isolation: documentation-only paths are excluded from the application publisher, avoiding redundant application builds while preserving the last verified app commit.
+- Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
+- Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
+- Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
 - Autonomous operation: at least one meaningful public production update and same-cycle repair of confirmed defects are required each local day.
-- Branch cleanup: best-effort and non-blocking.
+- Branch cleanup: best-effort and nonblocking.
 
 ## Active focus
 
-- Validate and merge the independent documentation deployer after complete CI and final security/workflow review.
-- Observe its `workflow_run` execution after the successful `Quality` push on `main` and verify the exact custom-domain build plus troubleshooting page.
-- Update or recreate the permanent production-evidence pull request against the repaired deployment.
+- Validate, review, and squash-merge the direct default-branch documentation publisher.
+- Verify its exact squash commit and bilingual TXT troubleshooting page on `https://www.webnovel.win/`.
+- Replace the blocked evidence pull requests with a current-main gate recording the separately verified application and documentation commits.
 - Complete the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
-- Evaluate remaining focused Dependabot pull requests after the permanent evidence gate; do not blindly merge Next.js 16 major-upgrade proposals.
+- Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
 This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,10 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/requirements-docs.txt'
+      - '.github/workflows/publish-docs-pages.yml'
+      - 'docs/**'
+      - 'mkdocs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publish-docs-pages.yml
+++ b/.github/workflows/publish-docs-pages.yml
@@ -1,13 +1,14 @@
 name: Publish WebNR documentation
 
 on:
-  workflow_run:
-    workflows:
-      - Quality
-    types:
-      - completed
+  push:
     branches:
       - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/requirements-docs.txt'
+      - '.github/workflows/publish-docs-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -20,34 +21,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  select-source:
-    name: Select verified documentation source
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == github.event.repository.default_branch &&
-        github.event.workflow_run.head_repository.full_name == github.repository
-      )
+  source:
+    name: Select trusted documentation source
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       source_sha: ${{ steps.source.outputs.sha }}
-      should_deploy: ${{ steps.changes.outputs.should_deploy }}
     steps:
-      - name: Select trusted source commit
+      - name: Select default-branch commit
         id: source
         env:
           EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          PUSH_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          if [ "${EVENT_NAME}" = 'workflow_run' ]; then
-            source_sha="${WORKFLOW_RUN_SHA}"
+          if [ "${EVENT_NAME}" = 'push' ]; then
+            source_sha="${PUSH_SHA}"
           else
             source_sha="$(
               curl --fail-with-body --silent --show-error \
@@ -64,44 +56,16 @@ jobs:
           fi
           printf 'sha=%s\n' "${source_sha}" >> "${GITHUB_OUTPUT}"
 
-      - name: Checkout trusted source history
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ steps.source.outputs.sha }}
-          fetch-depth: 2
-
-      - name: Detect documentation delivery changes
-        id: changes
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          SOURCE_SHA: ${{ steps.source.outputs.sha }}
-        run: |
-          set -euo pipefail
-          if [ "${EVENT_NAME}" = 'workflow_dispatch' ]; then
-            should_deploy=true
-          elif git diff --quiet "${SOURCE_SHA}^" "${SOURCE_SHA}" -- \
-            docs \
-            mkdocs.yml \
-            .github/requirements-docs.txt \
-            .github/workflows/publish-docs-pages.yml; then
-            should_deploy=false
-          else
-            should_deploy=true
-          fi
-          printf 'should_deploy=%s\n' "${should_deploy}" >> "${GITHUB_OUTPUT}"
-          printf 'Documentation deployment selected: %s\n' "${should_deploy}"
-
   build:
     name: Build documentation artifact
-    needs: select-source
-    if: needs.select-source.outputs.should_deploy == 'true'
+    needs: source
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Checkout verified source
+      - name: Checkout reviewed default-branch source
         uses: actions/checkout@v5
         with:
-          ref: ${{ needs.select-source.outputs.source_sha }}
+          ref: ${{ needs.source.outputs.source_sha }}
           fetch-depth: 0
           submodules: recursive
 
@@ -133,7 +97,7 @@ jobs:
 
       - name: Write exact documentation build identity
         env:
-          BUILD_SHA: ${{ needs.select-source.outputs.source_sha }}
+          BUILD_SHA: ${{ needs.source.outputs.source_sha }}
         run: |
           python - <<'PY'
           import json
@@ -154,7 +118,7 @@ jobs:
 
       - name: Validate documentation artifact
         env:
-          BUILD_SHA: ${{ needs.select-source.outputs.source_sha }}
+          BUILD_SHA: ${{ needs.source.outputs.source_sha }}
         run: |
           set -eu
           test -f site/index.html
@@ -183,7 +147,7 @@ jobs:
   deploy:
     name: Deploy and verify documentation
     needs:
-      - select-source
+      - source
       - build
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -197,7 +161,7 @@ jobs:
 
       - name: Verify exact documentation deployment
         env:
-          BUILD_SHA: ${{ needs.select-source.outputs.source_sha }}
+          BUILD_SHA: ${{ needs.source.outputs.source_sha }}
           PRODUCTION_BUILD_URL: https://www.webnovel.win/build.json
           TROUBLESHOOTING_URL: https://www.webnovel.win/troubleshooting/txt-import/
         run: |


### PR DESCRIPTION
## Evidence

Pull request #34 run 31032106290 verified the application at exact `e051c7f5cd6cc41eef84965404cafb493b8f84df`, but made forty-two cache-busted requests to the documentation custom domain and every response was Cloudflare HTTP 404 with `cache-control: no-store`. The independent `workflow_run` publisher merged in pull request #33 therefore did not execute; this is not propagation delay.

## Coherent repair

- replace the indirect `workflow_run` trigger with a direct `push` trigger on the default branch
- limit the trigger to documentation content, MkDocs configuration, pinned documentation dependencies, and the publisher workflow itself
- use the exact reviewed squash commit for default-branch pushes
- keep manual recovery constrained to the current default-branch commit
- build with pinned dependencies and `mkdocs build --strict`
- validate exact build identity, bilingual TXT troubleshooting, canonical manual pages, privacy boundary, and repository references
- publish through official Pages artifact/deployment actions
- require the workflow itself to verify both the public build identity and bilingual guide
- exclude documentation-only paths from the application publisher so the already verified app build is not replaced by an unrelated docs commit

## Delivery model

The exact source is already validated before merge by this PR's dependency audit, ESLint, TypeScript, production app build, strict documentation build, SEO-data validation, and final self-review. The merge push then directly deploys that reviewed squash commit instead of depending on a second workflow event that has proven unreliable.

## Required checks

- dependency audit, ESLint, TypeScript, production application build
- strict pinned documentation build and generated-output assertions
- public SEO-data validation
- complete final review of push scope, source selection, manual recovery, Pages permissions, artifact assertions, deployment verification, application isolation, and privacy boundary

## Post-merge acceptance

The new `Publish WebNR documentation` push run must deploy its exact squash commit and verify `https://www.webnovel.win/build.json` plus the public bilingual TXT troubleshooting page. A current-main permanent evidence PR will then independently prove the retained app commit and new docs commit before closeout.
