### PR TITLE
ci: permanently enforce exact public app and docs builds

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -22,7 +22,8 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Pull request #32 production evidence verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb` but observed twelve cache-busted documentation HTTP 404 responses with `cache-control: no-store`.
 - Pull request #33 added a separate security-reviewed `workflow_run` documentation deployer and squash-merged as `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
 - Pull request #34 production evidence verified the application at exact `e051c7f5cd6cc41eef84965404cafb493b8f84df`; it then observed forty-two consecutive cache-busted documentation HTTP 404 responses through Cloudflare between 17:53 and 18:00 UTC.
-- The forty-two failures prove that the indirect documentation workflow did not publish, rather than merely requiring more propagation time.
+- The forty-two failures proved that the indirect documentation workflow did not publish, rather than merely requiring more propagation time.
+- Pull request #35 replaced the indirect trigger with a direct default-branch publisher, passed all expected CI and final review, and squash-merged as `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
@@ -38,9 +39,10 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Pull request #31 published the bilingual TXT troubleshooting guide, covering real TXT/URL inputs, UTF-8/GB18030/Big5 failures, binary files renamed as TXT, CORS, redirects, HTTP errors, browser storage loss, safe PWA refresh, and privacy-safe authorized reproduction; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
 - Pull request #33 added a genuinely independent but indirect documentation Pages workflow; squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
 - Kept pull requests #32 and #34 blocked after their required evidence jobs failed; no check was bypassed and no false deployment claim was merged.
-- Prepared a focused replacement that changes documentation publication to a direct `push` workflow on the default branch, restricted to documentation content, MkDocs configuration, pinned documentation dependencies, and its own workflow file.
-- The direct publisher selects the exact default-branch commit, builds with pinned dependencies and `mkdocs build --strict`, validates the build identity and bilingual guide, uploads through official Pages actions, deploys through the `github-pages` environment, and verifies both the public build identity and guide content.
-- Updated the application publisher to ignore documentation-only paths so the repair does not replace the already verified application build with an unrelated documentation commit.
+- Pull request #35 changed documentation publication to a direct `push` workflow on the default branch, restricted to documentation content, MkDocs configuration, pinned documentation dependencies, and its own workflow file.
+- The direct publisher selects the exact reviewed default-branch commit, builds with pinned dependencies and `mkdocs build --strict`, validates the build identity and bilingual guide, uploads through official Pages actions, deploys through the `github-pages` environment, and verifies both the public build identity and guide content.
+- Pull request #35 also isolated documentation-only paths from the application publisher, preserving the already verified application commit `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
+- Created a final current-main evidence gate that records application `e051c7f5cd6cc41eef84965404cafb493b8f84df` and documentation `499762b2ead74a74a13286a7cdca2d8fa6045f2e`, adds an exact public verifier to Quality, and prevents evidence-only changes from redeploying either product surface.
 
 ## Validation and self-review
 
@@ -55,7 +57,8 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data; Production evidence correctly failed only on documentation HTTP 404.
 - PR #33 final Quality run 31031650857 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation after privileged-workflow security hardening.
 - PR #34 run 31032106290 passed Web quality, Documentation quality, and SEO data; Production evidence verified application `e051c7f5cd6cc41eef84965404cafb493b8f84df` and correctly failed after forty-two documentation HTTP 404 responses.
-- The direct-push replacement still requires complete PR CI, final workflow/security review, squash merge, exact public documentation verification, a current-main evidence gate, and metadata closeout.
+- PR #35 Quality run 31033047471 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation. Its direct-push scope, default-branch source, manual recovery, Pages permissions, artifact assertions, deployment verification, application isolation, and privacy boundary received a clean final review.
+- The final evidence pull request still requires its own Web, Documentation, SEO-data, and Production evidence jobs plus a complete final diff review before squash merge.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
@@ -70,19 +73,20 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
 - Bilingual TXT troubleshooting and canonical manual paths: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
 - Indirect documentation deployer: #33, squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Direct default-branch documentation publisher: #35, squash `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
 - Evidence diagnoses: #32 and #34 remain open and intentionally blocked by missing documentation production
-- Direct default-branch documentation publisher: pending PR, CI, final review, squash merge, and public verification
-- Final permanent evidence gate and metadata-only closeout: pending
+- Final permanent evidence gate: pending PR, CI, final review, and squash merge
+- Metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
 
 - A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Both public custom domains must expose recorded exact commits.
 - Failed evidence checks remain blocking evidence and must not be bypassed.
-- Direct default-branch push deployment is preferable here because the exact commit has already passed PR CI and final review before merge, while the indirect `workflow_run` path did not execute reliably.
-- Documentation-only changes must not trigger redundant application deployment.
+- Direct default-branch push deployment is used because the exact commit passed PR CI and final review before merge, while the indirect `workflow_run` path did not execute reliably.
+- Documentation-only and evidence-only changes must not trigger redundant application deployment.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
 - After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the direct publisher deploys and verifies documentation, a permanent evidence PR proves both domains, and the metadata-only closeout passes CI, final review, and squash merge.
+- The cycle remains incomplete until the final evidence PR proves both recorded public builds and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,27 +3,26 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application deployment are merged; documentation production and final closeout remain
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and direct application/documentation delivery are merged; permanent public evidence and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #33
-- Last squash merge: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Last site-change pull request: #35
+- Last squash merge: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
 - Last closeout pull request: #17
 - Last successful attributable application deployment: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
-- Last successful attributable documentation artifact: strict builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
-- Last public verification: pull request #34 production-evidence job verified the application at `e051c7f5cd6cc41eef84965404cafb493b8f84df`; forty-two cache-busted documentation requests returned HTTP 404 through Cloudflare
+- Last successful attributable documentation deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
+- Last public verification: this pull request cannot merge unless its required `Production evidence` job proves the application endpoint exposes `e051c7f5cd6cc41eef84965404cafb493b8f84df` and the documentation endpoint exposes `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, cache-busted custom-domain requests, and exact build identities.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, and public SEO-data validation.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks use DNS, response headers, cache-busted custom-domain requests, and exact build identities.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, exact public production evidence, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
 - Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Documentation deployment diagnosis: pull request #33 registered a separate `workflow_run` deployer, but no deployment reached the public custom domain after its merge. Pull request #34 proved this was not propagation delay by observing forty-two consecutive `404 no-store` responses.
-- Documentation deployment repair: active work replaces the indirect trigger with a default-branch `push` workflow restricted to documentation-delivery paths. The exact reviewed squash commit will directly build, deploy, and verify the public documentation.
-- Application deployment isolation: documentation-only paths are excluded from the application publisher, avoiding redundant application builds while preserving the last verified app commit.
+- Documentation deployment: pull request #35 replaced the non-firing indirect trigger with a direct default-branch publisher and squash-merged as `499762b2ead74a74a13286a7cdca2d8fa6045f2e`. The same PR isolated documentation-only paths from application publication.
+- Production evidence: application and documentation deployment statements above are enforced by this same pull request's required public verifier and cannot reach `main` without matching endpoints.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -32,11 +31,11 @@
 
 ## Active focus
 
-- Validate, review, and squash-merge the direct default-branch documentation publisher.
-- Verify its exact squash commit and bilingual TXT troubleshooting page on `https://www.webnovel.win/`.
-- Replace the blocked evidence pull requests with a current-main gate recording the separately verified application and documentation commits.
-- Complete the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
+- Pass the permanent custom-domain production-evidence check for application `e051c7f5cd6cc41eef84965404cafb493b8f84df` and documentation `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
+- Complete a clean final review and squash-merge the evidence gate without triggering redundant application or documentation deployment.
+- Close superseded failed evidence pull requests #32 and #34 without merge.
+- Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified facts or facts whose truth is enforced by the same pull request's required public-evidence check. Detailed history belongs in `daily/`.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,27 +3,28 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and direct application delivery are merged; documentation production, permanent evidence, and final metadata closeout remain
-- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #35
-- Last squash merge: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application delivery are merged; documentation production, permanent evidence, and final metadata closeout remain
+- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow-registration, Pages-configuration, and public-artifact evidence collected on 2026-08-05
+- Last site-change pull request: #37
+- Last squash merge: `bd0f859303a426a653970118102612f1ae6345f9`
 - Last closeout pull request: #17
 - Last successful attributable application deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Last successful attributable documentation deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Last public verification: pull request #36 observed the application at exact `499762b2ead74a74a13286a7cdca2d8fa6045f2e`; its documentation statement remains unproven and cannot merge while the custom-domain endpoint returns HTTP 404
+- Last successful attributable documentation deployment: `bd0f859303a426a653970118102612f1ae6345f9`
+- Last public verification: this diagnostic branch may not merge; it is observing whether pull request #37's exact squash commit reaches the configured legacy Pages source, custom domain, and bilingual troubleshooting page
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks use DNS, response headers, cache-busted custom-domain requests, and exact build identities.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, exact public production evidence, and public SEO-data validation.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks use DNS, response headers, cache-busted custom-domain requests, Pages API state, and exact build identities.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public SEO-data validation, read-only deployment diagnosis, and exact production evidence.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
 - Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Application deployment: pull request #35 changed `.github/workflows/nextjs.yml`, so the application publisher correctly ran once for that merge and publicly exposes `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
-- Documentation deployment: pull request #35 added a direct default-branch publisher, but the public documentation custom domain still returns HTTP 404. A read-only diagnostic job now inspects workflow registration, recent documentation runs, Pages configuration, and the latest Pages build before the next repair.
-- Production evidence: only the application deployment is currently verified. The documentation deployment line above is an intended target enforced by the same failing PR and must not reach `main` until the public endpoint matches.
+- Application deployment: the public application exposes exact commit `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
+- Pages root cause: authenticated diagnosis found legacy `gh-pages:/`, `cname: null`, and two failed documentation runs. The latest failure was HTTP 403 when a normal workflow token attempted an Administration-protected Pages settings mutation.
+- Documentation repair: pull request #37 passed all expected CI and final review, removed the duplicate failing publisher, preserved `CNAME` and `.nojekyll`, and merged a publisher compatible with the existing legacy `gh-pages` source as `bd0f859303a426a653970118102612f1ae6345f9`.
+- Production evidence: the documentation line above is an intended target for this failing diagnostic branch and must not reach `main` unless a clean current-main evidence PR proves it.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -32,11 +33,10 @@
 
 ## Active focus
 
-- Read the Pages and workflow diagnostic from pull request #36 and repair the precise registration, permission, Pages-source, or custom-domain defect.
-- Deploy and publicly verify the documentation build and bilingual TXT troubleshooting page.
-- Restore the permanent evidence job to its normal bounded retry window and merge it only after both endpoints match.
+- Inspect pull request #37's documentation workflow run, `gh-pages` publication, Pages build, CNAME registration, and public bilingual troubleshooting page.
+- If verified, close this diagnostic branch and create a clean current-main permanent evidence gate with normal retry bounds.
 - Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified facts and clearly marks the unproven documentation target. Detailed history belongs in `daily/`.
+This file is diagnostic-only and must not be merged. Detailed history belongs in `daily/`.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,14 +3,14 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and direct application/documentation delivery are merged; permanent public evidence and final metadata closeout remain
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and direct application delivery are merged; documentation production, permanent evidence, and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow, and public-artifact evidence collected on 2026-08-05
 - Last site-change pull request: #35
 - Last squash merge: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `e051c7f5cd6cc41eef84965404cafb493b8f84df`
+- Last successful attributable application deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
 - Last successful attributable documentation deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Last public verification: this pull request cannot merge unless its required `Production evidence` job proves the application endpoint exposes `e051c7f5cd6cc41eef84965404cafb493b8f84df` and the documentation endpoint exposes `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
+- Last public verification: pull request #36 observed the application at exact `499762b2ead74a74a13286a7cdca2d8fa6045f2e`; its documentation statement remains unproven and cannot merge while the custom-domain endpoint returns HTTP 404
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
@@ -21,8 +21,9 @@
 - Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, exact public production evidence, and public SEO-data validation.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
 - Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Documentation deployment: pull request #35 replaced the non-firing indirect trigger with a direct default-branch publisher and squash-merged as `499762b2ead74a74a13286a7cdca2d8fa6045f2e`. The same PR isolated documentation-only paths from application publication.
-- Production evidence: application and documentation deployment statements above are enforced by this same pull request's required public verifier and cannot reach `main` without matching endpoints.
+- Application deployment: pull request #35 changed `.github/workflows/nextjs.yml`, so the application publisher correctly ran once for that merge and publicly exposes `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
+- Documentation deployment: pull request #35 added a direct default-branch publisher, but the public documentation custom domain still returns HTTP 404. A read-only diagnostic job now inspects workflow registration, recent documentation runs, Pages configuration, and the latest Pages build before the next repair.
+- Production evidence: only the application deployment is currently verified. The documentation deployment line above is an intended target enforced by the same failing PR and must not reach `main` until the public endpoint matches.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -31,11 +32,11 @@
 
 ## Active focus
 
-- Pass the permanent custom-domain production-evidence check for application `e051c7f5cd6cc41eef84965404cafb493b8f84df` and documentation `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
-- Complete a clean final review and squash-merge the evidence gate without triggering redundant application or documentation deployment.
-- Close superseded failed evidence pull requests #32 and #34 without merge.
+- Read the Pages and workflow diagnostic from pull request #36 and repair the precise registration, permission, Pages-source, or custom-domain defect.
+- Deploy and publicly verify the documentation build and bilingual TXT troubleshooting page.
+- Restore the permanent evidence job to its normal bounded retry window and merge it only after both endpoints match.
 - Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified facts or facts whose truth is enforced by the same pull request's required public-evidence check. Detailed history belongs in `daily/`.
+This file contains verified facts and clearly marks the unproven documentation target. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -8,8 +8,11 @@ on:
       - '.github/seo-data/**'
       - '.github/requirements-docs.txt'
       - '.github/workflows/publish-docs-pages.yml'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -107,3 +107,19 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pages: read
 
 concurrency:
   group: quality-${{ github.workflow }}-${{ github.ref }}
@@ -108,10 +110,94 @@ jobs:
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
 
+  deployment-configuration:
+    name: Deployment configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Inspect registered workflows, recent documentation runs, and Pages state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/${REPOSITORY}"
+          headers=(
+            --header 'Accept: application/vnd.github+json'
+            --header "Authorization: Bearer ${GH_TOKEN}"
+            --header 'X-GitHub-Api-Version: 2022-11-28'
+          )
+
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/actions/workflows?per_page=100" > "${RUNNER_TEMP}/workflows.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/actions/workflows/publish-docs-pages.yml/runs?branch=main&per_page=10" \
+            > "${RUNNER_TEMP}/docs-runs.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/pages" > "${RUNNER_TEMP}/pages.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/pages/builds/latest" > "${RUNNER_TEMP}/latest-pages-build.json" || true
+
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          temp = Path(os.environ['RUNNER_TEMP'])
+          workflows = json.loads((temp / 'workflows.json').read_text())
+          runs = json.loads((temp / 'docs-runs.json').read_text())
+          pages = json.loads((temp / 'pages.json').read_text())
+
+          print('REGISTERED WORKFLOWS')
+          for item in workflows.get('workflows', []):
+              print(json.dumps({
+                  'id': item.get('id'),
+                  'name': item.get('name'),
+                  'path': item.get('path'),
+                  'state': item.get('state'),
+              }, sort_keys=True))
+
+          print('DOCUMENTATION WORKFLOW RUNS')
+          print('total_count=', runs.get('total_count'))
+          for item in runs.get('workflow_runs', []):
+              print(json.dumps({
+                  'id': item.get('id'),
+                  'event': item.get('event'),
+                  'status': item.get('status'),
+                  'conclusion': item.get('conclusion'),
+                  'head_sha': item.get('head_sha'),
+                  'run_number': item.get('run_number'),
+                  'html_url': item.get('html_url'),
+              }, sort_keys=True))
+
+          print('PAGES SITE')
+          allowed = {
+              key: pages.get(key)
+              for key in (
+                  'url', 'status', 'cname', 'custom_404', 'html_url',
+                  'build_type', 'source', 'https_enforced',
+                  'protected_domain_state', 'pending_domain_unverified_at'
+              )
+          }
+          print(json.dumps(allowed, sort_keys=True))
+
+          latest_path = temp / 'latest-pages-build.json'
+          if latest_path.exists() and latest_path.stat().st_size:
+              try:
+                  latest = json.loads(latest_path.read_text())
+              except json.JSONDecodeError:
+                  latest = {'unparsed': latest_path.read_text()[:500]}
+              print('LATEST PAGES BUILD')
+              print(json.dumps({
+                  key: latest.get(key)
+                  for key in ('url', 'status', 'error', 'pusher', 'commit', 'duration', 'created_at', 'updated_at')
+              }, default=str, sort_keys=True))
+          PY
+
   production-evidence:
     name: Production evidence
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 2
     steps:
       - name: Checkout recorded deployment state
         uses: actions/checkout@v5
@@ -122,4 +208,6 @@ jobs:
           node-version: '20'
 
       - name: Verify recorded public builds
+        env:
+          PRODUCTION_EVIDENCE_ATTEMPTS: '2'
         run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+const maxAttempts = 42;
+const retryDelayMs = 10_000;
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) {
+    throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  }
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: {
+          accept: 'application/json',
+          'cache-control': 'no-cache',
+        },
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+
+      if (!response.ok) {
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders,
+          };
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+
+    if (attempt < maxAttempts) {
+      await sleep(retryDelayMs);
+    }
+  }
+
+  throw new Error(
+    `${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`,
+  );
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') {
+    console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+  }
+}
+
+if (failures.length > 0) {
+  throw new Error(`Production evidence failed:\n${failures.join('\n')}`);
+}

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -3,7 +3,10 @@ import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
 
 const statusPath = '.github/seo-data/status.md';
 const status = readFileSync(statusPath, 'utf8');
-const maxAttempts = 42;
+const configuredAttempts = Number.parseInt(process.env.PRODUCTION_EVIDENCE_ATTEMPTS ?? '42', 10);
+const maxAttempts = Number.isInteger(configuredAttempts) && configuredAttempts > 0
+  ? configuredAttempts
+  : 42;
 const retryDelayMs = 10_000;
 
 const targets = [


### PR DESCRIPTION
Superseded without merge.

This diagnostic branch correctly verified the application and exposed the documentation deployment root cause: legacy `gh-pages:/`, absent custom-domain registration, failed Pages settings mutations, and stale public routing. The evidence was preserved in the merged operating record. Pull request #40 moved users to the working GitHub Pages project URL, and pull request #41 permanently verified both exact public builds plus the bilingual troubleshooting content. No failed check was bypassed.