### PR TITLE
ci: permanently verify the exact public reader and documentation builds

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Complete a same-day WebNR rescue and operating cycle: repair product onboarding, privacy, accessibility, PWA reliability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production delivery. Publish a meaningful bilingual troubleshooting resource and expose it through a working public URL.
+Complete a same-day WebNR rescue and operating cycle: repair product onboarding, privacy, accessibility, PWA reliability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production delivery. Publish a meaningful bilingual troubleshooting resource through a working public URL and close only after exact reader and documentation builds are proven.
 
 ## Data window
 
@@ -19,13 +19,12 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - EPUB was advertised and accepted although no EPUB parser existed.
 - The original documentation used unpinned dependencies, had broken deployment, loaded third-party analytics, contained obsolete links and generic AI content, and lacked exact public build identity.
 - Pull requests #19–#23 repaired the product, dependencies, format boundary, documentation quality, CI, and community infrastructure.
-- Pull request #31 published the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- Pull request #31 published the bilingual TXT import troubleshooting guide and canonical `manual` paths.
 - Evidence pull requests #32, #34, #36, and #38 were allowed to fail rather than merge unproven delivery claims. They verified application deployments while repeatedly observing documentation HTTP 404 responses.
 - Authenticated Pages diagnosis found `build_type: legacy`, source `gh-pages:/`, status `built`, project URL `https://autoarchive.github.io/webNR/`, and `cname: null`.
-- Registered documentation runs `31031843502` and `31033180994` failed because a normal workflow token attempted an Administration-protected Pages settings mutation and received HTTP 403 `Resource not accessible by integration`.
-- Pull request #37 removed that mutation, deleted the duplicate publisher, generated exact documentation artifacts, and successfully pushed commit `bd0f859303a426a653970118102612f1ae6345f9` content to `gh-pages`.
-- The #37 workflow then waited through 45 checks and failed only because it required custom-domain registration. Pages remained built with `cname: null`, and Cloudflare continued serving HTTP 404 for `www.webnovel.win`.
-- The current connector cannot write the GitHub Pages custom-domain setting, and the connected Cloudflare accounts do not expose the zone. The working GitHub Pages project URL is therefore the reliable public documentation endpoint for this cycle.
+- Registered documentation runs failed when normal workflow tokens attempted an Administration-protected Pages settings mutation. Pull request #37 removed that mutation, published generated content to `gh-pages`, and proved the build path worked.
+- Pull request #37 still failed its final wait because it required an unconfigured custom domain. The current connector cannot write the GitHub Pages custom-domain setting, and the connected Cloudflare accounts do not expose the zone.
+- Pull request #40 made the working GitHub Pages project URL canonical, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, and required exact public reader/documentation verification.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
@@ -37,42 +36,47 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - Pull request #22 removed false EPUB support; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
 - Pull request #23 added strict pinned documentation builds, bilingual guidance, security, roadmap, contribution and issue-reporting content, and removed unrelated AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 - Pull requests #25, #27, #33, and #35 progressively diagnosed and replaced nonfunctional Pages delivery approaches without bypassing failed evidence.
-- Pull request #37 aligned publishing with the repository's actual legacy `gh-pages` source, preserved generated identity, removed the duplicate workflow, and merged as `bd0f859303a426a653970118102612f1ae6345f9` after green CI and clean final review.
-- Prepared a focused working-URL migration that:
-  - changes MkDocs `site_url` and canonical output to `https://autoarchive.github.io/webNR/`;
-  - changes the reader's Home action, README documentation/troubleshooting/contribution links, and issue help link to the working site;
-  - removes stale generated `CNAME` metadata so default GitHub Pages routing remains authoritative;
-  - publishes generated documentation to `gh-pages` and verifies Pages reports legacy `gh-pages:/`, no custom domain, status `built`, and the expected project URL;
-  - verifies the exact commit and both English and Chinese TXT troubleshooting content at the public project URL;
-  - rejects stale `www.webnovel.win` references in generated documentation.
+- Pull request #37 aligned publication with the repository's actual legacy `gh-pages` source and merged as `bd0f859303a426a653970118102612f1ae6345f9` after green CI and clean final review.
+- Pull request #40:
+  - changed MkDocs canonical output to `https://autoarchive.github.io/webNR/`;
+  - changed the reader Home action and all active repository help links to the working project URL;
+  - removed stale generated CNAME metadata;
+  - required Pages to report legacy `gh-pages:/`, no custom domain, status `built`, and the expected project URL;
+  - required the public project URL to expose the exact commit and English and Chinese TXT troubleshooting content;
+  - rejected stale `www.webnovel.win` references in generated documentation.
+- Pull request #40 passed all expected CI and a complete final review, had no review threads, remained mergeable with an unchanged head, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Created the final production-evidence branch, adding a permanent exact-build verifier and a temporary read-only Pages/workflow diagnostic for the final transition.
 
 ## Validation and self-review
 
 - PR #19 Quality run `30998009742` passed after review findings were fixed and rerun.
 - PR #20 run `30998402518`, PR #21 run `31000279292`, PR #22 run `31001024829`, PR #23 run `31002086657`, PR #25 run `31003643559`, PR #27 run `31028991965`, PR #31 run `31030398159`, PR #33 run `31031650857`, PR #35 run `31033047471`, and PR #37 run `31034906301` passed their expected checks.
-- PR #37 final review confirmed exact default-branch source selection, generated-only `gh-pages` publication, root metadata handling, duplicate-workflow removal, bounded public verification, privacy safety, no review threads, unchanged head, and mergeability.
-- PR #38 deployment diagnostics observed documentation run `31035078870` and a new successful Pages build from generated `gh-pages` commit `86f6e430c03205fc19bec3833e4a74bbb6ff4bf7`; its production evidence remained blocked because the custom domain was not configured.
-- The working-URL migration still requires a real non-draft PR, complete application/documentation/SEO CI, final diff review, squash merge, exact application and documentation deployments, and public verification.
+- PR #38 diagnostics observed a successful generated Pages build from `gh-pages`, but its evidence remained blocked because the former custom domain was not configured.
+- PR #40 Quality run `31036258893` passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
+- PR #40 final review confirmed consistent project-subpath canonical output, reader and repository links, removal of stale CNAME and custom-domain references from generated content, unchanged application canonical domain, privacy safety, no review threads, unchanged head, and mergeability.
+- The final evidence pull request still requires Web, Documentation, SEO-data, deployment-configuration, and Production evidence jobs plus a complete final diff review before squash merge.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
 
 - Product rescue and operating foundation: pull requests #14–#23
-- Bilingual TXT troubleshooting: #31, squash `57c904bb637b97eb0b8cc9a99e035d91c39574fb`
+- Bilingual TXT troubleshooting: #31
 - Legacy Pages-compatible generated publication: #37, squash `bd0f859303a426a653970118102612f1ae6345f9`
-- Working GitHub Pages URL migration: pending PR, CI, final review, squash merge, and exact public verification
-- Superseded evidence PRs: #32 and #34 closed without merge; #36 and #38 must be closed without merge after the replacement is established
-- Permanent evidence gate and metadata-only closeout: pending
+- Working GitHub Pages URL migration: #40, squash `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
+- Superseded evidence PRs: #32 and #34 closed without merge; #36 and #38 must be closed without merge after the final evidence gate is established
+- Permanent production-evidence gate: pending PR, CI, final review, and squash merge
+- Metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
 
 - A branch, merge, generated artifact, workflow URL, or HTTP 200 alone is not production proof; public pages must expose the recorded exact commit and intended content.
 - Failed evidence checks remain blocking evidence and are never bypassed.
-- The working GitHub Pages project URL becomes the canonical documentation endpoint now; the optional custom-domain migration is separated from current public availability.
+- The working GitHub Pages project URL is the canonical documentation endpoint. The optional custom-domain migration is separated from current public availability.
 - Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, followed by a separate reviewed migration and redirect plan.
+- Evidence-only changes must not trigger redundant application or documentation publication.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
 - After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the working-URL migration and permanent evidence gate are merged and the metadata-only closeout passes CI, final review, and squash merge.
+- The cycle remains incomplete until the permanent evidence gate proves both public builds and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -24,7 +24,12 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - Authenticated Pages diagnosis found `build_type: legacy`, source `gh-pages:/`, status `built`, project URL `https://autoarchive.github.io/webNR/`, and `cname: null`.
 - Registered documentation runs failed when normal workflow tokens attempted an Administration-protected Pages settings mutation. Pull request #37 removed that mutation, published generated content to `gh-pages`, and proved the build path worked.
 - Pull request #37 still failed its final wait because it required an unconfigured custom domain. The current connector cannot write the GitHub Pages custom-domain setting, and the connected Cloudflare accounts do not expose the zone.
-- Pull request #40 made the working GitHub Pages project URL canonical, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, and required exact public reader/documentation verification.
+- Pull request #40 made the working GitHub Pages project URL canonical, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Documentation workflow run `31036446960` completed successfully for source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Pages API reported legacy `gh-pages:/`, `cname: null`, project URL `https://autoarchive.github.io/webNR/`, HTTPS enforced, status `built`, and a successful latest Pages build from generated branch commit `f06553dfa0c7116d467861b338f6d7f41f01f4ba`.
+- Pull request #41 initial Quality run `31036915052` passed all five jobs. Production evidence job `92411188768` verified both public build identities at exact source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and verified the public bilingual troubleshooting content.
+- The application endpoint resolved through Cloudflare and returned the exact commit with cache-control and ETag evidence.
+- The documentation endpoint resolved to GitHub Pages addresses and returned exact commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`, GitHub Pages response headers, the English heading `TXT import troubleshooting`, the Chinese heading `TXT 导入排障`, and the canonical project URL.
 - The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
 
 ## Work performed
@@ -45,7 +50,9 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
   - required the public project URL to expose the exact commit and English and Chinese TXT troubleshooting content;
   - rejected stale `www.webnovel.win` references in generated documentation.
 - Pull request #40 passed all expected CI and a complete final review, had no review threads, remained mergeable with an unchanged head, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Created the final production-evidence branch, adding a permanent exact-build verifier and a temporary read-only Pages/workflow diagnostic for the final transition.
+- Pull request #41 added a permanent required Production evidence job that parses recorded source commits, checks public DNS and selected response headers, fetches cache-busted build identities, and requires the actual bilingual troubleshooting content.
+- Pull request #41 also excludes evidence-only workflow, verifier, and SEO-record changes from redundant application deployment.
+- After the first full green run captured final Pages/workflow transition evidence, the temporary read-only diagnostic job and its extra Actions/Pages permissions were removed. The permanent Quality workflow now requires only Contents read.
 
 ## Validation and self-review
 
@@ -54,7 +61,9 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - PR #38 diagnostics observed a successful generated Pages build from `gh-pages`, but its evidence remained blocked because the former custom domain was not configured.
 - PR #40 Quality run `31036258893` passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
 - PR #40 final review confirmed consistent project-subpath canonical output, reader and repository links, removal of stale CNAME and custom-domain references from generated content, unchanged application canonical domain, privacy safety, no review threads, unchanged head, and mergeability.
-- The final evidence pull request still requires Web, Documentation, SEO-data, deployment-configuration, and Production evidence jobs plus a complete final diff review before squash merge.
+- PR #41 initial Quality run `31036915052` passed Web quality, Documentation quality, SEO data contract, Deployment configuration, and Production evidence.
+- PR #41 Production evidence job `92411188768` verified the reader and documentation exact source commit plus the public bilingual troubleshooting content on its first request.
+- The temporary transition diagnostic was removed after capturing workflow run `31036446960`, Pages configuration, and latest Pages build evidence. A full final CI rerun is required before merge.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 
 ## Delivery
@@ -63,8 +72,8 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - Bilingual TXT troubleshooting: #31
 - Legacy Pages-compatible generated publication: #37, squash `bd0f859303a426a653970118102612f1ae6345f9`
 - Working GitHub Pages URL migration: #40, squash `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Superseded evidence PRs: #32 and #34 closed without merge; #36 and #38 must be closed without merge after the final evidence gate is established
-- Permanent production-evidence gate: pending PR, CI, final review, and squash merge
+- Exact public reader and documentation verification: PR #41 initial run passed; final reduced-permission rerun, final review, and squash merge pending
+- Superseded evidence PRs: #32 and #34 closed without merge; #36 and #38 must be closed without merge after PR #41 is established
 - Metadata-only closeout: pending
 - Branch cleanup: best-effort and nonblocking
 
@@ -79,4 +88,4 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
 - Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
 - After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until the permanent evidence gate proves both public builds and the metadata-only closeout passes CI, final review, and squash merge.
+- The cycle remains incomplete until PR #41 passes its final reduced-permission rerun, receives a clean final review, squash-merges, and the metadata-only closeout passes CI, final review, and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,27 +3,27 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product, dependency, truthful format support, bilingual troubleshooting, and application delivery are merged; the documentation entrypoint is being migrated from a broken custom domain to the working GitHub Pages project URL before permanent evidence and closeout
+- Active operating cycle: product rescue, dependency repair, truthful format support, bilingual troubleshooting, and the working documentation URL migration are merged; permanent production evidence and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow-registration, Pages-configuration, and public-artifact evidence collected on 2026-08-05
-- Last site-change pull request: #37
-- Last squash merge: `bd0f859303a426a653970118102612f1ae6345f9`
+- Last site-change pull request: #40
+- Last squash merge: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last closeout pull request: #17
-- Last successful attributable application deployment: `499762b2ead74a74a13286a7cdca2d8fa6045f2e`
-- Last successful attributable documentation artifact: `bd0f859303a426a653970118102612f1ae6345f9` is present on `gh-pages`, but the former `www.webnovel.win` entrypoint remains unconfigured and returns HTTP 404
-- Last public verification: pull request #38 diagnostics found the documentation workflow and latest Pages build active, while Pages API continued to report `cname: null`; the custom domain therefore cannot be treated as production
+- Last successful attributable application deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
+- Last successful attributable documentation deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
+- Last public verification: this pull request cannot merge unless its required Production evidence job proves the reader and GitHub Pages documentation project both expose exact commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and the public troubleshooting page contains the expected bilingual content
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. The broken `www` hostname cannot be repaired through the available account connection in this cycle.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public SEO-data validation, and exact production evidence.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. The former `www.webnovel.win` documentation hostname is not treated as production.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, Pages state diagnosis, public SEO-data validation, and exact production evidence.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-- Pages configuration: authenticated diagnosis found legacy source `gh-pages:/`, status `built`, project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
-- Workflow behavior: pull request #37 successfully built and published exact documentation artifacts to `gh-pages`; its final wait failed only because it required the absent custom-domain registration and the Cloudflare-served `www` URL.
-- Documentation migration: active work makes the verified GitHub Pages project URL the canonical documentation URL, removes stale `CNAME` output, updates the reader home action, README and issue help link, and verifies the exact commit plus bilingual guide at the project URL.
+- Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths.
+- Pages diagnosis: authenticated inspection found legacy source `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
+- Documentation publication: pull request #37 repaired generated `gh-pages` delivery. Pull request #40 then made the working project URL canonical, removed stale `CNAME` output, updated the reader Home action and public repository links, passed every expected check and final review, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Production evidence: both deployment lines above are enforced by this same pull request and cannot reach `main` unless the public reader, documentation build identity, canonical project URL, and bilingual troubleshooting content all match.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -32,12 +32,13 @@
 
 ## Active focus
 
-- Validate and merge the working-URL migration through complete application, documentation, SEO, and final-diff review.
-- Verify the exact squash commit on both the reader and `https://autoarchive.github.io/webNR/`, including the bilingual TXT troubleshooting page.
-- Replace stale diagnostic evidence branches with a clean permanent evidence gate using the working documentation URL.
+- Pass exact production evidence for application and documentation commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Capture final Pages workflow, source, build, project URL, and bilingual troubleshooting evidence, then remove the temporary deployment-configuration diagnostic job.
+- Complete a clean final review and squash-merge the permanent evidence gate without triggering redundant deployment.
+- Close superseded diagnostic pull requests #36 and #38 without merge.
 - Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
-- Track the optional `www.webnovel.win` custom-domain migration separately until either the GitHub Pages setting or the correct Cloudflare zone becomes writable; it no longer blocks a working public documentation site.
+- Track an optional `www.webnovel.win` migration separately until the GitHub Pages setting or correct Cloudflare zone becomes writable; it does not block the working public documentation site.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified current facts and clearly marked pending work. Detailed history belongs in `daily/`.
+This file contains verified facts or facts whose truth is enforced by the same pull request's required public-evidence check. Detailed history belongs in `daily/`.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,14 +3,14 @@
 ## Current state
 
 - Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product rescue, dependency repair, truthful format support, bilingual troubleshooting, and the working documentation URL migration are merged; permanent production evidence and final metadata closeout remain
+- Active operating cycle: product rescue, dependency repair, truthful format support, bilingual troubleshooting, the working documentation URL migration, and exact public production verification are complete; the permanent evidence gate and final metadata closeout remain
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow-registration, Pages-configuration, and public-artifact evidence collected on 2026-08-05
 - Last site-change pull request: #40
 - Last squash merge: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last closeout pull request: #17
 - Last successful attributable application deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last successful attributable documentation deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Last public verification: this pull request cannot merge unless its required Production evidence job proves the reader and GitHub Pages documentation project both expose exact commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and the public troubleshooting page contains the expected bilingual content
+- Last public verification: pull request #41 Quality run `31036915052`, Production evidence job `92411188768`, verified both public build identities at exact `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and verified the public bilingual TXT troubleshooting page
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
@@ -18,12 +18,13 @@
 - Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
 - Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone. The former `www.webnovel.win` documentation hostname is not treated as production.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, Pages state diagnosis, public SEO-data validation, and exact production evidence.
+- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public SEO-data validation, and exact public production evidence.
 - Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
 - Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths.
 - Pages diagnosis: authenticated inspection found legacy source `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
-- Documentation publication: pull request #37 repaired generated `gh-pages` delivery. Pull request #40 then made the working project URL canonical, removed stale `CNAME` output, updated the reader Home action and public repository links, passed every expected check and final review, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Production evidence: both deployment lines above are enforced by this same pull request and cannot reach `main` unless the public reader, documentation build identity, canonical project URL, and bilingual troubleshooting content all match.
+- Documentation publication: pull request #37 repaired generated `gh-pages` delivery. Pull request #40 made the working project URL canonical, removed stale `CNAME` output, updated the reader Home action and public repository links, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Public production: the reader build endpoint returned exact `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` through Cloudflare; the GitHub Pages build endpoint returned the same exact commit through GitHub Pages; the public troubleshooting page matched the English and Chinese headings and the canonical project URL.
+- Permanent evidence: the temporary Pages diagnostic has been removed. Quality retains a required read-only production verifier that checks both exact builds and the actual troubleshooting content on every run.
 - Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
 - Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
@@ -32,13 +33,11 @@
 
 ## Active focus
 
-- Pass exact production evidence for application and documentation commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Capture final Pages workflow, source, build, project URL, and bilingual troubleshooting evidence, then remove the temporary deployment-configuration diagnostic job.
-- Complete a clean final review and squash-merge the permanent evidence gate without triggering redundant deployment.
+- Rerun every required check after removal of the temporary transition diagnostic, then complete a clean final review and squash-merge pull request #41.
 - Close superseded diagnostic pull requests #36 and #38 without merge.
 - Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
 - Track an optional `www.webnovel.win` migration separately until the GitHub Pages setting or correct Cloudflare zone becomes writable; it does not block the working public documentation site.
 - Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
-This file contains verified facts or facts whose truth is enforced by the same pull request's required public-evidence check. Detailed history belongs in `daily/`.
+This file contains verified current facts. Detailed history belongs in `daily/`.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -8,8 +8,11 @@ on:
       - '.github/seo-data/**'
       - '.github/requirements-docs.txt'
       - '.github/workflows/publish-docs-pages.yml'
+      - '.github/workflows/quality.yml'
+      - '.github/workflows/nextjs.yml'
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 
 permissions:
@@ -30,16 +33,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Write public build identity
         env:
           BUILD_SHA: ${{ github.sha }}
@@ -53,10 +53,8 @@ jobs:
           };
           fs.writeFileSync('public/build.json', `${JSON.stringify(manifest, null, 2)}\n`);
           NODE
-
       - name: Build static application
         run: npm run build
-
       - name: Validate deployment artifact
         env:
           BUILD_SHA: ${{ github.sha }}
@@ -75,7 +73,6 @@ jobs:
             exit 1
           fi
           touch out/.nojekyll
-
       - name: Publish app-pages branch
         uses: peaceiris/actions-gh-pages@v4.1.0
         with:
@@ -84,7 +81,6 @@ jobs:
           publish_branch: app-pages
           force_orphan: true
           commit_message: "deploy: ${{ github.sha }}"
-
       - name: Verify exact production build
         env:
           BUILD_SHA: ${{ github.sha }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pages: read
 
 concurrency:
   group: quality-${{ github.workflow }}-${{ github.ref }}
@@ -26,27 +28,21 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
       - name: Audit dependency tree
         run: |
           npm audit --json > "${RUNNER_TEMP}/npm-audit.json" || true
           node scripts/validate-npm-audit.mjs "${RUNNER_TEMP}/npm-audit.json"
-
       - name: Lint
         run: npm run lint
-
       - name: Type check
         run: npm run typecheck
-
       - name: Production build
         run: npm run build
 
@@ -60,31 +56,31 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: .github/requirements-docs.txt
-
       - name: Install pinned documentation dependencies
         run: pip install --requirement .github/requirements-docs.txt
-
       - name: Build documentation strictly
         run: mkdocs build --strict
-
       - name: Validate documentation output
         run: |
           set -eu
           test -f site/index.html
+          test -f site/troubleshooting/txt-import/index.html
           grep -Fq 'AutoArchive/webNR' site/index.html
+          grep -Fq 'https://autoarchive.github.io/webNR/' site/index.html
+          grep -Fq 'TXT import troubleshooting' site/troubleshooting/txt-import/index.html
+          grep -Fq 'TXT 导入排障' site/troubleshooting/txt-import/index.html
           if grep -R -Fq 'googletagmanager.com' site; then
             echo 'Unexpected Google Analytics loader in documentation artifact' >&2
             exit 1
           fi
-          if grep -R -E -q 'yourusername/webnr|yunwei37/webNR' site; then
-            echo 'Obsolete repository reference in documentation artifact' >&2
+          if grep -R -E -q 'yourusername/webnr|yunwei37/webNR|https://www\.webnovel\.win' site; then
+            echo 'Obsolete repository or documentation-domain reference in artifact' >&2
             exit 1
           fi
 
@@ -97,13 +93,83 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-
       - name: Validate public SEO operating data
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
+
+  deployment-configuration:
+    name: Deployment configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Inspect documentation workflow and Pages state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          api="https://api.github.com/repos/${REPOSITORY}"
+          headers=(
+            --header 'Accept: application/vnd.github+json'
+            --header "Authorization: Bearer ${GH_TOKEN}"
+            --header 'X-GitHub-Api-Version: 2022-11-28'
+          )
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/actions/workflows/publish-docs-pages.yml/runs?branch=main&per_page=10" \
+            > "${RUNNER_TEMP}/docs-runs.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/pages" > "${RUNNER_TEMP}/pages.json"
+          curl --fail-with-body --silent --show-error "${headers[@]}" \
+            "${api}/pages/builds/latest" > "${RUNNER_TEMP}/latest-pages-build.json"
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          temp = Path(os.environ['RUNNER_TEMP'])
+          runs = json.loads((temp / 'docs-runs.json').read_text())
+          pages = json.loads((temp / 'pages.json').read_text())
+          latest = json.loads((temp / 'latest-pages-build.json').read_text())
+
+          print('DOCUMENTATION WORKFLOW RUNS')
+          for item in runs.get('workflow_runs', []):
+              print(json.dumps({
+                  'id': item.get('id'),
+                  'event': item.get('event'),
+                  'status': item.get('status'),
+                  'conclusion': item.get('conclusion'),
+                  'head_sha': item.get('head_sha'),
+                  'run_number': item.get('run_number'),
+                  'html_url': item.get('html_url'),
+              }, sort_keys=True))
+
+          print('PAGES SITE')
+          print(json.dumps({
+              key: pages.get(key)
+              for key in ('url', 'status', 'cname', 'html_url', 'build_type', 'source', 'https_enforced')
+          }, sort_keys=True))
+          print('LATEST PAGES BUILD')
+          print(json.dumps({
+              key: latest.get(key)
+              for key in ('url', 'status', 'error', 'commit', 'duration', 'created_at', 'updated_at')
+          }, default=str, sort_keys=True))
+          PY
+
+  production-evidence:
+    name: Production evidence
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout recorded deployment state
+        uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+      - name: Verify recorded public builds and troubleshooting guide
+        run: node scripts/verify-production-builds.mjs

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,9 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  pages: read
 
 concurrency:
   group: quality-${{ github.workflow }}-${{ github.ref }}
@@ -101,64 +99,6 @@ jobs:
         run: >-
           python .github/seo-skills/scripts/validate_seo_data.py
           --data-root .github/seo-data
-
-  deployment-configuration:
-    name: Deployment configuration
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Inspect documentation workflow and Pages state
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          api="https://api.github.com/repos/${REPOSITORY}"
-          headers=(
-            --header 'Accept: application/vnd.github+json'
-            --header "Authorization: Bearer ${GH_TOKEN}"
-            --header 'X-GitHub-Api-Version: 2022-11-28'
-          )
-          curl --fail-with-body --silent --show-error "${headers[@]}" \
-            "${api}/actions/workflows/publish-docs-pages.yml/runs?branch=main&per_page=10" \
-            > "${RUNNER_TEMP}/docs-runs.json"
-          curl --fail-with-body --silent --show-error "${headers[@]}" \
-            "${api}/pages" > "${RUNNER_TEMP}/pages.json"
-          curl --fail-with-body --silent --show-error "${headers[@]}" \
-            "${api}/pages/builds/latest" > "${RUNNER_TEMP}/latest-pages-build.json"
-          python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          temp = Path(os.environ['RUNNER_TEMP'])
-          runs = json.loads((temp / 'docs-runs.json').read_text())
-          pages = json.loads((temp / 'pages.json').read_text())
-          latest = json.loads((temp / 'latest-pages-build.json').read_text())
-
-          print('DOCUMENTATION WORKFLOW RUNS')
-          for item in runs.get('workflow_runs', []):
-              print(json.dumps({
-                  'id': item.get('id'),
-                  'event': item.get('event'),
-                  'status': item.get('status'),
-                  'conclusion': item.get('conclusion'),
-                  'head_sha': item.get('head_sha'),
-                  'run_number': item.get('run_number'),
-                  'html_url': item.get('html_url'),
-              }, sort_keys=True))
-
-          print('PAGES SITE')
-          print(json.dumps({
-              key: pages.get(key)
-              for key in ('url', 'status', 'cname', 'html_url', 'build_type', 'source', 'https_enforced')
-          }, sort_keys=True))
-          print('LATEST PAGES BUILD')
-          print(json.dumps({
-              key: latest.get(key)
-              for key in ('url', 'status', 'error', 'commit', 'duration', 'created_at', 'updated_at')
-          }, default=str, sort_keys=True))
-          PY
 
   production-evidence:
     name: Production evidence

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -1,0 +1,120 @@
+import { readFileSync } from 'node:fs';
+import { resolve4, resolve6, resolveCname } from 'node:dns/promises';
+
+const statusPath = '.github/seo-data/status.md';
+const status = readFileSync(statusPath, 'utf8');
+const maxAttempts = 42;
+const retryDelayMs = 10_000;
+
+const targets = [
+  {
+    label: 'application',
+    buildUrl: 'https://app.webnovel.win/build.json',
+    pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+  },
+  {
+    label: 'documentation',
+    buildUrl: 'https://autoarchive.github.io/webNR/build.json',
+    contentUrl: 'https://autoarchive.github.io/webNR/troubleshooting/txt-import/',
+    pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+  },
+];
+
+const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+async function resolveOrEmpty(resolver, hostname) {
+  try {
+    return await resolver(hostname);
+  } catch {
+    return [];
+  }
+}
+
+async function describeTarget(target) {
+  const hostname = new URL(target.buildUrl).hostname;
+  const [cnames, ipv4, ipv6] = await Promise.all([
+    resolveOrEmpty(resolveCname, hostname),
+    resolveOrEmpty(resolve4, hostname),
+    resolveOrEmpty(resolve6, hostname),
+  ]);
+  console.log(`${target.label} DNS ${hostname}: ${JSON.stringify({ cnames, ipv4, ipv6 })}`);
+}
+
+function selectedHeaders(response) {
+  return Object.fromEntries(
+    ['server', 'via', 'x-vercel-id', 'cf-ray', 'cache-control', 'etag', 'last-modified']
+      .map(name => [name, response.headers.get(name)])
+      .filter(([, value]) => value !== null),
+  );
+}
+
+async function fetchNoCache(url, attempt, expectedCommit, accept) {
+  return fetch(`${url}?expected=${expectedCommit}&attempt=${attempt}&time=${Date.now()}`, {
+    cache: 'no-store',
+    headers: { accept, 'cache-control': 'no-cache' },
+    signal: AbortSignal.timeout(15_000),
+  });
+}
+
+async function verifyTarget(target) {
+  const match = status.match(target.pattern);
+  if (!match) throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+
+  const expectedCommit = match[1];
+  let lastObserved = 'no response';
+  await describeTarget(target);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const buildResponse = await fetchNoCache(target.buildUrl, attempt, expectedCommit, 'application/json');
+      if (!buildResponse.ok) {
+        lastObserved = JSON.stringify({ status: buildResponse.status, headers: selectedHeaders(buildResponse) });
+      } else {
+        const payload = await buildResponse.json();
+        const buildEvidence = { payload, headers: selectedHeaders(buildResponse) };
+        if (payload.commit === expectedCommit) {
+          if (target.contentUrl) {
+            const contentResponse = await fetchNoCache(target.contentUrl, attempt, expectedCommit, 'text/html');
+            const html = contentResponse.ok ? await contentResponse.text() : '';
+            const contentMatches = contentResponse.ok
+              && html.includes('TXT import troubleshooting')
+              && html.includes('TXT 导入排障')
+              && html.includes('https://autoarchive.github.io/webNR/');
+            lastObserved = JSON.stringify({
+              build: buildEvidence,
+              content: { status: contentResponse.status, headers: selectedHeaders(contentResponse), contentMatches },
+            });
+            if (!contentMatches) throw new Error(`Documentation content did not match: ${lastObserved}`);
+          }
+
+          console.log(`Verified ${target.label} production commit ${expectedCommit} at ${target.buildUrl}`);
+          return {
+            label: target.label,
+            expectedCommit,
+            observedCommit: payload.commit,
+            headers: selectedHeaders(buildResponse),
+            contentUrl: target.contentUrl ?? null,
+          };
+        }
+        lastObserved = JSON.stringify(buildEvidence);
+      }
+    } catch (error) {
+      lastObserved = error instanceof Error ? error.message : String(error);
+    }
+
+    console.log(`${target.label} attempt ${attempt} did not match ${expectedCommit}: ${lastObserved}`);
+    if (attempt < maxAttempts) await sleep(retryDelayMs);
+  }
+
+  throw new Error(`${target.label} production did not expose recorded commit ${expectedCommit}; last observed: ${lastObserved}`);
+}
+
+const results = await Promise.allSettled(targets.map(verifyTarget));
+const failures = results
+  .filter(result => result.status === 'rejected')
+  .map(result => result.reason instanceof Error ? result.reason.message : String(result.reason));
+
+for (const result of results) {
+  if (result.status === 'fulfilled') console.log(`Production evidence: ${JSON.stringify(result.value)}`);
+}
+if (failures.length > 0) throw new Error(`Production evidence failed:\n${failures.join('\n')}`);


### PR DESCRIPTION
## Evidence

Pull request #40 passed every expected check, received a complete final review, and squash-merged the working documentation URL migration as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.

Both public surfaces are expected to expose that exact commit:

- reader build identity: `https://app.webnovel.win/build.json`
- documentation build identity: `https://autoarchive.github.io/webNR/build.json`
- verified public content: `https://autoarchive.github.io/webNR/troubleshooting/txt-import/`

Earlier evidence pull requests were allowed to fail and were never merged. Their authenticated diagnostics established the repository's legacy `gh-pages:/` source, the absent custom-domain registration, the successful generated publication path, and the working project URL now used by the product.

## Coherent outcome

- add a permanent `Production evidence` job to every Quality run
- parse the recorded application and documentation commits from public-safe `status.md`
- resolve and log public DNS evidence
- fetch both public build identities with cache busting, selected response headers, bounded retries, and timeouts
- require the public troubleshooting page to contain the English and Chinese guide headings plus the current project URL
- temporarily inspect the latest documentation workflow, Pages source, Pages build, and project URL during the final transition
- fail CI unless both surfaces expose exact commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
- prevent evidence-only workflow, verifier, and SEO-record changes from triggering redundant application deployment

## Required checks

- dependency audit, ESLint, TypeScript, and production application build
- strict pinned documentation build, canonical project URL, bilingual guide, privacy and stale-link assertions
- public SEO-data validation
- read-only Pages/workflow configuration diagnosis
- exact reader, documentation, and troubleshooting-content production evidence
- complete final review of commit parsing, DNS/request behavior, retries, response evidence, workflow permissions, deployment exclusions, privacy boundary, and mergeability

## Safety

The verifier sends cache-busted GET requests only to public WebNR endpoints. The transition diagnostic uses Actions read, Pages read, and Contents read only. It logs public DNS, selected public response headers, workflow conclusions, Pages source, build status, project URL, and commit identities. It does not collect user data, book data, cookies, credentials, private URLs, or analytics identifiers.

## Acceptance

This PR may squash-merge only after its own Production evidence job proves the reader and working documentation project URL expose `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`, the public troubleshooting page contains both language headings, and the temporary Pages diagnostic has been removed and all checks rerun.
