### PR TITLE
docs: close out the 2026-08-05 WebNR operating cycle

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Complete a full WebNR product and operating rescue in one local-day cycle: establish autonomous PR-based maintenance; repair first use, privacy, accessibility, PWA reliability, crawlability, dependencies, truthful format support, documentation, community infrastructure, and deployment; publish durable bilingual TXT troubleshooting content; and prove the exact public reader and documentation builds before closeout.
+Complete a full WebNR product and operating rescue in one local-day cycle: establish autonomous PR-based maintenance; repair first use, privacy, accessibility, PWA reliability, crawlability, dependencies, truthful format support, documentation, community infrastructure, and deployment; publish durable bilingual TXT troubleshooting content; and prove the exact public reader and documentation builds before metadata closeout.
 
 ## Data window
 
@@ -14,107 +14,94 @@ Complete a full WebNR product and operating rescue in one local-day cycle: estab
 
 ## Evidence collected
 
-- The original application exposed an empty library without a reachable import action even though import code existed.
-- The reader loaded Google Analytics while promising no tracking, prevented browser zoom, unregistered Service Workers on every load, used blocking browser dialogs, lacked explicit robots and sitemap output, and contained conflicting Next.js configuration files.
-- The original dependency stack used Next.js 15.2.4, deprecated lint and text-decoder paths, Node-only browser behavior, stale tooling, and an audit report with 17 findings including 11 high findings.
-- EPUB was advertised and accepted although no EPUB parser existed; binary container bytes were decoded as text.
-- The original documentation used broken workflow configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, generic AI articles unrelated to the product, misspelled `mannual` paths, and no exact public build identity.
-- The configured analytics export folder contained no provider files, and the available Cloudflare connection did not expose the relevant zone. These optional gaps did not block repository, product, content, CI, deployment, or public verification work.
-- Failed production-evidence pull requests were retained as diagnostic evidence and not merged. They proved the reader deployed correctly while the former documentation hostname returned cache-busted HTTP 404 responses.
-- Authenticated Pages diagnosis established the actual repository configuration: `build_type: legacy`, source `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
-- Documentation workflows that attempted to mutate Pages mode failed with HTTP 403 because normal workflow tokens do not have the Administration write permission required by the repository Pages settings endpoint.
-- Generated documentation publication to `gh-pages` succeeded after the workflow stopped attempting the unauthorized settings mutation.
-- The former `www.webnovel.win` documentation hostname remained unconfigured and was served by a Cloudflare zone unavailable through the connected account. It was therefore removed from the production path rather than falsely treated as deployed.
-- The shared SEO skill remained current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no compatible upstream movement was available after the same-cycle technical-defect policy update.
+- The former application showed an empty library without a reachable import action even though import code existed.
+- Runtime behavior contradicted privacy and accessibility promises: Google Analytics loaded unconditionally, page zoom was restricted, Service Workers were unregistered on every load, and global/import errors used blocking browser dialogs.
+- The repository had conflicting Next.js configuration, no explicit crawl files, stale dependencies and tooling, browser code dependent on Node behavior, and an audit report containing high-severity findings.
+- EPUB was advertised and accepted despite the absence of an EPUB parser; binary container bytes were decoded as text.
+- Documentation used broken deployment configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, unrelated generic AI articles, misspelled `mannual` paths, and no exact public build identity.
+- Optional analytics were unavailable: the configured export folder was empty and the connected Cloudflare accounts did not expose the relevant zone. Product, repository, content, CI, and public verification work continued without inventing zero metrics.
+- Failed evidence pull requests were preserved and closed without merge. Their cache-busted requests proved the reader was deploying while the former documentation hostname returned HTTP 404.
+- Authenticated Pages diagnosis established the real repository configuration: legacy `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
+- Normal workflow tokens could not mutate Pages mode because that settings endpoint requires Administration write. Generated documentation publication to `gh-pages` succeeded once the workflow stopped making the unauthorized mutation.
+- The former `www.webnovel.win` hostname remained outside the available Cloudflare account and had no GitHub Pages custom-domain registration. It was removed from the production path instead of being falsely reported as deployed.
+- The shared SEO skill remained current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`.
 
 ## Work performed
 
 ### Operating foundation
 
-- Pull requests #14–#17 added the pinned shared SEO skill, public-safe site metadata, daily operating records, CI quality gates, autonomous scheduling contract, complete PR/self-review/squash-merge rules, and nonblocking merged-branch cleanup policy.
+- Pull requests #14–#17 added the pinned shared SEO skill, public-safe operating records, pull-request quality gates, autonomous daily contract, complete CI/self-review/squash-merge requirements, and nonblocking branch cleanup.
 
-### Product rescue
+### Product, privacy, accessibility, PWA, and SEO repair
 
-- Pull request #19 made local TXT and URL import reachable through onboarding, an Add view, footer navigation, and a useful empty-library state.
-- It replaced blocking import, repository, export, and deletion alerts with recoverable application feedback.
-- It repaired document-language synchronization, skip navigation, semantic status/alert behavior, visible input labels, browser zoom, and first-use copy.
-- It removed unconditional Google Analytics so privacy promises match runtime behavior.
-- It replaced destructive Service Worker handling with normal registration, same-origin caching, network-first navigation, safe cache upgrades, and offline fallback.
-- It consolidated Next.js configuration and added accurate metadata, canonical ownership, SoftwareApplication JSON-LD, `robots.txt`, `sitemap.xml`, and improved PWA manifest shortcuts.
-- Pull request #19 passed its final corrected Quality run and squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
+- Pull request #19 exposed local TXT and supported URL import through first-use onboarding, Add navigation, and a useful empty-library state.
+- It replaced blocking dialogs with recoverable UI feedback, repaired language synchronization, skip navigation, semantic status behavior, visible labels, and browser zoom.
+- It removed unconditional Google Analytics, repaired Service Worker registration and caching, consolidated Next.js configuration, and added accurate metadata, canonical ownership, SoftwareApplication JSON-LD, `robots.txt`, `sitemap.xml`, and PWA shortcuts.
+- It passed corrected final CI and squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
 
 ### Verifiable application delivery
 
-- Pull request #20 added public `build.json` identity, generated-artifact and privacy assertions, exact-source deployment messages, and cache-busted public commit verification.
-- It squash-merged as `cba8cff1975d293947143f7efefc2b2db37d849a`.
+- Pull request #20 added public `build.json` identity, generated-artifact/privacy assertions, exact-source deployment messages, and cache-busted production verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
 
-### Dependency and tooling repair
+### Dependencies and tooling
 
-- Pull request #21 upgraded to supported Next.js 15.5.22, aligned ESLint tooling, replaced deprecated `next lint`, removed obsolete text-decoding dependencies, fixed browser encoding detection that used Node `Buffer`, migrated icon tooling to ESM, regenerated the lockfile through CI, and added a permanent dependency-audit validator.
-- It squash-merged as `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+- Pull request #21 upgraded to supported Next.js 15.5.22, aligned ESLint tooling, removed deprecated decoding dependencies, fixed browser encoding detection, regenerated the lockfile, and added a permanent dependency-audit validator; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
 
-### Truthful format support
+### Truthful format boundary
 
-- Pull request #22 removed EPUB from local file selection, storage acceptance, metadata, structured data, manifest descriptions, and public product claims.
-- Unsupported local containers now fail explicitly instead of becoming corrupted books.
-- It squash-merged as `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+- Pull request #22 removed EPUB from file selection, storage acceptance, metadata, structured data, manifest descriptions, and public claims. Unsupported containers now fail explicitly; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
 
-### Documentation and community repair
+### Documentation and community
 
-- Pull request #23 pinned the MkDocs toolchain, added `mkdocs build --strict` to PR CI, removed documentation analytics, corrected repository references, published current bilingual usage and privacy guidance, and added `SECURITY.md`, `ROADMAP.md`, `CONTRIBUTING.md`, structured issue forms, and current release documentation.
-- It deleted four unrelated generic AI storytelling articles rather than retaining low-value search content.
-- It squash-merged as `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+- Pull request #23 pinned MkDocs dependencies, added `mkdocs build --strict` to CI, removed documentation analytics, corrected repository references, published current bilingual usage/privacy/release guidance, added security, roadmap, contribution and structured issue resources, and deleted four unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
 
-### User-visible daily knowledge unit
+### Meaningful daily public content
 
 - Pull request #31 published a substantial bilingual TXT import troubleshooting guide tied to current implementation.
-- The guide documents supported local TXT and permitted HTTP/HTTPS text URL inputs; UTF-8, GB18030, Big5, malformed bytes, mixed encoding, and binary files renamed as TXT; CORS, redirects, authentication, HTTP failures, content-type problems, timeouts, and large requests; browser-profile storage loss; safe PWA refresh procedures; and privacy-safe issue reproduction using synthetic, public-domain, self-owned, or explicitly authorized fixtures.
+- It covers supported TXT and authorized text URL inputs; UTF-8, GB18030, Big5, malformed bytes, mixed encoding, and binary files renamed as TXT; CORS, redirects, authentication, HTTP status, content type, timeout, and large-request failures; browser storage loss; safe PWA refresh; and privacy-safe reproduction with synthetic, public-domain, self-owned, or explicitly authorized fixtures.
 - It explicitly rejects bypassing login, payment, DRM, robots, rate limits, CORS, or other access controls.
-- It corrected source and public paths from `mannual` to canonical `manual` and updated README, documentation home, release, contribution, and source links.
-- It passed all expected checks and two complete final reviews before squash merge as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+- It corrected `mannual` to `manual`, updated active links, passed all expected CI and two complete final reviews, and squash-merged as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
 
 ### Documentation deployment diagnosis and repair
 
-- Pull requests #25, #27, #33, and #35 implemented and tested progressively more direct documentation delivery approaches. Their generated builds passed, but failed deployment evidence was never bypassed.
-- Pull requests #32 and #34 proved exact reader deployments while recording repeated cache-busted documentation HTTP 404 responses; both were closed without merge after their evidence was superseded.
-- Pull request #36 added read-only Actions and Pages diagnostics. It found legacy `gh-pages:/`, no CNAME, stale Pages build state, and exact workflow failures caused by an unauthorized Pages settings mutation.
-- Pull request #37 removed that mutation, deleted the duplicate publisher, built with pinned dependencies and strict validation, wrote exact source identity, published generated output to `gh-pages`, and verified the generated branch and Pages build path. It squash-merged as `bd0f859303a426a653970118102612f1ae6345f9`.
-- Pull request #38 confirmed the generated Pages build while retaining a failed custom-domain check; it was later closed without merge.
-- Pull request #40 made the working GitHub Pages project URL the canonical documentation endpoint, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, rejected stale custom-domain references from generated output, and required exact project-subpath verification.
-- Pull request #40 passed Quality run `31036258893`, received a complete final review with no review threads, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Pull requests #25, #27, #33, and #35 tested progressively more direct Pages approaches. Generated builds passed, but failed production evidence was never bypassed.
+- Pull requests #32 and #34 proved exact reader deployments while recording repeated documentation HTTP 404 responses; both were closed without merge.
+- Pull request #36 added read-only Actions and Pages diagnostics, exposing legacy `gh-pages:/`, absent CNAME, stale Pages state, and workflow failures caused by unauthorized Pages settings mutation.
+- Pull request #37 removed that mutation and duplicate publisher, strictly built exact-source documentation, and published generated output to `gh-pages`; squash `bd0f859303a426a653970118102612f1ae6345f9`.
+- Pull request #38 confirmed the generated Pages build but remained blocked on the unavailable custom domain and was later closed without merge.
+- Pull request #40 made `https://autoarchive.github.io/webNR/` the canonical documentation endpoint, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, and rejected stale custom-domain references from generated documentation.
+- Pull request #40 passed Quality run `31036258893`, received a clean final review with no review threads, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
 - Documentation workflow run `31036446960` succeeded for source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Pages API reported legacy source `gh-pages:/`, status `built`, HTTPS enabled, project URL `https://autoarchive.github.io/webNR/`, no custom domain, and latest generated Pages build commit `f06553dfa0c7116d467861b338f6d7f41f01f4ba`.
+- Pages API reported legacy `gh-pages:/`, HTTPS enabled, status `built`, project URL `https://autoarchive.github.io/webNR/`, no custom domain, and generated Pages build commit `f06553dfa0c7116d467861b338f6d7f41f01f4ba`.
 
 ### Permanent production evidence
 
 - Pull request #41 added a required `Production evidence` job to every Quality run.
-- The verifier parses separately recorded application and documentation source commits, resolves public DNS, sends cache-busted requests, captures selected public response headers, verifies exact build identities, and checks the actual public troubleshooting page for both language headings and the canonical project URL.
-- The application publisher now ignores evidence-only workflow, verifier, and SEO-record changes, preventing redundant production deployments.
-- Initial PR #41 run `31036915052` passed Web quality, Documentation quality, SEO data contract, transition deployment diagnosis, and Production evidence.
-- Initial Production evidence job `92411188768` verified both public builds at exact source `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and matched the bilingual troubleshooting content on the first request.
-- After capturing final transition evidence, the temporary diagnostic job and additional Actions/Pages read permissions were removed. The permanent workflow requires only Contents read.
-- Final reduced-permission run `31037180170` passed Web quality, Documentation quality, SEO data contract, and Production evidence.
-- Final Production evidence job `92412164747` again verified the exact reader and documentation builds and actual bilingual troubleshooting content.
-- The complete final #41 diff, commit parser, request behavior, retry bounds, response evidence, deployment exclusions, privacy boundary, review threads, unchanged head, and mergeability were reviewed before squash merge.
+- The verifier parses recorded application and documentation source commits, resolves public DNS, sends cache-busted requests, captures selected response headers, verifies exact build identities, and checks the actual public troubleshooting page for both language headings and the canonical project URL.
+- Evidence-only workflow, verifier, and SEO-record changes are excluded from redundant application deployment.
+- Initial run `31036915052` passed all five jobs. Production evidence job `92411188768` verified both public builds at exact source `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and matched the bilingual troubleshooting content on its first request.
+- After final Pages transition evidence was captured, the temporary diagnostic and extra Actions/Pages read permissions were removed. The permanent workflow requires only Contents read.
+- Final run `31037180170` passed application checks, strict documentation checks, SEO-data validation, and Production evidence.
+- Final Production evidence job `92412164747` again verified the exact reader and documentation builds and the actual bilingual troubleshooting content.
+- The complete final diff, commit parser, request behavior, retry bounds, response evidence, deployment exclusions, privacy boundary, review threads, unchanged head, and mergeability were reviewed before squash merge.
 - Pull request #41 squash-merged as `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
 - Superseded diagnostic pull requests #36 and #38 were closed without merge after their evidence was preserved.
 
 ## Validation and self-review
 
 - Every merged outcome used a fresh branch and real non-draft pull request.
-- Every relevant pull request passed its expected dependency audit, ESLint, TypeScript, production app build, strict documentation build, generated-output assertions, and SEO-data validation before merge.
-- Every merge followed a complete final diff and check-results review. Findings were fixed on the same branch and CI rerun when necessary.
-- All production claims are supported by exact public build identities rather than a branch, generated artifact, workflow URL, or HTTP 200 alone.
+- Every relevant pull request passed its expected dependency audit, ESLint, TypeScript, production app build, strict documentation build, generated-output assertions, SEO-data validation, and—after #41—exact public production evidence.
+- Every merge followed a complete final diff and check-results review; findings were fixed on the same branch and all checks rerun.
 - The final public reader and documentation source identity is `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- The permanent evidence implementation is `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
+- The permanent production-evidence implementation is `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
 - Branch cleanup remained best-effort and never created a blocker.
 
 ## Delivery
 
 - Autonomous operating foundation: pull requests #14–#17
-- Product first-use, privacy, accessibility, PWA, and SEO repair: #19
-- Exact application deployment identity: #20
+- Product first-use, privacy, accessibility, PWA, crawlability, and SEO repair: #19
+- Exact application build identity and deployment verification: #20
 - Supported dependency and tooling repair: #21
 - Truthful TXT-only local format boundary: #22
 - Documentation, CI, and community repair: #23
@@ -123,15 +110,15 @@ Complete a full WebNR product and operating rescue in one local-day cycle: estab
 - Working canonical GitHub Pages documentation URL: #40, squash `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Permanent exact reader/documentation/content evidence: #41, squash `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
 - Superseded diagnostic PRs #32, #34, #36, and #38: closed without merge
-- Final metadata-only closeout: pending this branch and its real pull request
+- Final metadata-only closeout: pull request #42, pending final checks, final review, and squash merge
 - Shared SEO skill: current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Decisions and follow-ups
 
-- The canonical public documentation endpoint is the working GitHub Pages project URL. The former custom hostname is not production.
-- Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, plus a separately reviewed migration and redirect plan.
+- The working GitHub Pages project URL is the canonical documentation endpoint. The former custom hostname is not production.
+- Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, followed by a separately reviewed migration and redirect plan.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
 - Next product priorities are browser-library backup and restore, versioned IndexedDB migrations, Playwright accessibility/offline/import tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
 - Next.js 16 proposals remain a deliberate major migration and must not be blindly merged as routine security updates.
 - Daily content must continue to originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles, keyword variants, and thin pages remain prohibited.
-- The cycle is complete only after this metadata-only closeout passes all permanent checks, receives a clean final review, and squash-merges.
+- The cycle is complete only after closeout pull request #42 passes all permanent checks, receives a clean final review, and squash-merges.

--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-Complete a same-day WebNR rescue and operating cycle: repair product onboarding, privacy, accessibility, PWA reliability, dependency support, truthful format claims, documentation, community infrastructure, and attributable production delivery. Publish a meaningful bilingual troubleshooting resource through a working public URL and close only after exact reader and documentation builds are proven.
+Complete a full WebNR product and operating rescue in one local-day cycle: establish autonomous PR-based maintenance; repair first use, privacy, accessibility, PWA reliability, crawlability, dependencies, truthful format support, documentation, community infrastructure, and deployment; publish durable bilingual TXT troubleshooting content; and prove the exact public reader and documentation builds before closeout.
 
 ## Data window
 
@@ -10,82 +10,128 @@ Complete a same-day WebNR rescue and operating cycle: repair product onboarding,
 - Analytics target: 28 finalized days with a 3-day lag
 - Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no GA4 or Search Console export
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull requests, CI jobs and logs, generated artifacts, registered workflow API results, Pages API state, DNS, response headers, public build endpoints, and visible content
+- Evidence used: repository source, pull-request diffs and metadata, CI jobs and logs, dependency audit output, generated app and documentation artifacts, GitHub workflow registration, Pages API state, DNS, selected public response headers, cache-busted build identities, and visible public content
 
 ## Evidence collected
 
-- The original application lacked a reachable import path, contradicted its privacy promise, prevented zoom, destructively reset Service Workers, used blocking dialogs, lacked crawl files, and had conflicting Next.js configuration.
-- The original dependency stack used stale and vulnerable packages, deprecated lint and decoder paths, and browser code that depended on Node-only behavior.
-- EPUB was advertised and accepted although no EPUB parser existed.
-- The original documentation used unpinned dependencies, had broken deployment, loaded third-party analytics, contained obsolete links and generic AI content, and lacked exact public build identity.
-- Pull requests #19–#23 repaired the product, dependencies, format boundary, documentation quality, CI, and community infrastructure.
-- Pull request #31 published the bilingual TXT import troubleshooting guide and canonical `manual` paths.
-- Evidence pull requests #32, #34, #36, and #38 were allowed to fail rather than merge unproven delivery claims. They verified application deployments while repeatedly observing documentation HTTP 404 responses.
-- Authenticated Pages diagnosis found `build_type: legacy`, source `gh-pages:/`, status `built`, project URL `https://autoarchive.github.io/webNR/`, and `cname: null`.
-- Registered documentation runs failed when normal workflow tokens attempted an Administration-protected Pages settings mutation. Pull request #37 removed that mutation, published generated content to `gh-pages`, and proved the build path worked.
-- Pull request #37 still failed its final wait because it required an unconfigured custom domain. The current connector cannot write the GitHub Pages custom-domain setting, and the connected Cloudflare accounts do not expose the zone.
-- Pull request #40 made the working GitHub Pages project URL canonical, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Documentation workflow run `31036446960` completed successfully for source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Pages API reported legacy `gh-pages:/`, `cname: null`, project URL `https://autoarchive.github.io/webNR/`, HTTPS enforced, status `built`, and a successful latest Pages build from generated branch commit `f06553dfa0c7116d467861b338f6d7f41f01f4ba`.
-- Pull request #41 initial Quality run `31036915052` passed all five jobs. Production evidence job `92411188768` verified both public build identities at exact source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and verified the public bilingual troubleshooting content.
-- The application endpoint resolved through Cloudflare and returned the exact commit with cache-control and ETag evidence.
-- The documentation endpoint resolved to GitHub Pages addresses and returned exact commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`, GitHub Pages response headers, the English heading `TXT import troubleshooting`, the Chinese heading `TXT 导入排障`, and the canonical project URL.
-- The shared SEO skill is current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no submodule update is available.
+- The original application exposed an empty library without a reachable import action even though import code existed.
+- The reader loaded Google Analytics while promising no tracking, prevented browser zoom, unregistered Service Workers on every load, used blocking browser dialogs, lacked explicit robots and sitemap output, and contained conflicting Next.js configuration files.
+- The original dependency stack used Next.js 15.2.4, deprecated lint and text-decoder paths, Node-only browser behavior, stale tooling, and an audit report with 17 findings including 11 high findings.
+- EPUB was advertised and accepted although no EPUB parser existed; binary container bytes were decoded as text.
+- The original documentation used broken workflow configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, generic AI articles unrelated to the product, misspelled `mannual` paths, and no exact public build identity.
+- The configured analytics export folder contained no provider files, and the available Cloudflare connection did not expose the relevant zone. These optional gaps did not block repository, product, content, CI, deployment, or public verification work.
+- Failed production-evidence pull requests were retained as diagnostic evidence and not merged. They proved the reader deployed correctly while the former documentation hostname returned cache-busted HTTP 404 responses.
+- Authenticated Pages diagnosis established the actual repository configuration: `build_type: legacy`, source `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
+- Documentation workflows that attempted to mutate Pages mode failed with HTTP 403 because normal workflow tokens do not have the Administration write permission required by the repository Pages settings endpoint.
+- Generated documentation publication to `gh-pages` succeeded after the workflow stopped attempting the unauthorized settings mutation.
+- The former `www.webnovel.win` documentation hostname remained unconfigured and was served by a Cloudflare zone unavailable through the connected account. It was therefore removed from the production path rather than falsely treated as deployed.
+- The shared SEO skill remained current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`; no compatible upstream movement was available after the same-cycle technical-defect policy update.
 
 ## Work performed
 
-- Pull requests #14–#17 established autonomous PR-based operations and nonblocking branch cleanup.
-- Pull request #19 delivered first-use onboarding, visible TXT/URL import, recoverable feedback, privacy-aligned runtime behavior, repaired PWA caching, metadata, JSON-LD, robots, sitemap, and one Next.js configuration; squash `d8325d3f906e3aead84a4aec98d15815daf57545`.
-- Pull request #20 added exact application build identity and deployment verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
-- Pull request #21 upgraded to supported Next.js 15.5.22, repaired decoding/tooling, regenerated the lockfile, and added dependency-audit enforcement; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-- Pull request #22 removed false EPUB support; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-- Pull request #23 added strict pinned documentation builds, bilingual guidance, security, roadmap, contribution and issue-reporting content, and removed unrelated AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-- Pull requests #25, #27, #33, and #35 progressively diagnosed and replaced nonfunctional Pages delivery approaches without bypassing failed evidence.
-- Pull request #37 aligned publication with the repository's actual legacy `gh-pages` source and merged as `bd0f859303a426a653970118102612f1ae6345f9` after green CI and clean final review.
-- Pull request #40:
-  - changed MkDocs canonical output to `https://autoarchive.github.io/webNR/`;
-  - changed the reader Home action and all active repository help links to the working project URL;
-  - removed stale generated CNAME metadata;
-  - required Pages to report legacy `gh-pages:/`, no custom domain, status `built`, and the expected project URL;
-  - required the public project URL to expose the exact commit and English and Chinese TXT troubleshooting content;
-  - rejected stale `www.webnovel.win` references in generated documentation.
-- Pull request #40 passed all expected CI and a complete final review, had no review threads, remained mergeable with an unchanged head, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Pull request #41 added a permanent required Production evidence job that parses recorded source commits, checks public DNS and selected response headers, fetches cache-busted build identities, and requires the actual bilingual troubleshooting content.
-- Pull request #41 also excludes evidence-only workflow, verifier, and SEO-record changes from redundant application deployment.
-- After the first full green run captured final Pages/workflow transition evidence, the temporary read-only diagnostic job and its extra Actions/Pages permissions were removed. The permanent Quality workflow now requires only Contents read.
+### Operating foundation
+
+- Pull requests #14–#17 added the pinned shared SEO skill, public-safe site metadata, daily operating records, CI quality gates, autonomous scheduling contract, complete PR/self-review/squash-merge rules, and nonblocking merged-branch cleanup policy.
+
+### Product rescue
+
+- Pull request #19 made local TXT and URL import reachable through onboarding, an Add view, footer navigation, and a useful empty-library state.
+- It replaced blocking import, repository, export, and deletion alerts with recoverable application feedback.
+- It repaired document-language synchronization, skip navigation, semantic status/alert behavior, visible input labels, browser zoom, and first-use copy.
+- It removed unconditional Google Analytics so privacy promises match runtime behavior.
+- It replaced destructive Service Worker handling with normal registration, same-origin caching, network-first navigation, safe cache upgrades, and offline fallback.
+- It consolidated Next.js configuration and added accurate metadata, canonical ownership, SoftwareApplication JSON-LD, `robots.txt`, `sitemap.xml`, and improved PWA manifest shortcuts.
+- Pull request #19 passed its final corrected Quality run and squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
+
+### Verifiable application delivery
+
+- Pull request #20 added public `build.json` identity, generated-artifact and privacy assertions, exact-source deployment messages, and cache-busted public commit verification.
+- It squash-merged as `cba8cff1975d293947143f7efefc2b2db37d849a`.
+
+### Dependency and tooling repair
+
+- Pull request #21 upgraded to supported Next.js 15.5.22, aligned ESLint tooling, replaced deprecated `next lint`, removed obsolete text-decoding dependencies, fixed browser encoding detection that used Node `Buffer`, migrated icon tooling to ESM, regenerated the lockfile through CI, and added a permanent dependency-audit validator.
+- It squash-merged as `f86d7967f44ae57d83c558a63e322f52dd18373a`.
+
+### Truthful format support
+
+- Pull request #22 removed EPUB from local file selection, storage acceptance, metadata, structured data, manifest descriptions, and public product claims.
+- Unsupported local containers now fail explicitly instead of becoming corrupted books.
+- It squash-merged as `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
+
+### Documentation and community repair
+
+- Pull request #23 pinned the MkDocs toolchain, added `mkdocs build --strict` to PR CI, removed documentation analytics, corrected repository references, published current bilingual usage and privacy guidance, and added `SECURITY.md`, `ROADMAP.md`, `CONTRIBUTING.md`, structured issue forms, and current release documentation.
+- It deleted four unrelated generic AI storytelling articles rather than retaining low-value search content.
+- It squash-merged as `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
+
+### User-visible daily knowledge unit
+
+- Pull request #31 published a substantial bilingual TXT import troubleshooting guide tied to current implementation.
+- The guide documents supported local TXT and permitted HTTP/HTTPS text URL inputs; UTF-8, GB18030, Big5, malformed bytes, mixed encoding, and binary files renamed as TXT; CORS, redirects, authentication, HTTP failures, content-type problems, timeouts, and large requests; browser-profile storage loss; safe PWA refresh procedures; and privacy-safe issue reproduction using synthetic, public-domain, self-owned, or explicitly authorized fixtures.
+- It explicitly rejects bypassing login, payment, DRM, robots, rate limits, CORS, or other access controls.
+- It corrected source and public paths from `mannual` to canonical `manual` and updated README, documentation home, release, contribution, and source links.
+- It passed all expected checks and two complete final reviews before squash merge as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
+
+### Documentation deployment diagnosis and repair
+
+- Pull requests #25, #27, #33, and #35 implemented and tested progressively more direct documentation delivery approaches. Their generated builds passed, but failed deployment evidence was never bypassed.
+- Pull requests #32 and #34 proved exact reader deployments while recording repeated cache-busted documentation HTTP 404 responses; both were closed without merge after their evidence was superseded.
+- Pull request #36 added read-only Actions and Pages diagnostics. It found legacy `gh-pages:/`, no CNAME, stale Pages build state, and exact workflow failures caused by an unauthorized Pages settings mutation.
+- Pull request #37 removed that mutation, deleted the duplicate publisher, built with pinned dependencies and strict validation, wrote exact source identity, published generated output to `gh-pages`, and verified the generated branch and Pages build path. It squash-merged as `bd0f859303a426a653970118102612f1ae6345f9`.
+- Pull request #38 confirmed the generated Pages build while retaining a failed custom-domain check; it was later closed without merge.
+- Pull request #40 made the working GitHub Pages project URL the canonical documentation endpoint, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, rejected stale custom-domain references from generated output, and required exact project-subpath verification.
+- Pull request #40 passed Quality run `31036258893`, received a complete final review with no review threads, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Documentation workflow run `31036446960` succeeded for source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Pages API reported legacy source `gh-pages:/`, status `built`, HTTPS enabled, project URL `https://autoarchive.github.io/webNR/`, no custom domain, and latest generated Pages build commit `f06553dfa0c7116d467861b338f6d7f41f01f4ba`.
+
+### Permanent production evidence
+
+- Pull request #41 added a required `Production evidence` job to every Quality run.
+- The verifier parses separately recorded application and documentation source commits, resolves public DNS, sends cache-busted requests, captures selected public response headers, verifies exact build identities, and checks the actual public troubleshooting page for both language headings and the canonical project URL.
+- The application publisher now ignores evidence-only workflow, verifier, and SEO-record changes, preventing redundant production deployments.
+- Initial PR #41 run `31036915052` passed Web quality, Documentation quality, SEO data contract, transition deployment diagnosis, and Production evidence.
+- Initial Production evidence job `92411188768` verified both public builds at exact source `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and matched the bilingual troubleshooting content on the first request.
+- After capturing final transition evidence, the temporary diagnostic job and additional Actions/Pages read permissions were removed. The permanent workflow requires only Contents read.
+- Final reduced-permission run `31037180170` passed Web quality, Documentation quality, SEO data contract, and Production evidence.
+- Final Production evidence job `92412164747` again verified the exact reader and documentation builds and actual bilingual troubleshooting content.
+- The complete final #41 diff, commit parser, request behavior, retry bounds, response evidence, deployment exclusions, privacy boundary, review threads, unchanged head, and mergeability were reviewed before squash merge.
+- Pull request #41 squash-merged as `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
+- Superseded diagnostic pull requests #36 and #38 were closed without merge after their evidence was preserved.
 
 ## Validation and self-review
 
-- PR #19 Quality run `30998009742` passed after review findings were fixed and rerun.
-- PR #20 run `30998402518`, PR #21 run `31000279292`, PR #22 run `31001024829`, PR #23 run `31002086657`, PR #25 run `31003643559`, PR #27 run `31028991965`, PR #31 run `31030398159`, PR #33 run `31031650857`, PR #35 run `31033047471`, and PR #37 run `31034906301` passed their expected checks.
-- PR #38 diagnostics observed a successful generated Pages build from `gh-pages`, but its evidence remained blocked because the former custom domain was not configured.
-- PR #40 Quality run `31036258893` passed dependency audit, ESLint, TypeScript, production application build, strict documentation build, generated-output validation, and SEO-data validation.
-- PR #40 final review confirmed consistent project-subpath canonical output, reader and repository links, removal of stale CNAME and custom-domain references from generated content, unchanged application canonical domain, privacy safety, no review threads, unchanged head, and mergeability.
-- PR #41 initial Quality run `31036915052` passed Web quality, Documentation quality, SEO data contract, Deployment configuration, and Production evidence.
-- PR #41 Production evidence job `92411188768` verified the reader and documentation exact source commit plus the public bilingual troubleshooting content on its first request.
-- The temporary transition diagnostic was removed after capturing workflow run `31036446960`, Pages configuration, and latest Pages build evidence. A full final CI rerun is required before merge.
+- Every merged outcome used a fresh branch and real non-draft pull request.
+- Every relevant pull request passed its expected dependency audit, ESLint, TypeScript, production app build, strict documentation build, generated-output assertions, and SEO-data validation before merge.
+- Every merge followed a complete final diff and check-results review. Findings were fixed on the same branch and CI rerun when necessary.
+- All production claims are supported by exact public build identities rather than a branch, generated artifact, workflow URL, or HTTP 200 alone.
+- The final public reader and documentation source identity is `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- The permanent evidence implementation is `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
 - No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
+- Branch cleanup remained best-effort and never created a blocker.
 
 ## Delivery
 
-- Product rescue and operating foundation: pull requests #14–#23
-- Bilingual TXT troubleshooting: #31
-- Legacy Pages-compatible generated publication: #37, squash `bd0f859303a426a653970118102612f1ae6345f9`
-- Working GitHub Pages URL migration: #40, squash `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Exact public reader and documentation verification: PR #41 initial run passed; final reduced-permission rerun, final review, and squash merge pending
-- Superseded evidence PRs: #32 and #34 closed without merge; #36 and #38 must be closed without merge after PR #41 is established
-- Metadata-only closeout: pending
-- Branch cleanup: best-effort and nonblocking
+- Autonomous operating foundation: pull requests #14–#17
+- Product first-use, privacy, accessibility, PWA, and SEO repair: #19
+- Exact application deployment identity: #20
+- Supported dependency and tooling repair: #21
+- Truthful TXT-only local format boundary: #22
+- Documentation, CI, and community repair: #23
+- Bilingual TXT troubleshooting and canonical manual paths: #31
+- Legacy Pages-compatible generated publication: #37
+- Working canonical GitHub Pages documentation URL: #40, squash `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
+- Permanent exact reader/documentation/content evidence: #41, squash `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
+- Superseded diagnostic PRs #32, #34, #36, and #38: closed without merge
+- Final metadata-only closeout: pending this branch and its real pull request
+- Shared SEO skill: current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Decisions and follow-ups
 
-- A branch, merge, generated artifact, workflow URL, or HTTP 200 alone is not production proof; public pages must expose the recorded exact commit and intended content.
-- Failed evidence checks remain blocking evidence and are never bypassed.
-- The working GitHub Pages project URL is the canonical documentation endpoint. The optional custom-domain migration is separated from current public availability.
-- Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, followed by a separate reviewed migration and redirect plan.
-- Evidence-only changes must not trigger redundant application or documentation publication.
+- The canonical public documentation endpoint is the working GitHub Pages project URL. The former custom hostname is not production.
+- Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, plus a separately reviewed migration and redirect plan.
 - Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
-- Daily content must originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles and thin pages are prohibited.
-- Next.js 16 Dependabot proposals are major migrations and must not be blindly merged as routine security patches.
-- After closeout, next priorities are backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- The cycle remains incomplete until PR #41 passes its final reduced-permission rerun, receives a clean final review, squash-merges, and the metadata-only closeout passes CI, final review, and squash merge.
+- Next product priorities are browser-library backup and restore, versioned IndexedDB migrations, Playwright accessibility/offline/import tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
+- Next.js 16 proposals remain a deliberate major migration and must not be blindly merged as routine security updates.
+- Daily content must continue to originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles, keyword variants, and thin pages remain prohibited.
+- The cycle is complete only after this metadata-only closeout passes all permanent checks, receives a clean final review, and squash-merges.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,13 +2,13 @@
 
 ## Current state
 
-- Last completed run: 2026-08-05 full product, content, deployment, and production-evidence cycle; final metadata closeout pull request pending
+- Last completed run: 2026-08-05 full product, content, deployment, and production-evidence cycle; metadata closeout pull request #42 pending final checks and merge
 - Last data window: Google Drive contains no matching analytics exports; repository, CI, dependency, deployment, Pages, DNS, response-header, and public-content evidence collected on 2026-08-05
 - Last site-change pull request: #40
 - Last site-change squash merge: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last production-evidence pull request: #41
 - Last production-evidence squash merge: `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
-- Last closeout pull request: pending this branch
+- Last closeout pull request: #42, pending final checks and squash merge
 - Last successful attributable application deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last successful attributable documentation deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last public verification: PR #41 final Quality run `31037180170`, Production evidence job `92412164747`, verified both public build identities and the bilingual TXT troubleshooting page at exact source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
@@ -32,7 +32,7 @@
 
 ## Active focus
 
-- Complete this metadata-only closeout through the permanent Quality and Production evidence gates, final diff review, and squash merge.
+- Complete closeout pull request #42 through the permanent Quality and Production evidence gates, final diff review, and squash merge.
 - Next product milestones: browser-library backup and restore, versioned IndexedDB migrations, Playwright accessibility/offline/import tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
 - Evaluate focused dependency updates against current `main`; Next.js 16 remains a deliberate major migration rather than an automatic routine update.
 - Treat an optional `www.webnovel.win` custom-domain migration as a separate reviewed task only after the GitHub Pages setting or correct Cloudflare zone becomes writable.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,42 +2,39 @@
 
 ## Current state
 
-- Last completed run: 2026-08-05 branch-cleanup policy adoption, recorded by closeout pull request #17
-- Active operating cycle: product rescue, dependency repair, truthful format support, bilingual troubleshooting, the working documentation URL migration, and exact public production verification are complete; the permanent evidence gate and final metadata closeout remain
-- Last data window: Google Drive contains no matching analytics exports; repository, CI, deployment, dependency, format, documentation, DNS, response-header, workflow-registration, Pages-configuration, and public-artifact evidence collected on 2026-08-05
+- Last completed run: 2026-08-05 full product, content, deployment, and production-evidence cycle; final metadata closeout pull request pending
+- Last data window: Google Drive contains no matching analytics exports; repository, CI, dependency, deployment, Pages, DNS, response-header, and public-content evidence collected on 2026-08-05
 - Last site-change pull request: #40
-- Last squash merge: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Last closeout pull request: #17
+- Last site-change squash merge: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
+- Last production-evidence pull request: #41
+- Last production-evidence squash merge: `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
+- Last closeout pull request: pending this branch
 - Last successful attributable application deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Last successful attributable documentation deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Last public verification: pull request #41 Quality run `31036915052`, Production evidence job `92411188768`, verified both public build identities at exact `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and verified the public bilingual TXT troubleshooting page
+- Last public verification: PR #41 final Quality run `31037180170`, Production evidence job `92412164747`, verified both public build identities and the bilingual TXT troubleshooting page at exact source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
 - Skill submodule commit: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
 
 ## Current signals
 
-- Google Analytics 4: Google Drive is connected; the configured export folder exists but contains no matching export. Neither the reader nor generated documentation loads Google Analytics.
-- Google Search Console: Google Drive is connected; the configured export folder contains no matching export.
-- Cloudflare: connected accounts do not expose the `webnovel.win` zone. The former `www.webnovel.win` documentation hostname is not treated as production.
-- Repository: administrator and pull-request write access verified; quality gates cover dependency audit, ESLint, TypeScript, production app build, strict documentation build, public SEO-data validation, and exact public production evidence.
-- Product delivery: pull requests #19 through #23 passed every expected check and final self-review and were squash-merged.
-- Documentation content: pull request #31 merged the bilingual TXT import troubleshooting guide and canonical `manual` paths.
-- Pages diagnosis: authenticated inspection found legacy source `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
-- Documentation publication: pull request #37 repaired generated `gh-pages` delivery. Pull request #40 made the working project URL canonical, removed stale `CNAME` output, updated the reader Home action and public repository links, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Public production: the reader build endpoint returned exact `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` through Cloudflare; the GitHub Pages build endpoint returned the same exact commit through GitHub Pages; the public troubleshooting page matched the English and Chinese headings and the canonical project URL.
-- Permanent evidence: the temporary Pages diagnostic has been removed. Quality retains a required read-only production verifier that checks both exact builds and the actual troubleshooting content on every run.
-- Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, or private analytics identifiers.
-- Application: local TXT and supported text-URL import are exposed through onboarding and Add navigation; EPUB remains rejected until a real parser and versioned fixtures exist.
-- Content and community: bilingual product guidance, security policy, roadmap, contribution policy, release archive, structured issue forms, and reproducible troubleshooting replace obsolete links and unrelated generic AI articles.
-- Autonomous operation: at least one meaningful public production update and same-cycle repair of confirmed defects are required each local day.
+- Analytics: the configured Google Drive export folder exists but contains no GA4 or Search Console files. Missing optional analytics did not block product, documentation, CI, deployment, or public verification work.
+- Cloudflare: connected accounts do not expose the `webnovel.win` zone. The reader remains verified at `app.webnovel.win`; the former `www.webnovel.win` documentation hostname is not treated as production.
+- Application: first-use onboarding exposes local TXT and supported text-URL import; privacy claims match runtime behavior; browser zoom, accessible navigation, recoverable feedback, PWA update behavior, metadata, JSON-LD, robots, sitemap, and exact build identity are repaired.
+- Format boundary: EPUB and other unsupported containers are rejected until a real parser, security model, fixtures, and tests exist.
+- Dependencies: Next.js 15.5.22 and the current lockfile pass the permanent dependency-audit boundary, ESLint, TypeScript, and production build.
+- Documentation: the canonical public site is `https://autoarchive.github.io/webNR/`. It contains current bilingual usage, privacy, security, roadmap, contribution, release, troubleshooting, and source-development guidance without third-party analytics.
+- Public content: the bilingual TXT import troubleshooting guide documents actual supported inputs, encoding failures, CORS and HTTP failures, browser storage loss, safe PWA recovery, authorization boundaries, and privacy-safe reproduction.
+- Deployment: documentation is strictly built and published through the configured legacy `gh-pages:/` source; the reader and documentation expose exact source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Permanent quality gate: every Quality run now requires dependency audit, application checks, strict documentation checks, public SEO-data validation, exact reader/documentation build identities, and actual bilingual troubleshooting content.
+- Diagnostic history: failed evidence pull requests #32, #34, #36, and #38 were retained as evidence and closed without merge; no failed check was bypassed.
+- Privacy: operations do not collect imported filenames, book titles, content, reading history, source URLs, cookies, credentials, personal emails, provider IDs, or raw analytics.
+- Autonomous operation: each local day requires at least one meaningful public update and same-cycle repair of confirmed low-risk defects.
 - Branch cleanup: best-effort and nonblocking.
 
 ## Active focus
 
-- Rerun every required check after removal of the temporary transition diagnostic, then complete a clean final review and squash-merge pull request #41.
-- Close superseded diagnostic pull requests #36 and #38 without merge.
-- Create and merge the metadata-only closeout pull request with complete PR, CI, squash, deployment, public-verification, analytics-availability, and submodule evidence.
-- Track an optional `www.webnovel.win` migration separately until the GitHub Pages setting or correct Cloudflare zone becomes writable; it does not block the working public documentation site.
-- Evaluate remaining focused Dependabot pull requests after closeout; do not blindly merge Next.js 16 major-upgrade proposals.
-- Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
+- Complete this metadata-only closeout through the permanent Quality and Production evidence gates, final diff review, and squash merge.
+- Next product milestones: browser-library backup and restore, versioned IndexedDB migrations, Playwright accessibility/offline/import tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
+- Evaluate focused dependency updates against current `main`; Next.js 16 remains a deliberate major migration rather than an automatic routine update.
+- Treat an optional `www.webnovel.win` custom-domain migration as a separate reviewed task only after the GitHub Pages setting or correct Cloudflare zone becomes writable.
 
-This file contains verified current facts. Detailed history belongs in `daily/`.
+This file is the current verified summary. Detailed history belongs in `daily/`.


### PR DESCRIPTION
## Closeout scope

Record the verified completion of the 2026-08-05 WebNR product, content, deployment, and production-evidence cycle. This pull request changes public operating metadata only; it does not change rendered product or documentation output and must not trigger redundant deployment.

## Recorded delivery

- product first-use, privacy, accessibility, PWA, crawlability, and SEO repair
- supported dependency and tooling repair
- truthful TXT-only local format boundary
- strict bilingual documentation, security, roadmap, contribution, issue-reporting, and release infrastructure
- substantial bilingual TXT import troubleshooting and canonical manual paths
- working GitHub Pages project URL used by the reader and repository
- exact application and documentation source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
- permanent evidence implementation `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
- final evidence run `31037180170` and Production evidence job `92412164747`
- superseded failed diagnostic pull requests closed without merge
- analytics export absence and current shared-skill commit recorded without private data

## Required checks

- dependency audit, ESLint, TypeScript, and production application build
- strict documentation build and generated-output assertions
- public SEO-data validation
- permanent exact reader, documentation, and bilingual troubleshooting production evidence
- complete final review of the two metadata files, factual correspondence, private-data boundary, scope, and mergeability

## Deployment

No deployment wait is expected because this branch changes only `.github/seo-data/**`, which is excluded from both application and documentation publishing. The permanent production-evidence check must nevertheless independently confirm that the previously deployed public surfaces remain exact and healthy.

## Completion

This operating cycle is complete only after this non-draft closeout pull request passes every expected check, receives a clean final self-review, and squash-merges.
