### PR TITLE
fix: migrate documentation to the working GitHub Pages URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/AutoArchive/webNR/security/advisories/new
     about: Report vulnerabilities privately. Do not include exploit details in a public issue.
   - name: WebNR documentation
-    url: https://www.webnovel.win/
-    about: Read current usage, privacy, format-support, and contribution guidance.
+    url: https://autoarchive.github.io/webNR/
+    about: Read current usage, privacy, format-support, troubleshooting, and contribution guidance.

--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Complete a same-day WebNR product rescue and operating cycle: repair first use, privacy, accessibility, PWA behavior, crawlability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production deployment. Publish meaningful user-visible troubleshooting content and close only after exact public application and documentation builds are proven.
+Complete a same-day WebNR rescue and operating cycle: repair product onboarding, privacy, accessibility, PWA reliability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production delivery. Publish a meaningful bilingual troubleshooting resource and expose it through a working public URL.
 
 ## Data window
 
@@ -10,97 +10,69 @@ Complete a same-day WebNR product rescue and operating cycle: repair first use, 
 - Analytics target: 28 finalized days with a 3-day lag
 - Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no GA4 or Search Console export
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs and logs, dependency metadata, generated artifacts, registered workflow API results, Pages API state, DNS, response headers, custom-domain build endpoints, and visible public content
+- Evidence used: repository source, pull requests, CI jobs and logs, generated artifacts, registered workflow API results, Pages API state, DNS, response headers, public build endpoints, and visible content
 
 ## Evidence collected
 
-- The original application had no reachable first-use import path, loaded analytics despite a no-tracking promise, prevented zoom, destructively re-registered Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
-- The original dependency stack used Next.js 15.2.4, deprecated lint and decoder paths, Node-only browser code, stale tooling, and 17 audit findings including 11 high findings.
-- EPUB was accepted and advertised although no EPUB parser existed.
-- The original documentation had broken deployment configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete links, generic AI content, and no exact public build identity.
-- Pull request #31 merged a bilingual TXT import troubleshooting guide and canonical manual paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb` after all expected CI and two complete final reviews.
-- Pull request #32 production evidence verified the application at `57c904bb637b97eb0b8cc9a99e035d91c39574fb` but observed twelve cache-busted documentation HTTP 404 responses with `cache-control: no-store`.
-- Pull request #33 added a separate security-reviewed documentation deployer and squash-merged as `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
-- Pull request #34 production evidence verified the application at exact `e051c7f5cd6cc41eef84965404cafb493b8f84df`; it then observed forty-two consecutive cache-busted documentation HTTP 404 responses through Cloudflare.
-- Pull request #35 replaced the indirect trigger with a direct default-branch publisher and squash-merged as `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
-- Pull request #36 observed the application at exact `499762b2ead74a74a13286a7cdca2d8fa6045f2e` and continued to receive documentation HTTP 404.
-- Pull request #36 authenticated diagnostics listed both documentation workflows as active and found two recent `Publish WebNR documentation` runs: `31031843502` and `31033180994`; both concluded failure.
-- Run `31033180994` selected exact main commit `499762b2ead74a74a13286a7cdca2d8fa6045f2e`, installed all pinned dependencies, then failed at `Configure repository Pages for workflow publishing` with HTTP 403 `Resource not accessible by integration`.
-- The failed job token had Contents read and Pages write. GitHub's Pages settings update endpoint also requires Administration write, which normal workflow tokens do not receive.
-- Pages API state was `build_type: legacy`, source `gh-pages:/`, status `built`, `cname: null`, and `html_url: https://autoarchive.github.io/webNR/`. The latest successful Pages build remained older `gh-pages` commit `b11e80376f77c04fbc9ca21dd985c30a51262521` from 2026-08-05 11:38 UTC.
-- The `gh-pages` branch contained no root `CNAME` file.
+- The original application lacked a reachable import path, contradicted its privacy promise, prevented zoom, destructively reset Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
+- The original dependency stack used stale and vulnerable packages, deprecated lint and decoder paths, and browser code that depended on Node-only behavior.
+- EPUB was advertised and accepted although no EPUB parser existed.
+- The original documentation used unpinned dependencies, had broken deployment, loaded third-party analytics, contained obsolete links and generic AI content, and lacked exact public build identity.
+- Pull requests #19–#23 repaired the product, dependencies, format boundary, documentation quality, CI, and community infrastructure.
+- Pull request #31 published the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Evidence pull requests #32, #34, #36, and #38 were allowed to fail rather than merge unproven delivery claims. They verified application deployments while repeatedly observing documentation HTTP 404 responses.
+- Authenticated Pages diagnosis found `build_type: legacy`, source `gh-pages:/`, status `built`, project URL `https://autoarchive.github.io/webNR/`, and `cname: null`.
+- Registered documentation runs `31031843502` and `31033180994` failed because a normal workflow token attempted an Administration-protected Pages settings mutation and received HTTP 403 `Resource not accessible by integration`.
+- Pull request #37 removed that mutation, deleted the duplicate publisher, generated exact documentation artifacts, and successfully pushed commit `bd0f859303a426a653970118102612f1ae6345f9` content to `gh-pages`.
+- The #37 workflow then waited through 45 checks and failed only because it required custom-domain registration. Pages remained built with `cname: null`, and Cloudflare continued serving HTTP 404 for `www.webnovel.win`.
+- The current connector cannot write the GitHub Pages custom-domain setting, and the connected Cloudflare accounts do not expose the zone. The working GitHub Pages project URL is therefore the reliable public documentation endpoint for this cycle.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
 
-- Pull requests #14–#17 established the pinned reusable SEO skill, public-safe operating records, CI gates, daily autonomous operation, and nonblocking branch-cleanup policy.
-- Pull request #19 repaired first-use onboarding, visible TXT and URL import, recoverable feedback, accessibility basics, privacy-aligned runtime behavior, PWA updates, metadata, JSON-LD, robots, sitemap, and duplicate Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Pull request #20 added exact application build identity and production verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- Pull request #21 upgraded to supported Next.js 15.5.22, repaired browser decoding and tooling, regenerated the lockfile, and added dependency-audit enforcement; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-- Pull request #22 stopped accepting and advertising unsupported EPUB; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-- Pull request #23 pinned strict MkDocs builds, removed third-party analytics and obsolete links, published bilingual product, security, roadmap, contribution, and issue-reporting content, and removed unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-- Pull request #25 implemented official GitHub Pages artifact deployment; squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`.
-- Pull request #27 attempted to move documentation delivery to a new workflow path; squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`.
-- Pull request #31 published the bilingual TXT troubleshooting guide, covering real TXT and permitted URL inputs, UTF-8/GB18030/Big5 failures, binary files renamed as TXT, CORS, redirects, HTTP errors, browser storage loss, safe PWA refresh, and privacy-safe authorized reproduction; squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Pull request #33 added an independently registered documentation workflow; squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`.
-- Pull request #35 changed it to direct default-branch push; squash `499762b2ead74a74a13286a7cdca2d8fa6045f2e`.
-- Kept pull requests #32, #34, and #36 blocked after their required evidence jobs failed; no check was bypassed and no false documentation deployment claim was merged.
-- Added a temporary read-only deployment diagnostic to #36, using only Actions read, Pages read, and Contents read. It exposed workflow registration, recent run conclusions, Pages source, custom-domain state, and latest build without changing external configuration.
-- Prepared a focused Pages-compatible repair that:
-  - keeps the repository's verified legacy Pages mode and `gh-pages:/` source instead of attempting an unauthorized mode change;
-  - builds documentation from the exact reviewed default-branch commit using pinned dependencies and `mkdocs build --strict`;
-  - writes exact source identity to `build.json`;
-  - writes root `CNAME` as `www.webnovel.win` and preserves `.nojekyll`;
-  - validates the bilingual troubleshooting page, canonical manual pages, privacy boundary, and repository links;
-  - force-orphan publishes only generated output to `gh-pages` through the existing GitHub token pattern already used successfully by the repository;
-  - waits for Pages API state to show legacy `gh-pages:/`, custom domain `www.webnovel.win`, status `built`, and for the public custom domain to expose both the exact commit and actual bilingual guide;
-  - deletes the duplicate `docs-pages.yml` workflow so one documentation update cannot create two competing failed deploys.
+- Pull requests #14–#17 established autonomous PR-based operations and nonblocking branch cleanup.
+- Pull request #19 delivered first-use onboarding, visible TXT/URL import, recoverable feedback, privacy-aligned runtime behavior, repaired PWA caching, metadata, JSON-LD, robots, sitemap, and one Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Pull request #20 added exact application build identity and deployment verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Pull request #21 upgraded to supported Next.js 15.5.22, repaired decoding/tooling, regenerated the lockfile, and added dependency-audit enforcement; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- Pull request #22 removed false EPUB support; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+- Pull request #23 added strict pinned documentation builds, bilingual guidance, security, roadmap, contribution and issue-reporting content, and removed unrelated AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Pull requests #25, #27, #33, and #35 progressively diagnosed and replaced nonfunctional Pages delivery approaches without bypassing failed evidence.
+- Pull request #37 aligned publishing with the repository's actual legacy `gh-pages` source, preserved generated identity, removed the duplicate workflow, and merged as `bd0f859303a426a653970118102612f1ae6345f9` after green CI and clean final review.
+- Prepared a focused working-URL migration that:
+  - changes MkDocs `site_url` and canonical output to `https://autoarchive.github.io/webNR/`;
+  - changes the reader's Home action, README documentation/troubleshooting/contribution links, and issue help link to the working site;
+  - removes stale generated `CNAME` metadata so default GitHub Pages routing remains authoritative;
+  - publishes generated documentation to `gh-pages` and verifies Pages reports legacy `gh-pages:/`, no custom domain, status `built`, and the expected project URL;
+  - verifies the exact commit and both English and Chinese TXT troubleshooting content at the public project URL;
+  - rejects stale `www.webnovel.win` references in generated documentation.
 
 ## Validation and self-review
 
-- PR #19 final Quality run 30998009742 passed after initial review findings were fixed and rerun.
-- PR #20 Quality run 30998402518 passed.
-- PR #21 Quality run 31000279292 passed dependency audit, ESLint, TypeScript, application build, and SEO-data validation.
-- PR #22 Quality run 31001024829 passed.
-- PR #23 Quality run 31002086657 passed application, strict documentation, and SEO jobs; final review was clean.
-- PR #25 Quality run 31003643559 passed all expected jobs and workflow/security review.
-- PR #27 Quality run 31028991965 passed all expected jobs and trigger/permissions review.
-- PR #31 final Quality run 31030398159 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
-- PR #32 run 31030743502 passed Web quality, Documentation quality, and SEO data; Production evidence correctly failed only on documentation HTTP 404.
-- PR #33 final Quality run 31031650857 passed after privileged-workflow security hardening.
-- PR #34 run 31032106290 passed Web quality, Documentation quality, and SEO data; Production evidence correctly failed after forty-two documentation HTTP 404 responses.
-- PR #35 Quality run 31033047471 passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
-- PR #36 deployment-configuration job `92402955921` passed and produced the authenticated diagnosis above. Its production evidence remains correctly blocked.
-- The legacy-source repair still requires a real non-draft PR, complete CI, final workflow/security review, squash merge, successful `gh-pages` publication, Pages build, custom-domain registration, public guide verification, a clean permanent evidence PR, and metadata closeout.
+- PR #19 Quality run `30998009742` passed after review findings were fixed and rerun.
+- PR #20 run `30998402518`, PR #21 run `31000279292`, PR #22 run `31001024829`, PR #23 run `31002086657`, PR #25 run `31003643559`, PR #27 run `31028991965`, PR #31 run `31030398159`, PR #33 run `31031650857`, PR #35 run `31033047471`, and PR #37 run `31034906301` passed their expected checks.
+- PR #37 final review confirmed exact default-branch source selection, generated-only `gh-pages` publication, root metadata handling, duplicate-workflow removal, bounded public verification, privacy safety, no review threads, unchanged head, and mergeability.
+- PR #38 deployment diagnostics observed documentation run `31035078870` and a new successful Pages build from generated `gh-pages` commit `86f6e430c03205fc19bec3833e4a74bbb6ff4bf7`; its production evidence remained blocked because the custom domain was not configured.
+- The working-URL migration still requires a real non-draft PR, complete application/documentation/SEO CI, final diff review, squash merge, exact application and documentation deployments, and public verification.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
 
-- Bootstrap and policy: pull requests #14–#17
-- Product rescue: #19, squash `d8325d3f906e3aead84a4aec98d15815daf57545`
-- Verifiable application deployment: #20, squash `cba8cff1975d293947143f7efefc2b2db37d849a`
-- Stable dependency maintenance: #21, squash `f86d7967f44ae57d83c558a63e322f52dd18373a`
-- Truthful TXT-only boundary: #22, squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`
-- Documentation and community repair: #23, squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`
-- Official Pages implementation attempt: #25, squash `57b6123141dc6b3396f41afe03c47ffead6fe66f`
-- Workflow-path repair: #27, squash `93cbeb9ba70d47cdb827ff7d878c90e67225d4d7`
-- Bilingual TXT troubleshooting and canonical manual paths: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
-- Independent documentation deployer: #33, squash `e051c7f5cd6cc41eef84965404cafb493b8f84df`
-- Direct-push attempt: #35, squash `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Evidence diagnoses: #32 and #34 closed superseded without merge; #36 open and blocked while serving as diagnostic evidence
-- Configured legacy Pages-source repair: pending PR, CI, final review, squash merge, and public verification
-- Final permanent evidence gate and metadata-only closeout: pending
+- Product rescue and operating foundation: pull requests #14–#23
+- Bilingual TXT troubleshooting: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Legacy Pages-compatible generated publication: #37, squash `bd0f859303a426a653970118102612f1ae6345f9`
+- Working GitHub Pages URL migration: pending PR, CI, final review, squash merge, and exact public verification
+- Superseded evidence PRs: #32 and #34 closed without merge; #36 and #38 must be closed without merge after the replacement is established
+- Permanent evidence gate and metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
 
-- A branch, merge, workflow URL, generated artifact, or HTTP 200 alone is not production proof. Both public custom domains must expose recorded exact commits.
-- Failed evidence checks remain blocking evidence and must not be bypassed.
-- The repository's existing Pages publishing mode is authoritative. A normal workflow token must not attempt a Pages settings mutation requiring Administration write.
-- In legacy branch mode, the generated root `CNAME` file must survive every force-orphan publication.
-- Duplicate documentation publishers are removed rather than allowed to compete or produce known failures.
+- A branch, merge, generated artifact, workflow URL, or HTTP 200 alone is not production proof; public pages must expose the recorded exact commit and intended content.
+- Failed evidence checks remain blocking evidence and are never bypassed.
+- The working GitHub Pages project URL becomes the canonical documentation endpoint now; the optional custom-domain migration is separated from current public availability.
+- Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, followed by a separate reviewed migration and redirect plan.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
 - After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the legacy-source repair deploys and verifies documentation, a permanent evidence PR proves both domains, and the metadata-only closeout passes CI, final review, and squash merge.
+- The cycle remains incomplete until the working-URL migration and permanent evidence gate are merged and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,27 +3,27 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application delivery are merged; documentation production, permanent evidence, and final metadata closeout remain
+- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application delivery are merged; the documentation entrypoint is being migrated from a broken custom domain to the working GitHub Pages project URL before permanent evidence and closeout
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow-registration, Pages-configuration, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #35
-- Last squash merge: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
+- Last site-change pull request: #37
+- Last squash merge: `bd0f859303a426a653970118102612f1ae6345f9`
 - Last closeout pull request: #17
 - Last successful attributable application deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Last successful attributable documentation artifact: strict builds contain the bilingual TXT troubleshooting guide and canonical manual paths, but the public documentation custom domain still returns `404 no-store`
-- Last public verification: pull request #36 observed the application at exact `499762b2ead74a74a13286a7cdca2d8fa6045f2e`; the documentation endpoint remained HTTP 404
+- Last successful attributable documentation artifact: `bd0f859303a426a653970118102612f1ae6345f9` is present on `gh-pages`, but the former `www.webnovel.win` entrypoint remains unconfigured and returns HTTP 404
+- Last public verification: pull request #38 diagnostics found the documentation workflow and latest Pages build active, while Pages API continued to report `cname: null`; the custom domain therefore cannot be treated as production
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. Public deployment checks continue through DNS, response headers, cache-busted custom-domain requests, Pages API state, and exact build identities.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. The broken `www` hostname cannot be repaired through the available account connection in this cycle.
 - Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public SEO-data validation, and exact production evidence.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
 - Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Pages configuration: authenticated read-only diagnosis in pull request #36 found `build_type: legacy`, source `gh-pages:/`, status `built`, and `cname: null`. The latest successful Pages build remained an older `gh-pages` commit.
-- Failed workflow evidence: registered documentation runs `31031843502` and `31033180994` both failed. Run `31033180994` failed at the first Pages-settings mutation with HTTP 403 `Resource not accessible by integration`; the job's token had Pages write but not the Administration write permission required to change repository Pages mode.
-- Documentation deployment repair: active work stops trying to mutate repository Pages settings. It builds strictly, preserves `CNAME` and `.nojekyll`, publishes the generated site to the already-configured `gh-pages` source, removes the duplicate failing workflow, and waits for both legacy Pages configuration and the public bilingual guide.
+- Pages configuration: authenticated diagnosis found legacy source `gh-pages:/`, status `built`, project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
+- Workflow behavior: pull request #37 successfully built and published exact documentation artifacts to `gh-pages`; its final wait failed only because it required the absent custom-domain registration and the Cloudflare-served `www` URL.
+- Documentation migration: active work makes the verified GitHub Pages project URL the canonical documentation URL, removes stale `CNAME` output, updates the reader home action, README and issue help link, and verifies the exact commit plus bilingual guide at the project URL.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -32,10 +32,11 @@
 
 ## Active focus
 
-- Validate, review, and squash-merge the `gh-pages`-compatible documentation publisher.
-- Verify its exact source commit, Pages custom-domain registration, and bilingual TXT troubleshooting page on `https://www.webnovel.win/`.
-- Replace the diagnostic evidence branch with a clean permanent evidence gate after deployment.
+- Validate and merge the working-URL migration through complete application, documentation, SEO, and final-diff review.
+- Verify the exact squash commit on both the reader and `https://autoarchive.github.io/webNR/`, including the bilingual TXT troubleshooting page.
+- Replace stale diagnostic evidence branches with a clean permanent evidence gate using the working documentation URL.
 - Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
+- Track the optional `www.webnovel.win` custom-domain migration separately until either the GitHub Pages setting or the correct Cloudflare zone becomes writable; it no longer blocks a working public documentation site.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 

--- a/.github/workflows/publish-docs-pages.yml
+++ b/.github/workflows/publish-docs-pages.yml
@@ -9,7 +9,6 @@ on:
       - 'mkdocs.yml'
       - '.github/requirements-docs.txt'
       - '.github/workflows/publish-docs-pages.yml'
-      - '.github/workflows/docs-pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -27,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      PRODUCTION_BUILD_URL: https://www.webnovel.win/build.json
-      TROUBLESHOOTING_URL: https://www.webnovel.win/troubleshooting/txt-import/
+      PRODUCTION_BUILD_URL: https://autoarchive.github.io/webNR/build.json
+      TROUBLESHOOTING_URL: https://autoarchive.github.io/webNR/troubleshooting/txt-import/
     steps:
       - name: Select trusted default-branch commit
         id: source
@@ -96,9 +95,9 @@ jobs:
       - name: Build documentation strictly
         run: mkdocs build --strict
 
-      - name: Preserve Pages custom domain and disable Jekyll
+      - name: Disable Jekyll and remove stale custom-domain metadata
         run: |
-          printf 'www.webnovel.win\n' > site/CNAME
+          rm -f site/CNAME
           touch site/.nojekyll
 
       - name: Validate documentation artifact
@@ -108,22 +107,22 @@ jobs:
           set -eu
           test -f site/index.html
           test -f site/build.json
-          test -f site/CNAME
           test -f site/.nojekyll
+          test ! -e site/CNAME
           test -f site/troubleshooting/txt-import/index.html
           test -f site/manual/contributing/index.html
           test -f site/manual/url-params/index.html
-          grep -Fxq 'www.webnovel.win' site/CNAME
           grep -Fq "${BUILD_SHA}" site/build.json
           grep -Fq 'TXT import troubleshooting' site/troubleshooting/txt-import/index.html
           grep -Fq 'TXT 导入排障' site/troubleshooting/txt-import/index.html
           grep -Fq 'AutoArchive/webNR' site/index.html
+          grep -Fq 'https://autoarchive.github.io/webNR/' site/index.html
           if grep -R -Fq 'googletagmanager.com' site; then
             echo 'Unexpected Google Analytics loader in documentation artifact' >&2
             exit 1
           fi
-          if grep -R -E -q 'yourusername/webnr|yunwei37/webNR' site; then
-            echo 'Obsolete repository reference in documentation artifact' >&2
+          if grep -R -E -q 'yourusername/webnr|yunwei37/webNR|https://www\.webnovel\.win' site; then
+            echo 'Obsolete repository or documentation-domain reference in artifact' >&2
             exit 1
           fi
 
@@ -136,7 +135,7 @@ jobs:
           force_orphan: true
           commit_message: "docs-deploy: ${{ steps.source.outputs.sha }}"
 
-      - name: Wait for legacy Pages build and custom-domain registration
+      - name: Wait for legacy Pages build and public documentation
         env:
           BUILD_SHA: ${{ steps.source.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
@@ -168,8 +167,9 @@ jobs:
               ready = (
                   data.get("build_type") == "legacy"
                   and data.get("source") == {"branch": "gh-pages", "path": "/"}
-                  and data.get("cname") == "www.webnovel.win"
+                  and not data.get("cname")
                   and data.get("status") == "built"
+                  and data.get("html_url") == "https://autoarchive.github.io/webNR/"
               )
               print("true" if ready else "false")
           PY
@@ -179,7 +179,7 @@ jobs:
               && printf '%s' "${build_response}" | grep -Fq "\"commit\": \"${BUILD_SHA}\"" \
               && printf '%s' "${guide_response}" | grep -Fq 'TXT import troubleshooting' \
               && printf '%s' "${guide_response}" | grep -Fq 'TXT 导入排障'; then
-              printf 'Verified legacy Pages configuration, documentation commit, and guide for %s\n' "${BUILD_SHA}"
+              printf 'Verified Pages configuration, documentation commit, and guide for %s\n' "${BUILD_SHA}"
               exit 0
             fi
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 WebNR is a private, local-first web reader for user-owned TXT books and supported text URLs. It runs as an installable progressive web app, stores books and reading progress in the browser, and does not require an account.
 
 - Reader: <https://app.webnovel.win/>
-- Documentation: <https://www.webnovel.win/>
+- Documentation: <https://autoarchive.github.io/webNR/>
 - Source and issues: <https://github.com/AutoArchive/webNR>
 
 ## Current capabilities
@@ -28,7 +28,7 @@ WebNR is a private, local-first web reader for user-owned TXT books and supporte
 3. Select a local TXT file, or enter a supported text URL.
 4. Start reading. The book and progress are stored in the current browser profile.
 
-For encoding, CORS, storage, and PWA-update failures, see the [TXT import troubleshooting guide](docs/troubleshooting/txt-import.md).
+For encoding, CORS, storage, and PWA-update failures, see the [TXT import troubleshooting guide](https://autoarchive.github.io/webNR/troubleshooting/txt-import/).
 
 ## Local development
 
@@ -66,7 +66,7 @@ WebNR source definitions are connectors, not content licenses. Contributors must
 
 ## Contributing
 
-Issues and focused pull requests are welcome. See the [contributing guide](docs/manual/contributing.md). Every change must use a branch and pull request, pass the expected app/documentation/SEO checks, receive a complete final review, and preserve the local-data and content-policy boundaries.
+Issues and focused pull requests are welcome. See the [contributing guide](https://autoarchive.github.io/webNR/manual/contributing/). Every change must use a branch and pull request, pass the expected app/documentation/SEO checks, receive a complete final review, and preserve the local-data and content-policy boundaries.
 
 ## License
 

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -3,7 +3,7 @@
  */
 export const CONFIG = {
   GITHUB_REPO: 'https://github.com/AutoArchive/webNR',
-  HOME_PAGE: 'https://www.webnovel.win',
+  HOME_PAGE: 'https://autoarchive.github.io/webNR/',
   CANONICAL_DOMAIN: 'https://app.webnovel.win',
 
   PWA: {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: WebNR Documentation
 site_description: User and developer documentation for the private, local-first WebNR TXT reader
 site_author: AutoArchive contributors
-site_url: https://www.webnovel.win/
+site_url: https://autoarchive.github.io/webNR/
 repo_url: https://github.com/AutoArchive/webNR
 repo_name: AutoArchive/webNR
 edit_uri: edit/main/docs/


### PR DESCRIPTION
## Evidence

The generated documentation is successfully built and published to the configured legacy `gh-pages:/` source, but GitHub Pages continues to report `cname: null`. The former `www.webnovel.win` entrypoint is served through an unavailable Cloudflare zone and returns cache-busted HTTP 404 responses.

Pull request #37 proved the generated publication path works: exact source commit `bd0f859303a426a653970118102612f1ae6345f9` was built, validated, pushed to `gh-pages`, and produced a new successful Pages build. Its final wait failed only because it required a custom-domain setting that the available GitHub token and Cloudflare connection cannot modify.

## Coherent outcome

- make `https://autoarchive.github.io/webNR/` the canonical and publicly supported documentation URL
- update MkDocs `site_url`, the reader Home action, README links, TXT troubleshooting link, contribution link, and issue help link
- stop emitting stale `CNAME` metadata so the default Pages project URL remains authoritative
- reject stale `www.webnovel.win` references in generated documentation
- publish generated output through the existing `gh-pages` source
- verify Pages reports legacy `gh-pages:/`, no custom domain, status `built`, and the expected project URL
- verify the exact squash commit and both English and Chinese TXT troubleshooting content at the public project URL

## Required checks

- dependency audit, ESLint, TypeScript, and production application build
- strict pinned documentation build and generated-output assertions
- public SEO-data validation
- complete final review of all public links, canonical output, subpath handling, application navigation, generated branch metadata, deployment verification, privacy boundary, and mergeability

## Safety and compatibility

- no user filenames, book titles, reading content, history, source URLs, cookies, credentials, provider IDs, or raw analytics are collected or committed
- the application canonical domain remains `app.webnovel.win`; only the documentation destination changes
- the optional custom-domain migration is deferred until the Pages setting or correct Cloudflare zone is writable and can be delivered through a separate reviewed migration

## Post-merge acceptance

This PR must deploy its exact squash commit to both the reader and the GitHub Pages documentation project URL. The public reader Home action must lead to the working documentation, and the public troubleshooting page must render the supported-format, encoding, CORS, storage-loss, PWA, and safe-reporting sections in both languages.
