### PR TITLE
docs: close out GA4 restoration and full URL reporting

### DIFF
--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -27,6 +27,7 @@ Complete the WebNR product and operating rescue, publish durable bilingual troub
 - Final analytics pull request #44 was one commit directly on completed-closeout `main`, preserved the working documentation URL and permanent Production evidence gate, passed all required checks, and squash-merged as `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
 - The `app-pages` deployment branch publishes build identity `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and generated HTML containing the GA4 loader and complete-URL configuration.
 - The `gh-pages` deployment branch publishes build identity `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and generated HTML containing GA4 measurement `G-DGH8HNQKE4`.
+- Analytics closeout Quality run `31038751609` passed Production evidence job `92417518169`, proving both public builds and the bilingual TXT troubleshooting page correspond to exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
 
 ## Work performed
 
@@ -64,7 +65,9 @@ Complete the WebNR product and operating rescue, publish durable bilingual troub
 - Published `app-pages/build.json` and `gh-pages/build.json` both identify `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
 - The application deployment artifact contains `G-DGH8HNQKE4`, `window.location.href`, pathname plus query reporting, and disabled Google and ad-personalization signals.
 - The documentation deployment artifact contains `G-DGH8HNQKE4` and canonical `https://autoarchive.github.io/webNR/` output.
-- The current metadata-only closeout must pass all four permanent Quality jobs. Its Production evidence job is the final public-site proof for exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
+- Metadata-only closeout pull request #45 initial Quality run `31038751609` passed Web quality, Documentation quality, SEO data contract, and Production evidence.
+- Production evidence job `92417518169` successfully verified the public reader build, documentation build, and bilingual troubleshooting page for exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
+- This evidence update is being validated by a final complete Quality run before squash merge. The complete final diff and checks must be reviewed again.
 
 ## Delivery
 
@@ -79,7 +82,10 @@ Complete the WebNR product and operating rescue, publish durable bilingual troub
 - Analytics squash commit: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
 - Application deployment artifact: exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
 - Documentation deployment artifact: exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
-- Analytics metadata closeout pull request, final public Production evidence, and closeout squash: pending current delivery
+- Analytics metadata closeout PR: `https://github.com/AutoArchive/webNR/pull/45`
+- Initial closeout Quality run and public verification: `https://github.com/AutoArchive/webNR/actions/runs/31038751609`
+- Initial closeout Production evidence job: `92417518169`, success
+- Final metadata-corrected closeout Quality run and closeout squash: pending current delivery
 - Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups

--- a/.github/seo-data/daily/2026-08-05.md
+++ b/.github/seo-data/daily/2026-08-05.md
@@ -2,123 +2,93 @@
 
 ## Scope
 
-Complete a full WebNR product and operating rescue in one local-day cycle: establish autonomous PR-based maintenance; repair first use, privacy, accessibility, PWA reliability, crawlability, dependencies, truthful format support, documentation, community infrastructure, and deployment; publish durable bilingual TXT troubleshooting content; and prove the exact public reader and documentation builds before metadata closeout.
+Complete the WebNR product and operating rescue, publish durable bilingual troubleshooting content, establish exact public deployment evidence, then correct the unauthorized removal of Google Analytics by restoring mandatory GA4 to the reader and documentation site with the owner-selected `full-url` reporting policy.
 
 ## Data window
 
 - Local operating date: 2026-08-05 (`America/Los_Angeles`)
 - Analytics target: 28 finalized days with a 3-day lag
-- Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no GA4 or Search Console export
+- Google Drive: the configured `webNR SEO Weekly CSV` folder exists and contains no matching GA4 or Search Console export
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone
-- Evidence used: repository source, pull-request diffs and metadata, CI jobs and logs, dependency audit output, generated app and documentation artifacts, GitHub workflow registration, Pages API state, DNS, selected public response headers, cache-busted build identities, and visible public content
+- Evidence used: repository history, pull requests, CI jobs, dependency audit output, generated application and documentation artifacts, GitHub Pages state, published deployment branches, exact build identities, public content, and permanent Production evidence
 
 ## Evidence collected
 
-- The former application showed an empty library without a reachable import action even though import code existed.
-- Runtime behavior contradicted privacy and accessibility promises: Google Analytics loaded unconditionally, page zoom was restricted, Service Workers were unregistered on every load, and global/import errors used blocking browser dialogs.
-- The repository had conflicting Next.js configuration, no explicit crawl files, stale dependencies and tooling, browser code dependent on Node behavior, and an audit report containing high-severity findings.
-- EPUB was advertised and accepted despite the absence of an EPUB parser; binary container bytes were decoded as text.
-- Documentation used broken deployment configuration, unpinned dependencies, no strict PR build, third-party analytics, obsolete repository links, unrelated generic AI articles, misspelled `mannual` paths, and no exact public build identity.
-- Optional analytics were unavailable: the configured export folder was empty and the connected Cloudflare accounts did not expose the relevant zone. Product, repository, content, CI, and public verification work continued without inventing zero metrics.
-- Failed evidence pull requests were preserved and closed without merge. Their cache-busted requests proved the reader was deploying while the former documentation hostname returned HTTP 404.
-- Authenticated Pages diagnosis established the real repository configuration: legacy `gh-pages:/`, status `built`, public project URL `https://autoarchive.github.io/webNR/`, and no registered custom domain.
-- Normal workflow tokens could not mutate Pages mode because that settings endpoint requires Administration write. Generated documentation publication to `gh-pages` succeeded once the workflow stopped making the unauthorized mutation.
-- The former `www.webnovel.win` hostname remained outside the available Cloudflare account and had no GitHub Pages custom-domain registration. It was removed from the production path instead of being falsely reported as deployed.
-- The shared SEO skill remained current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`.
+- The original application had no reachable first-use import action, restricted zoom, reset Service Workers on load, used blocking browser dialogs, had conflicting Next.js configuration, lacked crawl files, and advertised EPUB without an EPUB parser.
+- Product, dependency, accessibility, PWA, metadata, format-boundary, documentation, community, and deployment defects were repaired through focused pull requests #19–#23, #31, #37, #40, and #41.
+- Pull request #40 established `https://autoarchive.github.io/webNR/` as the working canonical documentation URL and deployed exact source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
+- Pull request #41 added a permanent Production evidence job that verifies recorded reader and documentation build identities and the actual bilingual TXT troubleshooting content.
+- Pull request #42 closed the first operating cycle as `8d29606ea45c52b5cb247dc09c819c326a2f322e`.
+- Historical source proved WebNR previously used GA4 measurement `G-DGH8HNQKE4`.
+- The owner explicitly rejected the agent's removal of analytics, required analytics on every managed site, and selected complete browser URL reporting, including query parameters and imported URLs in `?add=...`.
+- Shared SEO skill pull request #4 added mandatory runtime analytics, Search Console, infrastructure analytics where available, and an owner-selected `full-url` or `path-only` policy.
+- Shared skill pull request #4 passed Validate after its missing agent metadata was fixed and squash-merged as `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`.
+- Conflicted analytics pull request #39 and stale-base replacement #43 were closed without merge. No failed or obsolete check was bypassed.
+- Final analytics pull request #44 was one commit directly on completed-closeout `main`, preserved the working documentation URL and permanent Production evidence gate, passed all required checks, and squash-merged as `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
+- The `app-pages` deployment branch publishes build identity `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and generated HTML containing the GA4 loader and complete-URL configuration.
+- The `gh-pages` deployment branch publishes build identity `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and generated HTML containing GA4 measurement `G-DGH8HNQKE4`.
 
 ## Work performed
 
-### Operating foundation
+### Product and delivery foundation
 
-- Pull requests #14–#17 added the pinned shared SEO skill, public-safe operating records, pull-request quality gates, autonomous daily contract, complete CI/self-review/squash-merge requirements, and nonblocking branch cleanup.
+- Added autonomous PR-based operations, quality gates, self-review, squash merge, exact deployment verification, metadata closeout, and nonblocking branch cleanup.
+- Repaired first-use onboarding, visible TXT and URL import, accessible navigation and labels, browser zoom, recoverable feedback, PWA registration and caching, canonical metadata, JSON-LD, `robots.txt`, `sitemap.xml`, and exact build identity.
+- Upgraded to supported Next.js 15.5.22, aligned lint tooling, repaired encoding detection, regenerated the lockfile, and added dependency-audit enforcement.
+- Removed false EPUB support until a real parser, security model, fixtures, and tests exist.
+- Published strict pinned documentation, security, roadmap, contribution guidance, structured issue forms, corrected manual paths, and a substantial bilingual TXT import troubleshooting guide.
+- Established the working GitHub Pages documentation URL and permanent exact production evidence.
 
-### Product, privacy, accessibility, PWA, and SEO repair
+### Analytics correction
 
-- Pull request #19 exposed local TXT and supported URL import through first-use onboarding, Add navigation, and a useful empty-library state.
-- It replaced blocking dialogs with recoverable UI feedback, repaired language synchronization, skip navigation, semantic status behavior, visible labels, and browser zoom.
-- It removed unconditional Google Analytics, repaired Service Worker registration and caching, consolidated Next.js configuration, and added accurate metadata, canonical ownership, SoftwareApplication JSON-LD, `robots.txt`, `sitemap.xml`, and PWA shortcuts.
-- It passed corrected final CI and squash-merged as `d8325d3f906e3aead84a4aec98d15815daf57545`.
-
-### Verifiable application delivery
-
-- Pull request #20 added public `build.json` identity, generated-artifact/privacy assertions, exact-source deployment messages, and cache-busted production verification; squash `cba8cff1975d293947143f7efefc2b2db37d849a`.
-
-### Dependencies and tooling
-
-- Pull request #21 upgraded to supported Next.js 15.5.22, aligned ESLint tooling, removed deprecated decoding dependencies, fixed browser encoding detection, regenerated the lockfile, and added a permanent dependency-audit validator; squash `f86d7967f44ae57d83c558a63e322f52dd18373a`.
-
-### Truthful format boundary
-
-- Pull request #22 removed EPUB from file selection, storage acceptance, metadata, structured data, manifest descriptions, and public claims. Unsupported containers now fail explicitly; squash `4b488b6f1ba4f46d5231f21adc5f92ae21de2e39`.
-
-### Documentation and community
-
-- Pull request #23 pinned MkDocs dependencies, added `mkdocs build --strict` to CI, removed documentation analytics, corrected repository references, published current bilingual usage/privacy/release guidance, added security, roadmap, contribution and structured issue resources, and deleted four unrelated generic AI articles; squash `68f2d67f7cd2c2e14636d56a5c49d4d53a887278`.
-
-### Meaningful daily public content
-
-- Pull request #31 published a substantial bilingual TXT import troubleshooting guide tied to current implementation.
-- It covers supported TXT and authorized text URL inputs; UTF-8, GB18030, Big5, malformed bytes, mixed encoding, and binary files renamed as TXT; CORS, redirects, authentication, HTTP status, content type, timeout, and large-request failures; browser storage loss; safe PWA refresh; and privacy-safe reproduction with synthetic, public-domain, self-owned, or explicitly authorized fixtures.
-- It explicitly rejects bypassing login, payment, DRM, robots, rate limits, CORS, or other access controls.
-- It corrected `mannual` to `manual`, updated active links, passed all expected CI and two complete final reviews, and squash-merged as `57c904bb637b97eb0b8cc9a99e035d91c39574fb`.
-
-### Documentation deployment diagnosis and repair
-
-- Pull requests #25, #27, #33, and #35 tested progressively more direct Pages approaches. Generated builds passed, but failed production evidence was never bypassed.
-- Pull requests #32 and #34 proved exact reader deployments while recording repeated documentation HTTP 404 responses; both were closed without merge.
-- Pull request #36 added read-only Actions and Pages diagnostics, exposing legacy `gh-pages:/`, absent CNAME, stale Pages state, and workflow failures caused by unauthorized Pages settings mutation.
-- Pull request #37 removed that mutation and duplicate publisher, strictly built exact-source documentation, and published generated output to `gh-pages`; squash `bd0f859303a426a653970118102612f1ae6345f9`.
-- Pull request #38 confirmed the generated Pages build but remained blocked on the unavailable custom domain and was later closed without merge.
-- Pull request #40 made `https://autoarchive.github.io/webNR/` the canonical documentation endpoint, removed stale CNAME output, updated the reader Home action, README, troubleshooting, contribution and issue-help links, and rejected stale custom-domain references from generated documentation.
-- Pull request #40 passed Quality run `31036258893`, received a clean final review with no review threads, and squash-merged as `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Documentation workflow run `31036446960` succeeded for source commit `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- Pages API reported legacy `gh-pages:/`, HTTPS enabled, status `built`, project URL `https://autoarchive.github.io/webNR/`, no custom domain, and generated Pages build commit `f06553dfa0c7116d467861b338f6d7f41f01f4ba`.
-
-### Permanent production evidence
-
-- Pull request #41 added a required `Production evidence` job to every Quality run.
-- The verifier parses recorded application and documentation source commits, resolves public DNS, sends cache-busted requests, captures selected response headers, verifies exact build identities, and checks the actual public troubleshooting page for both language headings and the canonical project URL.
-- Evidence-only workflow, verifier, and SEO-record changes are excluded from redundant application deployment.
-- Initial run `31036915052` passed all five jobs. Production evidence job `92411188768` verified both public builds at exact source `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882` and matched the bilingual troubleshooting content on its first request.
-- After final Pages transition evidence was captured, the temporary diagnostic and extra Actions/Pages read permissions were removed. The permanent workflow requires only Contents read.
-- Final run `31037180170` passed application checks, strict documentation checks, SEO-data validation, and Production evidence.
-- Final Production evidence job `92412164747` again verified the exact reader and documentation builds and the actual bilingual troubleshooting content.
-- The complete final diff, commit parser, request behavior, retry bounds, response evidence, deployment exclusions, privacy boundary, review threads, unchanged head, and mergeability were reviewed before squash merge.
-- Pull request #41 squash-merged as `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
-- Superseded diagnostic pull requests #36 and #38 were closed without merge after their evidence was preserved.
+- Restored GA4 measurement `G-DGH8HNQKE4` in `config/constants.ts` and `app/layout.tsx`.
+- Configured reader page views with `page_location: window.location.href` and `page_path: window.location.pathname + window.location.search`.
+- Preserved `allow_google_signals: false` and `allow_ad_personalization_signals: false`.
+- Restored GA4 to MkDocs Material using the same measurement ID.
+- Replaced inaccurate “no tracking” statements with explicit English and Chinese disclosure that complete page URLs, including `?add=...` import URLs, are reported.
+- Added the mandatory `## Analytics` site contract and `URL reporting: full-url`.
+- Updated daily operating rules so an agent may not remove, reduce, redact, or change analytics without a later explicit owner instruction.
+- Updated Quality and deployment workflows so generated application and documentation artifacts must contain the expected GA4 implementation.
+- Adopted shared SEO skill commit `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`.
 
 ## Validation and self-review
 
-- Every merged outcome used a fresh branch and real non-draft pull request.
-- Every relevant pull request passed its expected dependency audit, ESLint, TypeScript, production app build, strict documentation build, generated-output assertions, SEO-data validation, and—after #41—exact public production evidence.
-- Every merge followed a complete final diff and check-results review; findings were fixed on the same branch and all checks rerun.
-- The final public reader and documentation source identity is `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`.
-- The permanent production-evidence implementation is `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`.
-- No credentials, provider IDs, raw analytics, personal emails, private URLs, imported filenames, book titles, reading content, reading history, cookies, or source credentials were committed.
-- Branch cleanup remained best-effort and never created a blocker.
+- Shared skill PR #4 final Validate run passed after the missing `agents/openai.yaml` metadata was added.
+- Analytics PR #44 Quality run `31038265520` passed all four jobs:
+  - Web quality: dependency audit, ESLint, TypeScript, Next.js production build, and generated full-URL GA4 assertions;
+  - Documentation quality: strict MkDocs build, working canonical URL, bilingual guide, and generated GA4 assertion;
+  - SEO data contract: mandatory analytics metadata and current shared skill;
+  - Production evidence: recorded exact public reader and documentation builds and bilingual troubleshooting content.
+- Final review confirmed PR #44 was one commit ahead of current `main`, had no review threads, retained the permanent Production evidence verifier, preserved the working documentation URL, and contained no credentials, private provider identifiers, raw analytics rows, cookies, or authorization values.
+- PR #44 squash-merged as `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
+- Published `app-pages/build.json` and `gh-pages/build.json` both identify `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
+- The application deployment artifact contains `G-DGH8HNQKE4`, `window.location.href`, pathname plus query reporting, and disabled Google and ad-personalization signals.
+- The documentation deployment artifact contains `G-DGH8HNQKE4` and canonical `https://autoarchive.github.io/webNR/` output.
+- The current metadata-only closeout must pass all four permanent Quality jobs. Its Production evidence job is the final public-site proof for exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
 
 ## Delivery
 
-- Autonomous operating foundation: pull requests #14–#17
-- Product first-use, privacy, accessibility, PWA, crawlability, and SEO repair: #19
-- Exact application build identity and deployment verification: #20
-- Supported dependency and tooling repair: #21
-- Truthful TXT-only local format boundary: #22
-- Documentation, CI, and community repair: #23
-- Bilingual TXT troubleshooting and canonical manual paths: #31
-- Legacy Pages-compatible generated publication: #37
-- Working canonical GitHub Pages documentation URL: #40, squash `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Permanent exact reader/documentation/content evidence: #41, squash `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
-- Superseded diagnostic PRs #32, #34, #36, and #38: closed without merge
-- Final metadata-only closeout: pull request #42, pending final checks, final review, and squash merge
-- Shared SEO skill: current at `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
+- Shared analytics skill PR: `https://github.com/AutoArchive/seo-skill/pull/4`
+- Shared analytics skill squash: `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`
+- Working documentation URL PR: `https://github.com/AutoArchive/webNR/pull/40`
+- Permanent production-evidence PR: `https://github.com/AutoArchive/webNR/pull/41`
+- First operating-cycle closeout PR: `https://github.com/AutoArchive/webNR/pull/42`
+- Superseded analytics PRs: #39 and #43, closed without merge
+- Final analytics restoration PR: `https://github.com/AutoArchive/webNR/pull/44`
+- Analytics PR Quality run: `https://github.com/AutoArchive/webNR/actions/runs/31038265520`
+- Analytics squash commit: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
+- Application deployment artifact: exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
+- Documentation deployment artifact: exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
+- Analytics metadata closeout pull request, final public Production evidence, and closeout squash: pending current delivery
+- Branch cleanup: best-effort and nonblocking
 
 ## Decisions and follow-ups
 
-- The working GitHub Pages project URL is the canonical documentation endpoint. The former custom hostname is not production.
-- Reintroducing `www.webnovel.win` requires writable GitHub Pages custom-domain configuration or access to the correct Cloudflare zone, followed by a separately reviewed migration and redirect plan.
-- Unsupported formats remain rejected until real parsers, capability limits, representative fixtures, and versioned tests exist.
-- Next product priorities are browser-library backup and restore, versioned IndexedDB migrations, Playwright accessibility/offline/import tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.
-- Next.js 16 proposals remain a deliberate major migration and must not be blindly merged as routine security updates.
-- Daily content must continue to originate from real product behavior, troubleshooting, compatibility fixtures, releases, or measured engineering evidence; generic AI articles, keyword variants, and thin pages remain prohibited.
-- The cycle is complete only after closeout pull request #42 passes all permanent checks, receives a clean final review, and squash-merges.
+- Every managed site must have runtime analytics; agents may not remove it based on preference.
+- WebNR's owner-selected policy is `full-url`; complete browser URLs and query parameters, including imported URLs in `?add=...`, are sent to GA4.
+- Google signals and ad-personalization signals remain disabled unless the owner explicitly changes them.
+- No custom analytics events containing local file contents or reading progress were added.
+- The working documentation canonical remains `https://autoarchive.github.io/webNR/`.
+- Missing GA4 or Search Console exports are missing evidence, not zero traffic.
+- The daily operator remains paused only during this repair to prevent concurrent default-branch movement and will be re-enabled after the closeout merges.
+- Next product milestones are backup and restore, IndexedDB migrations, Playwright accessibility/offline/import tests, stable releases, a secure EPUB parser, and versioned clean-room Legado compatibility fixtures.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -7,10 +7,13 @@
 - Last completed closeout squash merge: `8d29606ea45c52b5cb247dc09c819c326a2f322e`
 - Latest site-change pull request: #44
 - Latest site-change squash merge: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
-- Analytics closeout: pending current metadata-only pull request
+- Analytics closeout pull request: #45
+- Analytics closeout initial Quality run: `31038751609`
+- Analytics closeout final squash merge: pending
 - Last data window: Google Drive contains no matching GA4 or Search Console export; repository, CI, Pages, public-build, and analytics implementation evidence collected on 2026-08-05
 - Last successful attributable application deployment: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
 - Last successful attributable documentation deployment: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
+- Last successful public production verification: Quality run `31038751609`, Production evidence job `92417518169`
 - Last permanent production-evidence implementation: `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
 - Skill submodule commit: `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`
@@ -26,7 +29,7 @@
 - Infrastructure analytics: connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GA4, Search Console preparation, GitHub Pages analytics, or product delivery.
 - Application deployment artifact: `app-pages/build.json` identifies `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`; generated HTML contains the GA4 loader and full-URL configuration.
 - Documentation deployment artifact: `gh-pages/build.json` identifies `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`; generated HTML contains GA4 measurement `G-DGH8HNQKE4`.
-- Permanent production evidence: every Quality run verifies the recorded exact reader and documentation builds plus the bilingual troubleshooting content.
+- Public production verification: Production evidence successfully requested the reader build, documentation build, and bilingual TXT troubleshooting page for exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
 - Documentation delivery: `https://autoarchive.github.io/webNR/` is the canonical working documentation URL.
 - Data behavior: imported book content and reading progress remain in browser storage. No custom analytics events containing local file contents or reading progress were added.
 - Application: local TXT and supported text-URL import are available; EPUB remains rejected until a real parser and versioned fixtures exist.
@@ -35,9 +38,8 @@
 
 ## Active focus
 
-- Pass the metadata-only closeout through Web quality, Documentation quality, SEO data contract, and Production evidence.
-- Require Production evidence to prove both public sites expose exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and the required public content.
-- Record the final closeout pull request, Quality run, public verification, and squash merge in the current daily report.
+- Pass the final metadata-corrected closeout head through Web quality, Documentation quality, SEO data contract, and Production evidence.
+- Perform a complete final diff and check review, then squash-merge pull request #45.
 - Re-enable the daily WebNR operator with the working documentation URL and mandatory `full-url` analytics policy.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -5,37 +5,40 @@
 - Last completed run: 2026-08-05 full product, content, deployment, production-evidence, and metadata-closeout cycle
 - Last completed closeout pull request: #42
 - Last completed closeout squash merge: `8d29606ea45c52b5cb247dc09c819c326a2f322e`
-- Active correction: restore mandatory GA4 to the reader and documentation site with owner-selected `full-url` reporting
+- Latest site-change pull request: #44
+- Latest site-change squash merge: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
+- Analytics closeout: pending current metadata-only pull request
 - Last data window: Google Drive contains no matching GA4 or Search Console export; repository, CI, Pages, public-build, and analytics implementation evidence collected on 2026-08-05
-- Last successful attributable application deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
-- Last successful attributable documentation deployment: `d1b4d1ede10037bcc1353c3edbd9d4e7c245d882`
+- Last successful attributable application deployment: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
+- Last successful attributable documentation deployment: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
 - Last permanent production-evidence implementation: `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
-- Skill submodule commit on current `main`: `6dde51078f87d5f6cf1c22045df13a3f786a5f02`
-- Required skill submodule commit for analytics: `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`
+- Skill submodule commit: `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`
 
 ## Current signals
 
 - Runtime analytics policy: mandatory on every managed site. WebNR owner policy is `full-url`.
-- Google Analytics 4: the active correction restores measurement `G-DGH8HNQKE4` to the reader and documentation site. The reader sends the complete browser URL, including query parameters and imported URLs in `?add=...`.
+- Google Analytics 4: measurement `G-DGH8HNQKE4` is restored to the reader and documentation site.
+- Reader page views use `window.location.href` and pathname plus query string, so imported URLs in `?add=...` are included.
 - Google signals and ad-personalization signals remain disabled.
 - GA4 evidence: Google Drive is connected; the configured export folder contains no matching export. Missing exports are not treated as zero traffic.
 - Google Search Console: required; the configured Google Drive folder contains no matching export.
 - Infrastructure analytics: connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GA4, Search Console preparation, GitHub Pages analytics, or product delivery.
+- Application deployment artifact: `app-pages/build.json` identifies `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`; generated HTML contains the GA4 loader and full-URL configuration.
+- Documentation deployment artifact: `gh-pages/build.json` identifies `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`; generated HTML contains GA4 measurement `G-DGH8HNQKE4`.
 - Permanent production evidence: every Quality run verifies the recorded exact reader and documentation builds plus the bilingual troubleshooting content.
 - Documentation delivery: `https://autoarchive.github.io/webNR/` is the canonical working documentation URL.
-- Data behavior: imported book content and reading progress remain in browser storage. GA4 page views include complete page URLs and query parameters; no custom events containing local file contents or reading progress are added.
+- Data behavior: imported book content and reading progress remain in browser storage. No custom analytics events containing local file contents or reading progress were added.
 - Application: local TXT and supported text-URL import are available; EPUB remains rejected until a real parser and versioned fixtures exist.
 - Autonomous operation: each local day requires a meaningful public update, mandatory analytics verification, and same-cycle repair of confirmed defects.
 - Branch cleanup: best-effort and nonblocking.
 
 ## Active focus
 
-- Deliver the analytics correction from the latest default branch without replacing the completed #42 history or the permanent Production evidence gate.
-- Require green Web quality, Documentation quality, SEO data contract, and Production evidence on the final analytics head.
-- Squash-merge only after a clean complete diff review.
-- Verify the exact analytics squash commit and GA4 implementation on `https://app.webnovel.win/` and `https://autoarchive.github.io/webNR/`.
-- Create and merge a metadata-only analytics closeout that appends PR, CI, squash, deployment, public-verification, URL-policy, and submodule evidence to the existing daily record.
+- Pass the metadata-only closeout through Web quality, Documentation quality, SEO data contract, and Production evidence.
+- Require Production evidence to prove both public sites expose exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and the required public content.
+- Record the final closeout pull request, Quality run, public verification, and squash merge in the current daily report.
+- Re-enable the daily WebNR operator with the working documentation URL and mandatory `full-url` analytics policy.
 - Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
 
 This file is the current verified summary. Detailed history belongs in `daily/`.


### PR DESCRIPTION
## Scope

Metadata-only closeout for analytics restoration pull request #44.

## Recorded delivery

- shared analytics skill: AutoArchive/seo-skill PR #4, squash `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`
- WebNR analytics PR: #44
- WebNR analytics Quality run: `31038265520`
- WebNR analytics squash: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
- application deployment artifact: exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`, GA4 loader, and full-URL configuration
- documentation deployment artifact: exact commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78` and GA4 measurement
- owner policy: `URL reporting: full-url`, including imported URLs in `?add=...`

## Public verification

Initial closeout Quality run `31038751609` passed all four jobs. Production evidence job `92417518169` verified the public reader build, public documentation build, and bilingual TXT troubleshooting page for exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.

After that evidence was written into the repository record, final Quality run `31038924037` passed all four jobs again. Final Production evidence job `92418179524` repeated the same public verification successfully.

## Final review

- final diff is limited to `.github/seo-data/status.md` and the current daily record
- no runtime, analytics, deployment, or content behavior changes
- no credentials, private provider identifiers, raw analytics rows, cookies, authorization values, or user reading data
- shared skill remains `5c3174fa6ca5b01ff2f56b1cfb248877187ce2f5`
- exact application and documentation deployment source remains `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
- final Web quality, Documentation quality, SEO data contract, and Production evidence all succeeded

Ready for squash merge after clean final review.