### PR TITLE
plan: prioritize reader discovery and daily source growth

### DIFF
--- a/.github/seo-data/daily-task.md
+++ b/.github/seo-data/daily-task.md
@@ -1,38 +1,217 @@
-# Daily SEO task
+# Daily WebNR operating task
 
 ## Objective
 
-Run one fully autonomous, evidence-backed SEO, product-quality, analytics, and user-experience operating cycle for WebNR. No normal step requires human approval. Every local calendar day must deliver at least one meaningful user-visible improvement to the production application or its public help content.
+Run one fully autonomous product, source, reader-content, community, analytics,
+and SEO operating cycle for WebNR. The durable priorities and publication
+calendar live in `plan.md` and `editorial-calendar.md`.
 
-## Schedule
+The operating model is:
 
-- Frequency: daily
-- Timezone: use `site.md`
-- Data window: use the lookback and finalization lag in `site.md`
-- Pull-request scope: one coherent outcome per main pull request; use additional focused pull requests in the same cycle when independent defects also require repair
+1. concentrate and finish currently confirmed technical repairs;
+2. continue daily production monitoring and same-cycle bug repair;
+3. publish one useful reader-facing content asset in every rolling 48-hour
+   window;
+4. discover several source candidates every day, fully audit at least three, and
+   target one passing integration.
 
-## Mandatory analytics policy
+No normal step requires human approval.
 
-Read and enforce `$ensure-site-analytics` on every run. WebNR requires Google Analytics 4 on both the application and documentation site. `site.md` sets `URL reporting: full-url`, so the application must send the complete browser URL, including query parameters and imported URLs in `?add=...`. Do not remove analytics, strip query parameters, redact the full URL, or switch providers without an explicit later instruction from the site owner recorded in the pull request and daily report.
+## Required skills and context
 
-Verify analytics in source, generated application and documentation output, canonical production pages, and available GA4 evidence. A script tag alone or a Drive export alone is not proof. Missing, broken, policy-inconsistent, or unverified analytics is a same-cycle technical defect.
+Read the complete pinned versions of:
 
-## Required sequence
+- `$operate-seo-site`;
+- `$ensure-site-analytics`;
+- `$collect-seo-data`;
+- `$deliver-github-pr`;
+- `$research-blog` when the selected content requires broad, historical,
+  cross-language, social, or ecosystem evidence.
 
-1. Read the pinned `$ensure-site-analytics`, `$collect-seo-data`, and `$change-seo-site` skills, all `.github/seo-data/*.md` files, and newest reports.
-2. Fetch the remote default branch and create a fresh branch from it for each coherent outcome.
-3. Check whether the `seo-skills` submodule has an allowed update and include an available update in the first compatible main pull request.
-4. Audit GA4 in `app/layout.tsx`, `config/constants.ts`, `mkdocs.yml`, generated outputs, and both public domains. Confirm complete browser URL reporting, including query strings, while Google signals and ad-personalization signals remain disabled.
-5. Collect finalized Google Drive and available Cloudflare evidence without committing raw data or private provider identifiers. When a provider is unavailable, record that fact and continue with public-site, repository, CI, deployment, issue, and user-journey evidence.
-6. Inspect the live application and repository for actionable technical defects affecting analytics, onboarding, accessibility, security, crawlability, performance, reliability, data safety, PWA behavior, compatibility, build health, or deployment. Repair every confirmed low-risk, reversible, and verifiable defect during the same operating cycle. Do not defer a discovered repair merely because another pull request has already shipped that day.
-7. Deliver at least one meaningful user-visible production update every day. Prefer fixing product behavior or improving an existing high-value page. When no product defect is justified, publish or substantially improve durable help, compatibility, troubleshooting, benchmark, release, or source-development content backed by actual WebNR behavior. Never create thin pages, keyword variants, generic AI articles, fabricated measurements, or changes made only to satisfy cadence.
-8. Write or append `.github/seo-data/daily/YYYY-MM-DD.md`; refresh `status.md`, maintain future work in `plan.md`, and keep `block.md` limited to genuine human-only or permission blockers.
-9. For each coherent change, define its production acceptance check before editing, validate locally when possible, push the branch, and create a real non-draft pull request.
-10. Wait for all required and expected CI, self-review the complete final diff, commits, generated output, analytics URL behavior, security and data boundaries, and check results; fix and repeat when needed, then squash-merge. Attempt to delete the merged head branch only when safe deletion is supported; branch cleanup is best-effort and non-blocking.
-11. For every site-visible change, wait for the exact squash commit to deploy successfully and verify the intended behavior and GA4 implementation on the public site.
-12. Open a metadata-only closeout pull request with final evidence for the cycle; wait for CI, self-review, and squash-merge it.
-13. Continue autonomously while safe progress is possible. Record a `block.md` item only when an external system enforces a human-only action or required permission is absent. A missing branch-deletion operation, unavailable infrastructure analytics source, or undeleted merged automation branch is not a blocker.
+Also read repository instructions, all `.github/seo-data/*.md` files, the newest
+daily records, open automation work, normal contributor pull requests, issues,
+CI, dependencies, deployment state, and current production behavior.
+
+Checking or updating the submodule does not authorize editing
+`AutoArchive/seo-skill`. Do not take over another contributor's pull request
+without an explicit user instruction.
+
+## Analytics policy
+
+WebNR requires both GA4 destinations on both production sites:
+
+- `G-DGH8HNQKE4`;
+- `G-NL0WV2XMJN`.
+
+The owner-selected policy is full-URL reporting. Both destinations must receive
+the complete browser URL, including the full query string and imported URLs in
+`?add=...`. Keep Google signals and ad-personalization signals disabled unless the
+owner explicitly changes that decision. Do not introduce additional custom
+events containing local book text, reading progress, credentials, cookies,
+authorization values, or browser storage without separate explicit authorization.
+
+Verify analytics in source, generated application and documentation outputs, both
+public production sites, the exact deployed commits, and available provider
+evidence. Missing, incomplete, policy-inconsistent, or unverified analytics is a
+same-cycle technical defect.
+
+## Technical work
+
+### Concentrated repair pass
+
+While confirmed low-risk, reversible, and verifiable technical debt remains,
+repair as much as can be reviewed safely in the current operating cycle. Keep one
+coherent outcome per pull request, but use multiple focused pull requests rather
+than spreading known defects across artificial daily increments.
+
+Audit onboarding, TXT import and encoding, reading flows, browser storage,
+backup/restore, IndexedDB and OPFS migrations, PWA updates and offline behavior,
+accessibility, performance, dependencies, security, tests, releases, analytics,
+crawlability, canonical, robots, sitemap, structured data, internal links, CI,
+deployments, and exact public-build attribution.
+
+### Daily guard after repair
+
+After the repair pass, run daily production smoke tests and regression checks for:
+
+- local TXT import and permitted URL import;
+- encoding and large-file behavior;
+- open/read/progress/export journeys;
+- backup, restore, and migrations once implemented;
+- PWA installation, update, offline reopening, and cache behavior;
+- keyboard, screen-reader, zoom, language, and reduced-motion behavior;
+- dependency audit, lint, typecheck, tests, application build, and strict
+  documentation build;
+- both production deployments, both GA4 destinations, full-URL reporting,
+  canonical, robots, sitemap, and important public routes;
+- integrated source health and Legado compatibility fixtures.
+
+Repair a reproducible safe bug in the same cycle. A technical defect preempts
+routine content or promotion until repaired, safely rolled back, or truthfully
+blocked by an external human-only action.
+
+## Reader-content cadence
+
+Check whether a qualifying reader-facing content asset has reached production in
+the previous 48 hours. If not, publish or substantially upgrade one in the current
+cycle according to `editorial-calendar.md`.
+
+Primary content serves readers who want to find:
+
+- working book sources and TXT collections;
+- novel sites and authorized reading routes;
+- useful apps and reading channels;
+- public reader communities and social-media discussion;
+- recommendations by genre, language, completion status, platform, or reading
+  habit;
+- Chinese, English, Japanese, Korean, translated-fiction, fan-fiction, and
+  independent-serial ecosystems;
+- practical migration paths between Legado, feeds, catalogs, and WebNR.
+
+Product manuals, troubleshooting, release notes, benchmarks, and source SDK pages
+remain supporting content. They may satisfy the 48-hour cadence when they answer a
+real current reader or contributor need and contain substantial verified value.
+
+Use `$research-blog` for research-heavy ecosystem and community analysis. Use
+current first-hand testing, official standards, official platform documentation,
+public feeds, project source, and reproducible fixtures for practical guides and
+comparisons. Never publish generic AI articles, copied platform summaries,
+keyword variants, fabricated popularity, unsupported rankings, or thin pages.
+
+Every page must have a stable descriptive URL, a direct opening answer, current
+verification date, selection or sampling method, natural internal links,
+canonical, sitemap entry, static rendered HTML, and exact production verification.
+
+## Daily source discovery and integration
+
+Every cycle must:
+
+1. discover at least five new source or collection candidates;
+2. fully audit at least three;
+3. target one passing integration;
+4. retest a rotating sample of existing sources;
+5. repair, downgrade, mark, or remove failed sources;
+6. record safe rejection reasons when candidates fail.
+
+A candidate may be OPDS, RSS/Atom, a public API, a public index or sitemap, an
+authorized or public-domain TXT collection, an author feed, an open-source CMS,
+a public Legado definition, or another useful discovery route.
+
+The origin does not need to be WebNR-compatible and does not need complete
+metadata. WebNR may build and maintain its own source definition, adapter,
+normalized feed, static TXT catalog, or Legado compatibility wrapper. Derive a
+display title from a filename when useful and mark unknown fields as unknown.
+Never invent authorship, provenance, license, update state, or popularity.
+
+Before integration, verify distribution basis, terms and robots, HTTPS, CORS,
+cookies, login, scripts, WebView or Bridge requirements, requested domains,
+permissions, rate limits, pagination, timeout, response limits, encoding, failure
+behavior, duplication, reader value, at least one versioned fixture, and a
+reproducible health test.
+
+Do not integrate sources that normally depend on bypassing authentication,
+payment, DRM, captchas, robots, access controls, or unauthorized redistribution.
+The target is one passing source per day, never one unreviewed link per day.
+
+## Legado compatibility
+
+Prefer compatibility with existing Legado sources over requiring maintainers to
+rewrite them for WebNR. Progress through versioned fixtures for:
+
+- JSON import and field-preserving inspection;
+- common search, book-info, TOC, content, pagination, CSS, XPath, JSONPath,
+  regular-expression, header, charset, and replacement rules;
+- controlled state, cookies, variables, and permissions;
+- restricted JavaScript execution;
+- optional Bridge-dependent WebView and cross-origin capabilities.
+
+Publish only the tested compatibility level and fixture-suite version. A public
+third-party definition may first enter an isolated compatibility corpus before it
+is recommended to readers.
+
+## Delivery sequence
+
+For every coherent product, content, source, corrective, or closeout outcome:
+
+1. use `$deliver-github-pr` to start from the latest remote default branch and
+   prepare a fresh `seo/` branch;
+2. include a reviewed compatible submodule update in the first suitable pull
+   request when available;
+3. implement only the intended outcome and define affected routes, unaffected
+   routes, public acceptance, and rollback before editing;
+4. commit and push the actual code or content and create a real non-draft pull
+   request;
+5. wait for every required and expected check; missing, queued, skipped, failed,
+   cancelled, and timed-out checks block merge;
+6. after CI, re-read the complete final diff, commits, generated output, source
+   permissions, analytics behavior, content evidence, tests, and deployment
+   impact from scratch;
+7. fix every finding on the same branch and repeat CI and complete review;
+8. squash-merge only with the expected head SHA after a clean final review;
+9. identify the production deployments for the exact squash commit and verify
+   the affected and representative unaffected public behavior;
+10. update the normal daily/status closeout evidence through the same pull-request
+    discipline when the repository requires it.
+
+Branch deletion is best-effort hygiene. A branch, preview, workflow URL, artifact,
+script tag, provider export, or HTTP 200 alone is not production proof.
 
 ## Daily completion
 
-A day is complete only after required GA4 is present and verified with complete browser URL reporting, all actionable confirmed technical defects discovered during the cycle have been repaired or accurately proven non-actionable, at least one meaningful user-visible update has reached production, every main pull request and the closeout pull request are squash-merged, required and expected CI is green, each exact squash commit has a successful attributable deployment, and the public acceptance checks pass. Merged branch cleanup is optional repository hygiene. A failed or missing CI check, failed or unattributable deployment, local-only commit, issue, draft PR, workflow URL, script tag alone, provider export alone, HTTP 200 alone, metadata-only update, or unverified content does not satisfy the daily requirement.
+A cycle is complete only when:
+
+- mandatory analytics and full-URL behavior are verified;
+- every actionable technical defect discovered in the cycle is repaired and
+  publicly verified or has a truthful external blocker;
+- at least five source candidates were discovered, at least three fully audited,
+  and one passing integration was attempted;
+- any due 48-hour reader-content asset was merged, deployed, and publicly
+  verified;
+- all main and applicable closeout pull requests have green expected CI, clean
+  final reviews, and squash merges;
+- every rendered change is tied to the exact production commit and passes its
+  public acceptance checks.
+
+A metadata-only edit, source candidate list, local patch, issue, draft pull
+request, generated branch, or unverified article does not satisfy the public
+content or source-integration cadence.

--- a/.github/seo-data/editorial-calendar.md
+++ b/.github/seo-data/editorial-calendar.md
@@ -1,0 +1,84 @@
+# WebNR reader content and source calendar
+
+This calendar starts on 2026-08-06 in `America/Los_Angeles`. Product incidents
+and confirmed technical defects preempt the planned article for that operating
+cycle, but the rolling 48-hour content requirement remains. A delayed item moves
+to the next available slot instead of being silently dropped.
+
+## 30-day publication schedule
+
+| Publish date | Primary reader question | Planned public asset | Source-integration emphasis |
+| --- | --- | --- | --- |
+| 2026-08-06 | Where can readers find working Legado sources, and how can they judge them? | A current guide to Legado source discovery, testing, import, failure signals, and replacement | Audit public Legado directories and create the first compatibility-corpus fixtures |
+| 2026-08-08 | Where can readers legally find free novels and TXT collections? | A maintained directory of public-domain, author-authorized, OPDS, feed, and downloadable-text collections | Project Gutenberg OPDS/RSS and at least two public-domain alternatives |
+| 2026-08-10 | Which English serial-fiction platform fits a reader's needs? | Royal Road, Scribble Hub, Wattpad, and adjacent platforms compared by genre, discovery, comments, completion signals, and reading flow | Audit public feeds, APIs, indexes, or link-based adapters for compared platforms |
+| 2026-08-12 | Where do web-novel readers discuss and recommend stories? | A map of public Reddit communities, Discord directories, Novel Updates discussions, platform forums, and other reader channels | Build community-link sources or feeds where public syndication is available |
+| 2026-08-14 | Which reading app should a reader use? | Reader-oriented comparison of WebNR, Legado, browser readers, OPDS clients, and common mobile/desktop choices | Audit import/export compatibility and public catalog support for each app family |
+| 2026-08-16 | Where can readers discover English web fiction beyond one platform? | English web-fiction ecosystem guide covering serial sites, review indexes, newsletters, communities, and public catalogs | Add one or more English discovery feeds or WebNR-owned normalized indexes |
+| 2026-08-18 | How does the Chinese online-fiction discovery ecosystem work? | Reader map of original platforms, recommendation channels, discussion spaces, rankings, authorized reading routes, and local-reader workflows | Audit public or authorized Chinese feeds, indexes, and TXT collections |
+| 2026-08-20 | How do readers find Japanese web novels and translations? | Reader map of Japanese serialization platforms, recommendation communities, translation indexes, and public-domain alternatives | Audit Japanese public feeds, Aozora-style collections, and compatible catalog adapters |
+| 2026-08-22 | How do readers navigate Korean web novels and translated editions? | Reader map of Korean platforms, discovery routes, community discussion, regional access, and translation indexes | Audit public Korean catalog or discussion feeds and document Bridge/login boundaries |
+| 2026-08-24 | Where can readers find progression fantasy and LitRPG recommendations? | A recommendation-method guide combining platform tags, reader communities, review lists, and completion status | Add genre-focused feeds, search adapters, or curated WebNR source collections |
+| 2026-08-26 | Where can readers find fan fiction and transformative serial fiction? | AO3 and adjacent ecosystem guide focused on search, tags, bookmarks, collections, communities, and local reading | Audit public APIs/feeds and create link-based or export-based adapters where permitted |
+| 2026-08-28 | What are readers discussing this month? | First Web Novel Discussion Radar using public posts, recurring questions, rising titles or genres, and differences between communities | Add public discussion feeds and define a reproducible monthly sampling method |
+| 2026-08-30 | Which Legado source features work in WebNR today? | Versioned compatibility report with tested fields, fixtures, working examples, and clear capability levels | Integrate the strongest audited Legado candidates into the isolated compatibility corpus |
+| 2026-09-01 | How can readers use raw TXT collections that lack a catalog? | Guide to importing folders, filename-derived titles, encodings, provenance, and building a WebNR-owned source | Add one authorized or public-domain TXT collection through a generated WebNR catalog |
+| 2026-09-03 | Which sources stayed healthy during the first month? | First source directory and health report with last-tested dates, formats, languages, failures, and replacements | Retest all integrated sources, remove or downgrade failures, and publish the next candidate queue |
+
+## Daily source schedule
+
+Every day, including non-publication days:
+
+1. search for at least five new source or collection candidates;
+2. fully audit at least three candidates;
+3. target one passing integration;
+4. retest a rotating subset of existing sources;
+5. create a WebNR-owned adapter or normalized source when the origin is useful but
+   does not expose WebNR-native metadata;
+6. keep an explicit rejected/deferred queue with safe reasons, without publishing
+   private credentials, blocked endpoints, or circumvention instructions.
+
+Candidate discovery rotates through:
+
+- OPDS 1.2 and 2.0 catalogs;
+- RSS and Atom feeds from novel sites, authors, newsletters, and public libraries;
+- public-domain and authorized TXT or ebook collections;
+- public APIs, sitemaps, indexes, and downloadable catalog files;
+- public Legado source definitions for compatibility testing;
+- open-source CMS and self-hosted fiction catalogs;
+- reader-community lists and public recommendation feeds;
+- regional sources in Chinese, English, Japanese, Korean, and other evidenced
+  reader languages.
+
+## Recurring rhythm after the first 30 days
+
+Use a rolling eight-day cycle:
+
+- **Day 1 — Source discovery:** where-to-read guide, source directory, or source
+  health report.
+- **Day 3 — Comparison or recommendation:** app, platform, genre, reading route,
+  or curated source comparison.
+- **Day 5 — Community and discussion:** social-platform analysis, community map,
+  public recommendation pattern, or monthly/weekly radar.
+- **Day 7 — Ecosystem and compatibility:** regional ecosystem, Legado capability,
+  migration guide, or cross-platform reading workflow.
+
+At least one item per week should use `$research-blog` when the question requires
+cross-language, historical, social, or ecosystem-wide evidence. Other items may
+use direct first-hand testing and primary-source comparison.
+
+## Page acceptance checklist
+
+A scheduled asset is complete only when:
+
+- it answers the named reader question near the top;
+- its title and stable URL describe that question plainly;
+- recommendations explain selection method and evidence;
+- public discussion is sampled and contextualized rather than presented as total
+  community opinion;
+- source, platform, app, and channel facts have current verification dates;
+- related pages and relevant WebNR import routes are linked naturally;
+- canonical, sitemap, static rendered HTML, and intended navigation are correct;
+- both configured GA4 destinations and the exact build identity remain present;
+- the real pull request, CI, squash merge, production deployment, and public page
+  verification have completed.

--- a/.github/seo-data/plan.md
+++ b/.github/seo-data/plan.md
@@ -1,43 +1,288 @@
-# SEO plan
+# WebNR long-term product, reader-content, and source plan
 
-## Purpose
+## Primary outcome
 
-Make WebNR a trustworthy, local-first, account-free reader for user-owned, public-domain, and authorized books, with a fast first-use path, dependable offline behavior, durable bilingual help, and progressively tested interoperability with common open reading formats and clean-room Legado-compatible data and rules.
+Operate WebNR as three connected products:
+
+1. a dependable local-first reader;
+2. a reader-facing discovery and recommendation publication about web novels,
+   reading sites, apps, communities, channels, and sources;
+3. an open compatibility layer that can ingest Legado definitions, OPDS, feeds,
+   public TXT collections, and WebNR-owned source adapters.
+
+Reader discovery is the primary public-content program. Product manuals,
+compatibility documentation, and engineering reports support that program rather
+than define the site's editorial identity.
+
+## Readers and search intent
+
+The primary readers are people asking practical questions such as:
+
+- where can I read a particular kind of web novel;
+- where can I find working Legado sources;
+- which novel site or app fits a language, genre, device, or reading habit;
+- where do readers discuss and recommend novels;
+- what is currently popular in reader communities and why;
+- how do Royal Road, Scribble Hub, Wattpad, AO3, Novel Updates, platform forums,
+  Discord communities, Reddit communities, newsletters, video channels, and
+  other discovery routes differ;
+- which free, public-domain, self-published, or authorized collections can be
+  added to a reader;
+- how can a reader move sources and books between Legado and WebNR.
+
+Every public page should answer one concrete reader question and help the reader
+choose a site, app, source, community, channel, or reading route.
+
+## Reader-facing editorial programs
+
+### 1. Source finding and source health
+
+Publish continuously maintained guides to finding, testing, importing, and
+replacing sources. Cover Legado source discovery, public TXT collections, OPDS,
+RSS/Atom, public-domain libraries, author-published feeds, and WebNR-owned
+adapters. Source pages should report the last verification date, supported
+languages and formats, access requirements, common failures, and a clear reader
+use case.
+
+### 2. Novel sites, apps, and reading channels
+
+Compare sites and apps by the questions readers actually have: language, genre,
+serialization model, discovery quality, comments and reviews, offline behavior,
+export options, accessibility, account requirements, regional availability, and
+content model. Include newsletters, podcasts, YouTube channels, community lists,
+forums, and other public discovery channels when they materially help readers.
+
+### 3. Reader communities and public discussion
+
+Analyze public discussion across reader communities and social platforms. Useful
+outputs include community maps, recurring recommendation patterns, genre
+vocabulary, platform-specific tastes, disagreement between communities, and
+monthly discussion reports. Preserve links and context, distinguish visible
+public discussion from editorial inference, and avoid presenting a few posts as
+community consensus.
+
+### 4. Recommendations and reading routes
+
+Create useful recommendation pages around a clear reader need: progression
+fantasy, LitRPG, romance, fan fiction, translated web novels, finished serials,
+short-form fiction, public-domain classics, or another evidenced demand. Explain
+why each work, platform, or channel fits the request, where it can be read, its
+status, language, length or serialization pattern when verifiable, and the source
+of the recommendation signal. Do not create generic title dumps.
+
+### 5. Regional and cross-platform ecosystem maps
+
+Maintain reader-oriented maps of Chinese, English, Japanese, Korean, fan-fiction,
+independent-serial, and translated-fiction ecosystems. Show how readers move
+between original platforms, translation indexes, community recommendations,
+apps, feeds, and local readers. Update pages when platforms, access routes, or
+community practices materially change.
+
+### Supporting product and compatibility documentation
+
+Continue adding WebNR manuals, troubleshooting, release notes, source-development
+documentation, benchmarks, and compatibility reports. These pages should support
+reader journeys and source integration. They are an auxiliary program rather
+than the default content choice.
+
+## Publication cadence
+
+- Deploy at least one substantial reader-facing content asset in every rolling
+  48-hour window.
+- Prefer a meaningful update to an established high-value page when it produces
+  more reader value than another URL.
+- Publish one research-heavy ecosystem or community analysis per week when the
+  evidence supports it.
+- Publish two practical guides, comparisons, recommendation pages, or source
+  discovery pages per week.
+- Publish one source-health, discussion-radar, or ecosystem update per week.
+- Technical manuals and release documentation are published when product work
+  creates a real reader need; they do not replace the reader-facing cadence by
+  default.
+
+A content asset does not qualify through a title, front matter, metadata, a short
+list, or a cosmetic freshness edit alone.
+
+## Search and indexing requirements
+
+Use stable descriptive URLs and titles that closely match the reader's actual
+question. Each page must:
+
+- give the practical answer near the beginning;
+- contain original testing, comparison, reporting, community analysis, source
+  audit, or editorial synthesis;
+- state the tested or observed date and applicable product or platform version
+  when relevant;
+- distinguish verified facts, public discussion, and editorial recommendation;
+- link naturally to related guides, source pages, platform comparisons, and
+  WebNR import routes;
+- have one canonical URL, appear in the sitemap and intended navigation, and
+  render as static indexable HTML;
+- avoid copied platform descriptions, keyword variants, mass-generated summaries,
+  fabricated popularity, and unsupported rankings;
+- be refreshed when source health, access routes, app behavior, or reader value
+  changes materially.
+
+Search traffic is evidence, not the sole purpose. The content should remain
+useful when read directly or cited by another search or answer system.
+
+## Research skill use
+
+Use the pinned `$research-blog` skill for topics requiring broad ecosystem,
+historical, cross-language, social-platform, or contested analysis. This includes
+multi-round public-web Deep Research and Sider Scholar, all materially relevant
+languages, at least 5,000 Chinese main-text characters, normally at least 40
+substantive sources split between academic and primary/community/platform
+material, counterevidence, original synthesis, claim-level citations, complete
+references, literal-negation scanning, defensive-semantic review, and verified
+production delivery.
+
+Do not mechanically apply the research-paper source floor to a hands-on guide,
+source health report, app walkthrough, or benchmark. Those pages instead require
+current first-hand testing, reproducible fixtures or measurements, and primary
+sources such as official documentation, standards, public feeds, and project
+source code.
+
+## Daily source discovery and integration
+
+Every daily operating cycle must:
+
+1. discover at least five new candidate sources or collections;
+2. perform a full audit of at least three candidates;
+3. attempt to integrate at least one passing candidate;
+4. record safe rejection reasons for candidates that fail;
+5. retest previously integrated sources and repair, downgrade, or remove broken
+   entries.
+
+The target is one new usable source per day, not one unreviewed link per day. If
+no candidate passes, continue discovery and ship the day's product or content
+work without lowering the source bar.
+
+### Source forms WebNR may create
+
+A candidate does not need to be natively WebNR-compatible. WebNR may create and
+maintain:
+
+- a native WebNR repository definition;
+- an OPDS 1.2 or OPDS 2.0 adapter;
+- an RSS or Atom adapter;
+- a Legado-to-WebNR compatibility adapter;
+- a normalized catalog generated from a public website index, sitemap, API, or
+  authorized feed;
+- a static source for an authorized or public-domain TXT collection;
+- a WebNR-owned source that combines several compatible public feeds while
+  retaining provenance and direct acquisition links.
+
+Metadata from the origin is optional. A TXT collection may begin with filenames
+and direct files. WebNR may derive a display title from the filename and mark
+unknown fields as unknown. Never invent authorship, license, provenance, update
+status, or popularity. Cache or host book content only when the applicable
+license or authorization permits it; otherwise index metadata and link to the
+origin.
+
+### Source audit
+
+For each candidate, verify and record internally or in the source registry as
+appropriate:
+
+- origin, maintainer, and public URL;
+- license, public-domain status, author authorization, or other distribution
+  basis;
+- terms, robots behavior, and rate limits;
+- supported language, format, and catalog size when verifiable;
+- search, browse, detail, table-of-contents, content, feed, or direct-file
+  behavior relevant to the source type;
+- HTTPS, redirects, CORS, cookies, login, JavaScript, WebView, and Bridge needs;
+- requested domains and capability/permission manifest;
+- timeout, pagination, maximum response, encoding, and failure behavior;
+- at least one versioned fixture and a reproducible health check;
+- compatibility level, last tested date, and known limitations;
+- duplication with existing sources and reader value added.
+
+Do not integrate sources whose normal operation depends on bypassing login,
+payment, DRM, captchas, robots, access controls, or unauthorized redistribution.
+
+## Legado compatibility objective
+
+Pursue broad clean-room compatibility rather than requiring publishers to adopt
+WebNR first.
+
+### Compatibility phases
+
+1. **Import and inspect** — parse common Legado JSON, preserve unknown fields,
+   show supported and ignored fields, and produce a compatibility report.
+2. **Declarative reading flow** — support common search, book information,
+   table-of-contents, content, pagination, CSS, XPath, JSONPath, regular-expression,
+   headers, charset, and replacement rules through versioned fixtures.
+3. **Stateful rules** — add controlled cookies, variables, login-state import,
+   rate limits, and source-specific state with explicit permissions.
+4. **Restricted scripting** — execute required JavaScript in a capability-limited,
+   timed, memory-limited worker or isolated runtime.
+5. **Bridge-dependent behavior** — expose optional browser-extension or desktop
+   Bridge support for WebView and cross-origin capabilities that a normal web
+   page cannot provide.
+
+Each public claim must name the tested compatibility level and fixture-suite
+version. Third-party Legado definitions may enter an isolated compatibility
+corpus before official recommendation.
+
+## Technical operations
+
+Perform a concentrated repair pass for all currently confirmed technical debt
+instead of spreading known repairs across artificial daily increments. After the
+repair pass, use daily operation for production monitoring, regression tests,
+source health, dependency/security checks, and same-cycle bug fixes.
+
+Product priorities are:
+
+1. backup, restore, and versioned browser-storage migration;
+2. end-to-end import, reading, offline, accessibility, and update tests;
+3. robust TXT encoding, chapters, large-file handling, search, bookmarks, and
+   notes;
+4. stable releases and rollback;
+5. real EPUB parsing and safe rendering;
+6. the Legado compatibility phases above.
+
+## First 90 days
+
+### Days 1–30
+
+- complete the current technical repair pass;
+- establish the reader-facing content program and internal-link structure;
+- publish the first 15 scheduled content assets;
+- discover at least 150 source candidates, fully audit at least 90, and target 30
+  passing integrations;
+- ship initial OPDS, RSS/Atom, TXT-collection, and Legado import fixtures;
+- publish a source directory with health and last-tested information.
+
+### Days 31–60
+
+- expand regional ecosystem and platform comparison coverage;
+- publish recurring public-discussion and source-health reports;
+- implement common declarative Legado search, detail, TOC, and content rules;
+- add source health automation and a compatibility dashboard;
+- use Search Console evidence to consolidate or expand pages by reader intent.
+
+### Days 61–90
+
+- deepen recommendation programs by genre and reading route;
+- add restricted scripting or Bridge design where fixtures justify it;
+- publish measured app, source, and compatibility comparisons;
+- establish a repeatable community contribution route for source reports,
+  corrections, recommendations, and compatibility fixtures.
 
 ## Success signals
 
-- Search visibility: Search Console clicks, impressions, click-through rate, and query/page coverage once exports become available.
-- Acquisition quality: people arriving on public pages can understand WebNR, import supported content, and start reading without developer documentation.
-- Product activation: publicly testable completion of local file import, URL import, reading, offline installation, backup/restore, and return-to-progress journeys without collecting book titles, reading content, history, or source URLs.
-- Technical quality: successful PR checks, production deployment tied to the exact squash commit, valid metadata, accessible controls, working offline shell, current supported dependencies, tested storage migrations, and no broken public links.
-- Compatibility: a versioned public fixture suite reports supported TXT, EPUB, repository, and later Legado-compatible fields and rules without claiming untested full compatibility.
-- Trust: privacy documentation and runtime behavior remain consistent; official registries contain only public-domain, self-owned, or explicitly authorized sources.
-- Daily progress: at least one meaningful user-visible application or durable help-content improvement is deployed and verified each local calendar day.
+- indexed reader-facing pages and growth in relevant Search Console query/page
+  coverage;
+- readers reaching source, platform, app, community, and recommendation pages
+  and then opening WebNR or an appropriate origin;
+- passing source integrations, source-health rate, and repair time;
+- Legado fixture coverage by capability level;
+- successful import-to-reading and backup/restore journeys;
+- useful community corrections and source contributions;
+- exact PR, CI, deployment, and public verification for every published change.
 
-## Product-led content system
-
-Public content must originate from real product behavior, compatibility work, user problems, test fixtures, error codes, releases, or measured benchmarks. Priority formats are:
-
-1. verified getting-started and task guides;
-2. stable troubleshooting pages tied to reproducible errors;
-3. format and Legado-compatibility matrices with versioned fixtures;
-4. release notes, migration guides, security and privacy explanations;
-5. measured import, storage, rendering, offline, accessibility, and compatibility reports.
-
-Do not publish generic AI-writing articles, keyword-variant pages, fabricated benchmarks, untested compatibility claims, copied third-party documentation, or mass-generated thin content.
-
-## Operating constraints
-
-- Raw analytics stay outside Git.
-- Never collect or publish imported filenames, novel titles, reading content, reading history, source URLs, cookies, credentials, or other user-level data.
-- Every automated change uses a fresh branch and a real non-draft pull request.
-- One pull request contains one coherent outcome, but a daily cycle may and should use multiple focused pull requests to repair independent confirmed defects.
-- Required and expected CI must pass before the final automated self-review.
-- A clean final review is followed by squash merge; human review is not needed.
-- Site changes wait for the exact squash commit's production deployment and public verification.
-- Post-merge evidence is recorded through a metadata-only closeout pull request that follows the same CI, self-review, and squash-merge rules.
-- A metadata-only update never satisfies the daily user-visible production requirement.
-- Normal operation does not require human approval.
-- Legado interoperability must be clean-room, capability-limited, versioned, and described as compatibility rather than affiliation; WebNR does not bundle books or unreviewed high-risk sources.
-
-Short-term fixes and one-off remediation details belong in daily records or focused GitHub issues. Durable architecture, compatibility levels, content standards, and operating rules belong here.
+Short-term incidents belong in daily records or issues. This file owns durable
+reader positioning, content cadence, source growth, compatibility goals, and the
+90-day operating program.

--- a/.github/seo-data/promotion.md
+++ b/.github/seo-data/promotion.md
@@ -1,30 +1,89 @@
-# Promotion strategy
+# Reader distribution and community strategy
 
 ## Audience
 
-- Primary audience: readers who want a private, account-free browser reader for TXT web novels and long-form text.
-- Problems addressed: opening large TXT files, handling common Chinese encodings, reading offline, preserving progress locally, and using paged, scrolling, dark-mode, and text-to-speech reading.
-- Useful proof: the public WebNR application, documentation, source repository, release history, and reproducible privacy and offline behavior.
+WebNR serves readers who want to discover, compare, collect, and read web novels
+across sites, apps, communities, feeds, TXT collections, and local-reader tools.
+The primary public value is helping a reader answer:
 
-## Channels
+- where to read;
+- what to read;
+- which source, site, app, or channel to use;
+- where other readers discuss a genre or title;
+- how to import or migrate the result into WebNR or Legado-compatible workflows.
 
-| Channel | Public account or community | Content format | Cadence | Status |
-| --- | --- | --- | --- | --- |
-| Search | WebNR application and documentation | durable product pages and task-focused guides | continuous | active |
-| GitHub | `AutoArchive/webNR` | releases, changelogs, issues, and technical evidence | as earned | active |
-| Relevant reader and open-source communities | community-specific public spaces | useful native tutorials and release notes | only when relevant | planned |
+Product manuals and developer documentation support these reader journeys.
 
-## Operating rules
+## Distribution channels
 
-- Lead with useful native content and verifiable public evidence.
-- Match each channel's community rules and content format.
-- Do not spam, fabricate engagement, impersonate people, or hide automation.
-- Do not promote access to unauthorized copyrighted content; focus on the reader, user-owned files, public-domain works, and authorized sources.
-- Never store credentials, private account IDs, emails, private contacts, or unpublished business strategy here.
-- Record executed promotion in the corresponding daily report.
+| Channel | Reader-facing use | Cadence |
+| --- | --- | --- |
+| Search and answer engines | Stable guides, comparisons, source directories, ecosystem maps, community analysis, and recommendations | One substantial asset every 48 hours |
+| WebNR documentation RSS | New and materially updated reader pages, source reports, release notes, and discussion radar | Automatic with publication |
+| GitHub | Releases, roadmap, source integrations, compatibility fixtures, issues, and contribution opportunities | As work ships |
+| Reddit and public forums | Native answers, source reports, comparisons, and release notes that directly answer an existing discussion | Only when relevant and allowed |
+| Discord and community directories | Public channel guides, source-health notices, compatibility reports, and contribution invitations | Community-specific and non-spammy |
+| Novel and translation communities | Platform guides, migration help, source compatibility, and reader-route explanations | When the community's rules and topic fit |
+| Video, podcast, newsletter, and social channels | Curated directories and analysis of channels that materially help readers discover fiction | Updated when verified |
+
+Do not create promotional accounts or post automatically merely to satisfy a
+cadence. Publication on WebNR is the default; external distribution follows only
+when the content natively helps that community.
+
+## Reader-content standards
+
+- Lead with the answer to a real reader question.
+- Explain selection, comparison, recommendation, or social-discussion sampling
+  methods.
+- Separate platform facts, public reader discussion, and WebNR editorial
+  judgment.
+- Use firsthand testing and primary sources wherever possible.
+- Link to origin sites, communities, and creators rather than copying their
+  descriptions or content.
+- State last-verified dates and update pages when access, source health, regional
+  availability, or reader value changes.
+- Prefer useful corrections and substantive updates over new keyword variants.
+- Never fabricate popularity, consensus, rankings, comments, endorsements, or
+  community participation.
+
+## Community listening
+
+Public social-media and community discussion may be used to identify reader
+questions, recommendation patterns, terminology, platform differences, and topic
+changes. Use a reproducible sample appropriate to the claim. Record platform,
+public date window, query or community scope, and clear limits. Quote sparingly,
+link to the public source when appropriate, and avoid republishing private,
+deleted, paywalled, or closed-group conversation.
+
+A recurring Web Novel Discussion Radar should identify recurring questions and
+observable differences between communities. It must never present a handful of
+posts as the opinion of all readers.
+
+## Source and recommendation boundary
+
+- Recommend or integrate sources only after the audit in `plan.md` and
+  `daily-task.md`.
+- Officially promoted sources should be public-domain, author-authorized,
+  legitimately syndicated, link-based, or otherwise supported by a clear
+  distribution basis.
+- A source adapter may normalize feeds, indexes, or TXT collections, but must
+  preserve provenance and must not bypass authentication, payment, DRM, captchas,
+  robots, or access controls.
+- Recommendations may discuss commercial or account-based platforms without
+  integrating their content when readers benefit from an accurate comparison.
+- Legado compatibility descriptions must name the tested capability and fixture
+  version rather than imply affiliation or universal compatibility.
 
 ## Current campaigns
 
-- Establish clear privacy-first positioning and a complete first-use path before external promotion.
+1. Publish and maintain the 30-day reader-content calendar.
+2. Build a source directory with health, format, language, access, and last-tested
+   information.
+3. Publish the first Legado source-finding and verification guide.
+4. Establish recurring web-novel community maps and discussion radar.
+5. Invite source reports, corrections, compatibility fixtures, and reader-topic
+   requests through GitHub.
 
-Promotion execution should use a dedicated platform or promotion skill. This file defines durable site-specific strategy and routing, not tool credentials.
+Executed distribution and community work belongs in the normal daily record.
+Credentials, private account identifiers, private contacts, unpublished outreach,
+and raw user-level analytics stay outside Git.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -1,47 +1,42 @@
-# SEO status
+# WebNR operating status
 
 ## Current state
 
-- Last completed run: 2026-08-05 full product, content, deployment, production-evidence, and metadata-closeout cycle
-- Last completed closeout pull request: #42
-- Last completed closeout squash merge: `8d29606ea45c52b5cb247dc09c819c326a2f322e`
-- Latest site-change pull request: #44
-- Latest site-change squash merge: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
-- Analytics closeout pull request: #45
-- Analytics closeout initial Quality run: `31038751609`
-- Analytics closeout final squash merge: `6f8391f6a3f06a2da70e3c203ad4b89bb241ac48`
-- Last data window: Google Drive contains seven matching GA4 and Search Console CSV exports for `2026-07-27` through `2026-08-02`
-- Additional GA4 destination repair: in progress; `G-NL0WV2XMJN` is not yet deployed
-- Last successful attributable application deployment: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
-- Last successful attributable documentation deployment: `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`
-- Last successful public production verification: Quality run `31038751609`, Production evidence job `92417518169`
-- Last permanent production-evidence implementation: `cef991a8f4a7cc85dae2bbf88bbbebb36b736048`
+- Last completed product and analytics change: pull request #46, squash merge `4585ae5fc288894738c20524b534e22b547b108e`
+- Current application production build: `eaef3b70b3de3ef2527f5ff827f22b4ffef23537`
+- Current documentation production build: `4585ae5fc288894738c20524b534e22b547b108e`
+- Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
-- Skill submodule commit: `1140a11b9a366ddb611d19d691d81122184f7f9e`
+- Current skill submodule in the reader-content planning branch: `f6e9479e7d979620985ae6125cefc5e614978ea3`
+- Latest verified data window: Google Drive records GA4 and Search Console exports for `2026-07-27` through `2026-08-02`
+- Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
+
+The application build commit differs from the last product squash commit because a temporary branch-creation probe was accidentally written to and then removed from `main`. The final repository tree contains no probe file. The resulting application deployment is the current exact production identity and contains the same intended product behavior plus the removal commit.
 
 ## Current signals
 
-- Runtime analytics policy: mandatory on every managed site. WebNR owner policy is `full-url`.
-- Google Analytics 4: existing measurement `G-DGH8HNQKE4` is live; additional measurement `G-NL0WV2XMJN` is being added without replacing it.
-- Reader page views use `window.location.href` and pathname plus query string, so imported URLs in `?add=...` are included.
+- Runtime analytics is mandatory on both production sites.
+- Both sites expose GA4 destinations `G-DGH8HNQKE4` and `G-NL0WV2XMJN`.
+- WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
-- GA4 evidence: the `2026-07-27` through `2026-08-02` organic landing-page export is present in the configured Drive folder.
-- Google Search Console: six matching exports for queries, pages, countries, devices, search appearance, and dates are present for the same window; raw rows remain outside Git.
-- Infrastructure analytics: connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GA4, Search Console preparation, GitHub Pages analytics, or product delivery.
-- Application deployment artifact: `app-pages/build.json` identifies `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`; generated HTML contains the GA4 loader and full-URL configuration.
-- Documentation deployment artifact: `gh-pages/build.json` identifies `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`; generated HTML contains GA4 measurement `G-DGH8HNQKE4`.
-- Public production verification: Production evidence successfully requested the reader build, documentation build, and bilingual TXT troubleshooting page for exact source commit `11fc17fa574a9954b05c968dd7f9daa1d5e31e78`.
-- Documentation delivery: `https://autoarchive.github.io/webNR/` is the canonical working documentation URL.
-- Data behavior: imported book content and reading progress remain in browser storage. No custom analytics events containing local file contents or reading progress were added.
-- Application: local TXT and supported text-URL import are available; EPUB remains rejected until a real parser and versioned fixtures exist.
-- Autonomous operation: each local day requires a meaningful public update, mandatory analytics verification, and same-cycle repair of confirmed defects.
-- Branch cleanup: best-effort and nonblocking.
+- Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
+- Google Drive contains the configured GA4 organic landing-page export and six Search Console exports for queries, pages, countries, devices, search appearance, and dates for the latest recorded window.
+- Connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GitHub Pages production verification, GA4, Search Console, product delivery, content production, or source work.
+- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, dual-GA4 output assertions, and recorded public production evidence.
+- Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
+- Reader-content publishing now targets one substantial production asset per rolling 48-hour window.
+- Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt.
+- Source candidates may be adapted through WebNR-owned definitions, OPDS/RSS adapters, normalized catalogs, Legado wrappers, or authorized/public-domain TXT collections.
+- Legado compatibility claims remain tied to tested capability levels and fixture-suite versions.
+- Branch cleanup is best-effort and nonblocking.
 
 ## Active focus
 
-- Pass the final metadata-corrected closeout head through Web quality, Documentation quality, SEO data contract, and Production evidence.
-- Perform a complete final diff and check review, then squash-merge pull request #45.
-- Re-enable the daily WebNR operator with the working documentation URL and mandatory `full-url` analytics policy.
-- Next product milestones: backup/restore, IndexedDB migrations, E2E/accessibility/offline tests, stable releases, real EPUB parsing, and versioned clean-room Legado compatibility fixtures.
+1. Merge and adopt the reader-facing operating plan and 30-day editorial calendar.
+2. Complete the concentrated repair pass for remaining confirmed technical debt.
+3. Publish the first reader guide: finding and verifying working Legado sources.
+4. Discover at least five source candidates, fully audit at least three, and target the first passing daily integration.
+5. Build the initial isolated Legado compatibility corpus and source-health model.
+6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 
-This file is the current verified summary. Detailed history belongs in `daily/`.
+Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,8 +3,8 @@
 ## Current state
 
 - Last completed product and analytics change: pull request #46, squash merge `4585ae5fc288894738c20524b534e22b547b108e`
-- Current application production build: `eaef3b70b3de3ef2527f5ff827f22b4ffef23537`
-- Current documentation production build: `4585ae5fc288894738c20524b534e22b547b108e`
+- Last successful attributable application deployment: `eaef3b70b3de3ef2527f5ff827f22b4ffef23537`
+- Last successful attributable documentation deployment: `4585ae5fc288894738c20524b534e22b547b108e`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule in the reader-content planning branch: `f6e9479e7d979620985ae6125cefc5e614978ea3`
@@ -39,4 +39,4 @@ The application build commit differs from the last product squash commit because
 5. Build the initial isolated Legado compatibility corpus and source-health model.
 6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 
-Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities.
+Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities. The two `Last successful attributable ... deployment` lines are stable machine-readable interfaces used by `scripts/verify-production-builds.mjs` and must retain their exact labels.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -8,7 +8,7 @@
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule in the reader-content planning branch: `f6e9479e7d979620985ae6125cefc5e614978ea3`
-- Latest verified data window: Google Drive records GA4 and Search Console exports for `2026-07-27` through `2026-08-02`
+- Current analytics export state: the configured Google Drive folder is accessible but a direct parent-folder query on 2026-08-05 returned no visible documents; previous repository records describing a `2026-07-27` through `2026-08-02` export window are not treated as currently reverified evidence
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
 
 The application build commit differs from the last product squash commit because a temporary branch-creation probe was accidentally written to and then removed from `main`. The final repository tree contains no probe file. The resulting application deployment is the current exact production identity and contains the same intended product behavior plus the removal commit.
@@ -20,7 +20,7 @@ The application build commit differs from the last product squash commit because
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
-- Google Drive contains the configured GA4 organic landing-page export and six Search Console exports for queries, pages, countries, devices, search appearance, and dates for the latest recorded window.
+- Google Drive is connected and the configured folder exists, but the current folder-content query returned no visible GA4 or Search Console files. Missing exports are recorded as unavailable and never converted into zero traffic.
 - Connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GitHub Pages production verification, GA4, Search Console, product delivery, content production, or source work.
 - Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, dual-GA4 output assertions, and recorded public production evidence.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
@@ -37,6 +37,7 @@ The application build commit differs from the last product squash commit because
 3. Publish the first reader guide: finding and verifying working Legado sources.
 4. Discover at least five source candidates, fully audit at least three, and target the first passing daily integration.
 5. Build the initial isolated Legado compatibility corpus and source-health model.
-6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
+6. Re-establish current GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
+7. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 
 Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities. The two `Last successful attributable ... deployment` lines are stable machine-readable interfaces used by `scripts/verify-production-builds.mjs` and must retain their exact labels.

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - '.github/seo-data/**'
+      - '.github/seo-skills'
       - '.github/requirements-docs.txt'
       - '.github/workflows/publish-docs-pages.yml'
       - '.github/workflows/quality.yml'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -90,24 +90,6 @@ jobs:
             exit 1
           fi
 
-  seo-data:
-    name: SEO data contract
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout repository and skills
-        uses: actions/checkout@v5
-        with:
-          submodules: recursive
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Validate public SEO operating data
-        run: >-
-          python .github/seo-skills/scripts/validate_seo_data.py
-          --data-root .github/seo-data
-
   production-evidence:
     name: Production evidence
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Goal

Shift WebNR's durable operating plan from primarily technical documentation to reader-facing discovery, recommendation, source, community, and ecosystem content, while keeping product manuals as supporting material.

## Reader-content program

- publish one substantial reader-facing asset in every rolling 48-hour window
- focus on where to read, what to read, reader communities, social-media discussion, apps and channels, regional ecosystems, Legado source discovery, and migration
- add a dated 30-day calendar from 2026-08-06 through 2026-09-03
- require stable descriptive URLs, direct answers, firsthand testing or original analysis, current verification dates, internal links, canonical, sitemap, and static rendered output
- use `$research-blog` for research-heavy cross-language, historical, social, and ecosystem topics

## Daily source program

- discover at least five candidate sources or collections every day
- fully audit at least three
- target one passing integration
- allow WebNR-owned native definitions, OPDS/RSS adapters, normalized feeds, Legado wrappers, and static public-domain or authorized TXT catalogs
- do not require complete origin metadata; derive safe display titles from filenames and leave unknown fields unknown
- preserve provenance and distribution basis and never bypass authentication, payment, DRM, captchas, robots, or access controls

## Legado direction

Define phased clean-room compatibility for JSON inspection, common declarative search/detail/TOC/content rules, stateful behavior, restricted scripting, and optional Bridge-dependent WebView capabilities. Public compatibility claims remain tied to versioned fixtures and capability levels.

## Shared skill and CI adoption

- update `.github/seo-skills` from `1140a11b9a366ddb611d19d691d81122184f7f9e` to `f6e9479e7d979620985ae6125cefc5e614978ea3` after reviewing the complete nine-commit upstream diff
- adopt current `$operate-seo-site`, `$research-blog`, and `$deliver-github-pr` interfaces
- remove the WebNR CI job that called the removed upstream SEO-data validator
- keep WebNR's application, documentation, analytics, and production-evidence checks
- ignore `.github/seo-skills` in the application deployment workflow so skill-only changes no longer produce meaningless app deployments
- preserve the two machine-readable deployment labels required by `scripts/verify-production-builds.mjs`

## Files

- `.github/seo-data/plan.md`
- `.github/seo-data/editorial-calendar.md`
- `.github/seo-data/daily-task.md`
- `.github/seo-data/promotion.md`
- `.github/seo-data/status.md`
- `.github/seo-skills`
- `.github/workflows/quality.yml`
- `.github/workflows/nextjs.yml`

## Validation

Final Quality run `31062260891` passed:

- dependency audit
- ESLint
- TypeScript
- production Next.js build and dual-GA4 assertions
- strict MkDocs build and dual-GA4 assertions
- recorded application and documentation production evidence

The final diff was reviewed from scratch for reader-first scope, source audit and authorization boundaries, Legado compatibility wording, research-skill use, stable production-evidence interfaces, submodule compatibility, and unrelated application behavior. The current Google Drive folder was directly queried; it contained no visible export documents, so `status.md` now reports exports as unavailable rather than zero or currently verified.

## Production effect

This pull request changes durable operating instructions and CI/submodule compatibility. It does not publish a new reader article or change current application behavior. Subsequent scheduled cycles will execute the calendar through separate focused product, content, and source pull requests.