### PR TITLE
ci: permanently verify the exact public application and documentation builds

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -24,11 +24,11 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Pull request #34 production evidence verified the application at exact `e051c7f5cd6cc41eef84965404cafb493b8f84df`; it then observed forty-two consecutive cache-busted documentation HTTP 404 responses through Cloudflare.
 - Pull request #35 replaced the indirect trigger with a direct default-branch publisher and squash-merged as `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
 - Pull request #36 observed the application at exact `499762b2ead74a74a13286a7cdca2d8fa6045f2e` and continued to receive documentation HTTP 404.
-- Pull request #36 authenticated diagnostics listed both documentation workflows as active and found two recent `Publish WebNR documentation` runs: `31031843502` and `31033180994`; both concluded failure.
+- Pull request #36 authenticated diagnostics listed both documentation workflows as active and found recent `Publish WebNR documentation` runs `31031843502` and `31033180994`; both failed.
 - Run `31033180994` selected exact main commit `499762b2ead74a74a13286a7cdca2d8fa6045f2e`, installed all pinned dependencies, then failed at `Configure repository Pages for workflow publishing` with HTTP 403 `Resource not accessible by integration`.
 - The failed job token had Contents read and Pages write. GitHub's Pages settings update endpoint also requires Administration write, which normal workflow tokens do not receive.
 - Pages API state was `build_type: legacy`, source `gh-pages:/`, status `built`, `cname: null`, and `html_url: https://autoarchive.github.io/webNR/`. The latest successful Pages build remained older `gh-pages` commit `b11e80376f77c04fbc9ca21dd985c30a51262521` from 2026-08-05 11:38 UTC.
-- The `gh-pages` branch contained no root `CNAME` file.
+- The `gh-pages` branch contained no root `CNAME` file, so the configured branch publisher could not bind `www.webnovel.win` after force-orphan publication.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
@@ -45,16 +45,18 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Pull request #33 added an independently registered documentation workflow; squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
 - Pull request #35 changed it to direct default-branch push; squash `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
 - Kept pull requests #32, #34, and #36 blocked after their required evidence jobs failed; no check was bypassed and no false documentation deployment claim was merged.
-- Added a temporary read-only deployment diagnostic to #36, using only Actions read, Pages read, and Contents read. It exposed workflow registration, recent run conclusions, Pages source, custom-domain state, and latest build without changing external configuration.
-- Prepared a focused Pages-compatible repair that:
-  - keeps the repository's verified legacy Pages mode and `gh-pages:/` source instead of attempting an unauthorized mode change;
-  - builds documentation from the exact reviewed default-branch commit using pinned dependencies and `mkdocs build --strict`;
-  - writes exact source identity to `build.json`;
-  - writes root `CNAME` as `www.webnovel.win` and preserves `.nojekyll`;
-  - validates the bilingual troubleshooting page, canonical manual pages, privacy boundary, and repository links;
-  - force-orphan publishes only generated output to `gh-pages` through the existing GitHub token pattern already used successfully by the repository;
-  - waits for Pages API state to show legacy `gh-pages:/`, custom domain `www.webnovel.win`, status `built`, and for the public custom domain to expose both the exact commit and actual bilingual guide;
-  - deletes the duplicate `docs-pages.yml` workflow so one documentation update cannot create two competing failed deploys.
+- Added a temporary read-only deployment diagnostic to #36, using Actions read, Pages read, and Contents read only. It exposed workflow registration, recent run conclusions, Pages source, custom-domain state, and latest build without changing external configuration.
+- Pull request #37 implemented the Pages-compatible repair:
+  - retained verified legacy Pages mode and `gh-pages:/` source instead of attempting an unauthorized settings mutation;
+  - built from the exact reviewed default-branch commit using pinned dependencies and `mkdocs build --strict`;
+  - wrote exact source identity to public `build.json`;
+  - generated root `CNAME` as `www.webnovel.win` and preserved `.nojekyll`;
+  - validated the bilingual troubleshooting page, canonical manual pages, privacy boundary, and current repository links;
+  - force-orphan published generated output only to `gh-pages`;
+  - waited for Pages API state, custom-domain registration, exact public commit, and actual bilingual guide content;
+  - deleted the duplicate failing `docs-pages.yml` workflow.
+- Pull request #37 passed every expected check, received a clean final workflow/security review with no review threads, and squash-merged as `bd0f859303a426a653970118102612f1ae6345f9`.
+- Created a clean current-main evidence branch that adds a permanent exact-production job, read-only Pages/workflow diagnostics for the final transition, and app deployment exclusions for evidence-only changes.
 
 ## Validation and self-review
 
@@ -70,8 +72,10 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - PR #33 final Quality run 31031650857 passed after privileged-workflow security hardening.
 - PR #34 run 31032106290 passed Web quality, Documentation quality, and SEO data; Production evidence correctly failed after forty-two documentation HTTP 404 responses.
 - PR #35 Quality run 31033047471 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
-- PR #36 deployment-configuration job `92402955921` passed and produced the authenticated diagnosis above. Its production evidence remains correctly blocked.
-- The legacy-source repair still requires a real non-draft PR, complete CI, final workflow/security review, squash merge, successful `gh-pages` publication, Pages build, custom-domain registration, public guide verification, a clean permanent evidence PR, and metadata closeout.
+- PR #36 deployment-configuration job `92402955921` passed and produced the authenticated diagnosis above. Its production evidence remained correctly blocked.
+- PR #37 Quality run `31034906301` passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
+- PR #37 final review confirmed no Pages or Administration write request, exact default-branch source selection, generated-only `gh-pages` publication, root CNAME preservation under force-orphan publishing, duplicate-workflow removal, bounded Pages/public verification, privacy safety, no review threads, unchanged head, and mergeability.
+- The permanent evidence pull request still requires Web, Documentation, SEO-data, deployment-configuration, and Production evidence jobs plus a complete final diff review before squash merge.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
@@ -87,9 +91,10 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Bilingual TXT troubleshooting and canonical manual paths: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
 - Independent documentation deployer: #33, squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`
 - Direct-push attempt: #35, squash `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Evidence diagnoses: #32 and #34 closed superseded without merge; #36 open and blocked while serving as diagnostic evidence
-- Configured legacy Pages-source repair: pending PR, CI, final review, squash merge, and public verification
-- Final permanent evidence gate and metadata-only closeout: pending
+- Legacy Pages-source repair: #37, squash `bd0f859303a426a653970118102612f1ae6345f9`
+- Superseded evidence diagnoses: #32 and #34 closed without merge; #36 remains open only until this clean evidence branch is established
+- Final permanent evidence gate: pending PR, CI, final review, and squash merge
+- Metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
@@ -99,8 +104,9 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - The repository's existing Pages publishing mode is authoritative. A normal workflow token must not attempt a Pages settings mutation requiring Administration write.
 - In legacy branch mode, the generated root `CNAME` file must survive every force-orphan publication.
 - Duplicate documentation publishers are removed rather than allowed to compete or produce known failures.
+- Evidence-only changes must not trigger redundant application or documentation deployments.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
 - After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the legacy-source repair deploys and verifies documentation, a permanent evidence PR proves both domains, and the metadata-only closeout passes CI, final review, and squash merge.
+- The cycle remains incomplete until the permanent evidence PR proves application `499762b2ead74a74a13286a7cdca2d8fa6045f2e` and documentation `bd0f859303a426a653970118102612f1ae6345f9`, then the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,27 +3,27 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application delivery are merged; documentation production, permanent evidence, and final metadata closeout remain
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and legacy Pages-compatible delivery are merged; permanent evidence and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow-registration, Pages-configuration, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #35
-- Last squash merge: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
+- Last site-change pull request: #37
+- Last squash merge: `bd0f859303a426a653970118102612f1ae6345f9`
 - Last closeout pull request: #17
 - Last successful attributable application deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Last successful attributable documentation artifact: strict builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
-- Last public verification: pull request #36 observed the application at exact `499762b2ead74a74a13286a7cdca2d8fa6045f2e`; the documentation endpoint remained HTTP 404
+- Last successful attributable documentation deployment: `bd0f859303a426a653970118102612f1ae6345f9`
+- Last public verification: this pull request cannot merge unless its required evidence job proves the application endpoint exposes `499762b2ead74a74a13286a7cdca2d8fa6045f2e` and the documentation endpoint exposes `bd0f859303a426a653970118102612f1ae6345f9`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, cache-busted custom-domain requests, Pages API state, and exact build identities.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public SEO-data validation, and exact production evidence.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks use DNS, response headers, cache-busted custom-domain requests, Pages API state, and exact build identities.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, Pages configuration diagnosis, public SEO-data validation, and exact production evidence.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
 - Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Pages configuration: authenticated read-only diagnosis in pull request #36 found `build_type: legacy`, source `gh-pages:/`, status `built`, and `cname: null`. The latest successful Pages build remained an older `gh-pages` commit.
-- Failed workflow evidence: registered documentation runs `31031843502` and `31033180994` both failed. Run `31033180994` failed at the first Pages-settings mutation with HTTP 403 `Resource not accessible by integration`; the job's token had Pages write but not the Administration write permission required to change repository Pages mode.
-- Documentation deployment repair: active work stops trying to mutate repository Pages settings. It builds strictly, preserves `CNAME` and `.nojekyll`, publishes the generated site to the already-configured `gh-pages` source, removes the duplicate failing workflow, and waits for both legacy Pages configuration and the public bilingual guide.
+- Pages diagnosis: authenticated read-only inspection found legacy source `gh-pages:/`, no custom domain, two failed workflow runs, and HTTP 403 when a normal workflow token attempted an Administration-protected Pages settings mutation.
+- Documentation repair: pull request #37 passed all expected CI and final review, removed the duplicate failing workflow, preserved root `CNAME` and `.nojekyll`, and merged a publisher compatible with the configured legacy `gh-pages` source as `bd0f859303a426a653970118102612f1ae6345f9`.
+- Production evidence: the deployment statements above are enforced by this same pull request and cannot reach `main` without exact public matches.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -32,11 +32,12 @@
 
 ## Active focus
 
-- Validate, review, and squash-merge the `gh-pages`-compatible documentation publisher.
-- Verify its exact source commit, Pages custom-domain registration, and bilingual TXT troubleshooting page on `https://www.webnovel.win/`.
-- Replace the diagnostic evidence branch with a clean permanent evidence gate after deployment.
+- Pass exact production evidence for application `499762b2ead74a74a13286a7cdca2d8fa6045f2e` and documentation `bd0f859303a426a653970118102612f1ae6345f9`.
+- Remove the temporary deployment-configuration diagnostic job after its final evidence is captured.
+- Complete a clean final review and squash-merge the permanent evidence gate without redundant deployment.
+- Close superseded diagnostic pull request #36 without merge.
 - Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified facts or facts whose truth is enforced by the same pull request's required evidence check. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -8,8 +8,11 @@ on:
       - '.github/seo-data/**'
       - '.github/requirements-docs.txt'
       - '.github/workflows/publish-docs-pages.yml'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:
@@ -30,16 +33,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Write public build identity
         env:
           BUILD_SHA: ${{ github.sha }}
@@ -53,10 +53,8 @@ jobs:
           };
           fs.writeFileSync('public/build.json', `${JSON.stringify(manifest, null, 2)}\n`);
           NODE
-
       - name: Build static application
         run: npm run build
-
       - name: Validate deployment artifact
         env:
           BUILD_SHA: ${{ github.sha }}
@@ -75,7 +73,6 @@ jobs:
             exit 1
           fi
           touch out/.nojekyll
-
       - name: Publish app-pages branch
         uses: peaceiris/actions-gh-pages@v4.1.0
         with:
@@ -84,7 +81,6 @@ jobs:
           publish_branch: app-pages
           force_orphan: true
           commit_message: "deploy: ${{ github.sha }}"
-
       - name: Verify exact production build
         env:
           BUILD_SHA: ${{ github.sha }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pages: read
 
 concurrency:
   group: quality-${{ github.workflow }}-${{ github.ref }}
@@ -26,27 +28,21 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Audit dependency tree
         run: |
           npm audit --json > "${RUNNER_TEMP}/npm-audit.json" || true
           node scripts/validate-npm-audit.mjs "${RUNNER_TEMP}/npm-audit.json"
-
       - name: Lint
         run: npm run lint
-
       - name: Type check
         run: npm run typecheck
-
       - name: Production build
         run: npm run build
 
@@ -60,20 +56,16 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: .github/requirements-docs.txt
-
       - name: Install pinned documentation dependencies
         run: pip install --requirement .github/requirements-docs.txt
-
       - name: Build documentation strictly
         run: mkdocs build --strict
-
       - name: Validate documentation output
         run: |
           set -eu
@@ -97,13 +89,83 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-
       - name: Validate public SEO operating data
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  deployment-configuration:
+    name: Deployment configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Inspect documentation workflow and Pages state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/${REPOSITORY}"
+          headers=(
+            --header 'Accept: application/vnd.github+json'
+            --header "Authorization: Bearer ${GH_TOKEN}"
+            --header 'X-GitHub-Api-Version: 2022-11-28'
+          )
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/actions/workflows/publish-docs-pages.yml/runs?branch=main&per_page=10" \
+            > "${RUNNER_TEMP}/docs-runs.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/pages" > "${RUNNER_TEMP}/pages.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/pages/builds/latest" > "${RUNNER_TEMP}/latest-pages-build.json"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          temp = Path(os.environ['RUNNER_TEMP'])
+          runs = json.loads((temp / 'docs-runs.json').read_text())
+          pages = json.loads((temp / 'pages.json').read_text())
+          latest = json.loads((temp / 'latest-pages-build.json').read_text())
+
+          print('DOCUMENTATION WORKFLOW RUNS')
+          for item in runs.get('workflow_runs', []):
+              print(json.dumps({
+                  'id': item.get('id'),
+                  'event': item.get('event'),
+                  'status': item.get('status'),
+                  'conclusion': item.get('conclusion'),
+                  'head_sha': item.get('head_sha'),
+                  'run_number': item.get('run_number'),
+                  'html_url': item.get('html_url'),
+              }, sort_keys=True))
+
+          print('PAGES SITE')
+          print(json.dumps({
+              key: pages.get(key)
+              for key in ('url', 'status', 'cname', 'html_url', 'build_type', 'source', 'https_enforced')
+          }, sort_keys=True))
+          print('LATEST PAGES BUILD')
+          print(json.dumps({
+              key: latest.get(key)
+              for key in ('url', 'status', 'error', 'commit', 'duration', 'created_at', 'updated_at')
+          }, default=str, sort_keys=True))
+          PY
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+      - name: Verify recorded public builds
+        run: node scripts/verify-production-builds.mjs

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+const maxAttempts = 42;
+const retryDelayMs = 10_000;
+
+const targets = [
+  {
+    label: 'application',
+    url: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    url: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.url).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(`${target.url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+        cache: 'no-store',
+        headers: { accept: 'application/json', 'cache-control': 'no-cache' },
+        signal: AbortSignal.timeout(15_000),
+      });
+      const selectedHeaders = Object.fromEntries(
+        ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+          .map(name => [name, response.headers.get(name)])
+          .filter(([, value]) => value !== null),
+      );
+      if (!response.ok) {
+        lastObserved = JSON.stringify({ status: response.status, headers: selectedHeaders });
+      } else {
+        const payload = await response.json();
+        lastObserved = JSON.stringify({ payload, headers: selectedHeaders });
+        if (payload.commit === expectedCommit) {
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.url}`);
+          return { label: target.label, expectedCommit, observedCommit: payload.commit, headers: selectedHeaders };
+        }
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+    if (attempt < maxAttempts) await sleep(retryDelayMs);
+  }
+
+  throw new Error(`${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`);
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+}
+if (failures.length > 0) throw new Error(`Production evidence failed:\n${failures.join('\n')}`);


### PR DESCRIPTION
Superseded without merge.

This diagnostic branch correctly observed the generated `gh-pages` publication and correctly remained blocked while the former custom domain was unconfigured. Pull request #40 made the working GitHub Pages project URL canonical, and pull request #41 permanently verified exact reader/documentation build identities plus the public bilingual troubleshooting page. No failed evidence was bypassed.