### PR TITLE
docs: close out first reader-source operating cycle

### DIFF
--- a/.github/seo-data/daily/2026-08-06.md
+++ b/.github/seo-data/daily/2026-08-06.md
@@ -11,26 +11,25 @@ Complete the first repository-authoritative daily cycle: analyze all available e
 - Analytics target: latest finalized 28 days with a 3-day lag.
 - Google Drive: the exact configured folder exists; a direct parent-folder query returned no visible files. GA4 and Search Console aggregates, 7-day comparison, and 28-day comparison are unavailable rather than zero.
 - Cloudflare: connected accounts do not expose the `webnovel.win` zone; infrastructure traffic is unavailable.
-- GitHub: latest starting `main` was `1e511c1fab787e83f710b4b0ee15b9c9f1624df8`. No open WebNR automation pull request existed at cycle start. Open Dependabot pull requests #7, #8, #9, #28, and #29 remain contributor-owned and were not taken over.
-- Dependency state: the current lockfile already resolves `js-yaml` 4.1.1; the repository dependency audit, lint, typecheck, and production build remain authoritative for this cycle. The Next.js 16 proposals in #28 and #29 require a separate major-version compatibility review and are not silently bundled into source work.
-- Production application evidence: `app-pages/build.json` identifies `eaef3b70b3de3ef2527f5ff827f22b4ffef23537`.
-- Production documentation evidence: `gh-pages/build.json` identifies `4585ae5fc288894738c20524b534e22b547b108e`.
-- Public reader: the canonical application returns the Novel Reader interface and an empty-library state.
+- GitHub: starting `main` was `1e511c1fab787e83f710b4b0ee15b9c9f1624df8`. Open Dependabot pull requests #7, #8, #9, #28, and #29 remained contributor-owned and were not taken over.
+- Dependency state: the current lockfile already resolves `js-yaml` 4.1.1. The successful final Web quality job included dependency audit, lint, typecheck, and a production build. The Next.js 16 proposals in #28 and #29 remain separate contributor-owned major-version upgrades.
+- Production application before this delivery identified `eaef3b70b3de3ef2527f5ff827f22b4ffef23537`; after delivery `app-pages/build.json` identifies the exact squash commit `b5264279e0d728ada0934479ef1d800792b8e5fb`.
+- Production documentation before this delivery identified `4585ae5fc288894738c20524b534e22b547b108e`; after delivery `gh-pages/build.json` identifies the exact squash commit `b5264279e0d728ada0934479ef1d800792b8e5fb`.
 - Search evidence: current provider exports are missing, so no claim about traffic, demand volume, ranking movement, or indexed-page performance is made.
 
 ## Analysis
 
 ### Acquisition and search
 
-The data routes required for quantitative acquisition analysis are unavailable in the configured Drive folder. The first reader-facing publication therefore follows the repository's dated editorial calendar rather than an invented traffic signal. Its stable question is source finding and source validation, a prerequisite for the planned source directory, Legado migration coverage, and future Search Console query grouping.
+The configured quantitative acquisition routes were unavailable in the Drive folder. The reader-facing publication therefore followed the dated editorial calendar rather than an invented traffic signal. Its stable question is source finding and source validation, a prerequisite for the planned source directory, Legado migration coverage, and future Search Console query grouping.
 
 ### Content and community
 
-The rolling 48-hour reader-content window contains no previously deployed reader discovery asset. The 2026-08-06 calendar item is due. Public evidence sampled for the guide includes the current `gedoor/legado` GitHub announcement, Project Gutenberg access, licensing, linking, and OPDS policies, Standard Ebooks feed access rules, Wikisource licensing, and public community source repositories and issue history. Public posts and repositories are treated as examples and audit leads, not universal reader consensus.
+The rolling 48-hour reader-content window contained no previously deployed reader-discovery asset, so the 2026-08-06 calendar item was due. Public evidence sampled for the guide included the current `gedoor/legado` announcement, Project Gutenberg access/licensing/linking/OPDS policies, Standard Ebooks feed access rules, Wikisource licensing, and public community source repositories and issue history. Public posts and repositories were treated as examples and audit leads rather than universal reader consensus.
 
 ### Product and delivery
 
-Repository-source ingestion contained confirmed defects relevant to today's source program:
+Repository-source ingestion contained confirmed defects relevant to the source program:
 
 1. absent dates were replaced with the current time, fabricating freshness;
 2. repository YAML had no streaming response-size bound when `Content-Length` was absent;
@@ -38,9 +37,9 @@ Repository-source ingestion contained confirmed defects relevant to today's sour
 4. malformed per-entry YAML values could throw during string and array operations;
 5. a catalog entry without a download URL could render an invalid `?add=undefined` action.
 
-The repair adds explicit title/page/download fields, preserves absent dates as unknown, restricts source and item links to HTTP(S), stops reading an index as soon as it exceeds 5 MiB, validates the YAML top-level and item fields, hides unavailable item actions, and makes date sorting deterministic for unknown values.
+The repair added explicit title/page/download fields, preserved absent dates as unknown, restricted source and item links to HTTP(S), stopped reading an index above 5 MiB, validated the YAML top-level mapping and item fields, hid unavailable item actions, and made date sorting deterministic for unknown values.
 
-The first Web quality attempt failed before checkout because GitHub Actions could not resolve action download information and returned `Service Unavailable`. A later complete runner attempt reached TypeScript and correctly found that a component property was not narrowed inside an event callback; the source now stores the validated download URL in a local constant before rendering both import actions. Subsequent queued rerun attempts were cancelled by workflow concurrency while GitHub recalculated the pull-request merge ref. None of these states is accepted as passing evidence; the final merge-ref run must complete every expected job successfully before merge.
+Earlier CI attempts included a transient GitHub Actions `Service Unavailable`, a real TypeScript narrowing finding, and concurrency cancellations. The TypeScript finding was fixed on the same branch. None of the failed or cancelled attempts counted as completion. The final run `31126016604` completed successfully on head `39f5a3541316b190c3df316d9a51b59219ce9d7d` with Web quality, Documentation quality, and Production evidence all green.
 
 ### Source discovery and health
 
@@ -56,10 +55,10 @@ Six candidates or candidate families were discovered:
 Three full audits were completed:
 
 - **WebNR Originals — accepted and integrated.** The source is same-origin, project-authored, CC0, TXT-only, versioned, and free of authentication, scraping, cross-origin, payment, DRM, captcha, and redistribution dependencies.
-- **Project Gutenberg — catalog candidate accepted for adapter design, not directly integrated today.** Official policy supports machine-readable catalog and OPDS use with a contactable User-Agent and browser-like request rate, prohibits high-volume deep-linking, and prefers canonical ebook landing pages or self-hosted catalog data. Copyright status is evaluated under United States law, historical authorized entries may carry additional terms, and readers outside the United States must check local law and the license inside each ebook.
-- **Standard Ebooks — deferred.** New-release Atom/RSS feeds are public, while full ebook feeds have access conditions including an open-source-project route that requires contact and qualification. No restricted feed is presented as public.
+- **Project Gutenberg — accepted for adapter design, not directly integrated in this cycle.** Official policy supports machine-readable catalog and OPDS use with a contactable User-Agent and browser-like request rate, discourages high-volume direct-file linking, and prefers canonical ebook landing pages or locally hosted catalog data. Copyright status is evaluated under United States law; historical authorized entries and other jurisdictions require per-item review.
+- **Standard Ebooks — deferred.** New-release Atom/RSS feeds are public, while complete ebook feeds have access conditions including an open-source-project route that requires contact and qualification.
 
-Community Legado repositories are assigned to an isolated compatibility-corpus queue. A source-definition license does not establish target-site authorization, and the current official Legado repository announcement makes legal and provenance review especially important. Regional libraries remain in the candidate queue for per-work copyright, encoding, format, and attribution audit.
+Community Legado repositories remain in an isolated compatibility-corpus queue. A source-definition license does not establish target-site authorization. Regional public-text libraries remain candidates for per-work copyright, encoding, format, and attribution review.
 
 ## Decisions
 
@@ -70,34 +69,38 @@ Community Legado repositories are assigned to an isolated compatibility-corpus q
 5. **Community:** use public repositories and issue history as bounded evidence; continue broader community sampling for the scheduled community map and Discussion Radar.
 6. **Measurement:** preserve dual GA4 and full-URL reporting; mark provider exports unavailable; do not infer zero demand.
 
-## Work delivered in the main change
+## Work delivered
 
-- Added a reader-facing Chinese guide: `docs/blog/posts/2026-08-06-legado-source-guide.md`.
-- Added first-party source URL `https://app.webnovel.win/sources/webnr-originals`.
-- Added original CC0 TXT story 《灯下索引》 and source terms.
+- Published `docs/blog/posts/2026-08-06-legado-source-guide.md`.
+- Published first-party source `https://app.webnovel.win/sources/webnr-originals`.
+- Published original CC0 TXT story 《灯下索引》 and source terms.
 - Added explicit source-catalog title, canonical-page, and download-link support.
 - Removed fabricated current-date fallbacks for missing catalog metadata.
-- Added bounded streaming, repository index shape, item-field, protocol, and URL validation.
+- Added bounded streaming, repository-index shape, item-field, protocol, and URL validation.
 - Prevented missing download links from producing invalid import actions.
 - Added CI assertions for the source catalog, TXT fixture, generated guide, dual GA4, application build, and strict documentation build.
-- Checked the shared skill upstream. Commits after the pinned version add an optional static-site snapshot helper; no pointer update is required for this outcome.
+- Reviewed shared-skill commits after the pinned version; the newer commits add an optional static-site snapshot helper, so no pointer update was required for this outcome.
 
-## Delivery
+## Final delivery and verification
 
 - Main branch: `seo/legado-source-guide-starter`
 - Main pull request: #49
-- Current reviewed head: pending final CI after TypeScript narrowing repair
-- Expected checks: Web quality, Documentation quality, Production evidence
-- Main squash commit: pending
-- Application deployment: pending
-- Documentation deployment: pending
-- Public source verification: pending
-- Public guide verification: pending
-- Closeout pull request: pending
+- Final reviewed head: `39f5a3541316b190c3df316d9a51b59219ce9d7d`
+- Final Quality run: `31126016604`, success
+- Successful jobs: Web quality, Documentation quality, Production evidence
+- Main squash commit: `b5264279e0d728ada0934479ef1d800792b8e5fb`
+- Application deployment: `app-pages/build.json` identifies `b5264279e0d728ada0934479ef1d800792b8e5fb`, built at `2026-08-07T16:32:51.117Z`
+- Documentation deployment: `gh-pages/build.json` identifies `b5264279e0d728ada0934479ef1d800792b8e5fb`, built at `2026-08-07T16:32:45.725114+00:00`
+- Public guide artifact: `/blog/2026/08/06/legado-source-guide/` exists in the exact documentation build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`
+- Public source artifact: `/sources/webnr-originals/search_index.yml`, source terms, and the CC0 TXT fixture exist in the exact application build
+- Analytics: the final application and documentation quality gates verified both configured GA4 IDs; application output retains the required full-URL expressions and disabled Google-signals/ad-personalization settings
+- Final review: complete nine-file PR diff, generated outputs, source rights, source links, malformed-input behavior, data boundaries, analytics behavior, and affected/unaffected production expectations were reviewed from scratch after green CI
+- Closeout branch: `seo/closeout-2026-08-06-source-guide`
+- Closeout pull request: pending this metadata delivery
 
 ## Uncertainty and next evidence
 
-- Current GA4 and Search Console export rows are absent from the configured Drive folder; the next evidence required is a finalized provider export with the documented filename patterns.
+- Current GA4 and Search Console export rows remain absent from the configured Drive folder; the next evidence required is a finalized provider export with the documented filename patterns.
 - Project Gutenberg adapter behavior requires a design that honors official rate, linking, trademark, per-item licensing, and jurisdiction policies and avoids using browsers as uncontrolled bulk clients.
 - Community Legado definitions require per-target audit before any recommendation or runtime execution.
-- Search indexing and landing-page performance can only be assessed after the guide is deployed and finalized Search Console data becomes available.
+- Search indexing and landing-page performance can only be assessed after finalized Search Console data becomes available.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,16 +2,14 @@
 
 ## Current state
 
-- Last completed product and analytics change: pull request #46, squash merge `4585ae5fc288894738c20524b534e22b547b108e`
-- Last successful attributable application deployment: `eaef3b70b3de3ef2527f5ff827f22b4ffef23537`
-- Last successful attributable documentation deployment: `4585ae5fc288894738c20524b534e22b547b108e`
+- Last completed product, source, and reader-content change: pull request #49, squash merge `b5264279e0d728ada0934479ef1d800792b8e5fb`
+- Last successful attributable application deployment: `b5264279e0d728ada0934479ef1d800792b8e5fb`
+- Last successful attributable documentation deployment: `b5264279e0d728ada0934479ef1d800792b8e5fb`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
-- Current skill submodule in the reader-content planning branch: `f6e9479e7d979620985ae6125cefc5e614978ea3`
-- Current analytics export state: the configured Google Drive folder is accessible but a direct parent-folder query on 2026-08-05 returned no visible documents; previous repository records describing a `2026-07-27` through `2026-08-02` export window are not treated as currently reverified evidence
+- Current skill submodule: `f6e9479e7d979620985ae6125cefc5e614978ea3`
+- Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content checks have not exposed matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
-
-The application build commit differs from the last product squash commit because a temporary branch-creation probe was accidentally written to and then removed from `main`. The final repository tree contains no probe file. The resulting application deployment is the current exact production identity and contains the same intended product behavior plus the removal commit.
 
 ## Current signals
 
@@ -20,23 +18,26 @@ The application build commit differs from the last product squash commit because
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
-- Google Drive is connected and the configured folder exists, but the current folder-content query returned no visible GA4 or Search Console files. Missing exports are recorded as unavailable and never converted into zero traffic.
 - Connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GitHub Pages production verification, GA4, Search Console, product delivery, content production, or source work.
-- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, dual-GA4 output assertions, and recorded public production evidence.
+- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, dual-GA4 output assertions, first-party source output, and recorded public production evidence.
+- The first reader-discovery article, `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南`, is present in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
+- `WebNR Originals` is the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》.
+- Repository ingestion now preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
-- Reader-content publishing now targets one substantial production asset per rolling 48-hour window.
+- Reader-content publishing targets one substantial production asset per rolling 48-hour window. The next dated editorial slot is 2026-08-08: legal free novels and TXT collections.
 - Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt.
-- Source candidates may be adapted through WebNR-owned definitions, OPDS/RSS adapters, normalized catalogs, Legado wrappers, or authorized/public-domain TXT collections.
+- Project Gutenberg is the next adapter-design candidate under its official catalog, rate, linking, trademark, per-item licensing, and jurisdiction rules. Standard Ebooks remains deferred pending an applicable feed-access route.
+- Community Legado definitions remain isolated compatibility-corpus candidates until target-site authorization and health are audited.
 - Legado compatibility claims remain tied to tested capability levels and fixture-suite versions.
 - Branch cleanup is best-effort and nonblocking.
 
 ## Active focus
 
-1. Merge and adopt the reader-facing operating plan and 30-day editorial calendar.
-2. Complete the concentrated repair pass for remaining confirmed technical debt.
-3. Publish the first reader guide: finding and verifying working Legado sources.
-4. Discover at least five source candidates, fully audit at least three, and target the first passing daily integration.
-5. Build the initial isolated Legado compatibility corpus and source-health model.
+1. Complete the metadata closeout for pull request #49 without changing rendered production output.
+2. Run the 2026-08-07 data-analysis pass and source-health checks against the new exact production build.
+3. Discover at least five new source candidates, fully audit at least three, and target another safe source integration; prioritize Project Gutenberg-compatible catalog design and public/authorized regional collections.
+4. Prepare the 2026-08-08 reader asset on legal free novels and TXT collections without inventing demand where GA4/GSC exports remain unavailable.
+5. Continue the concentrated technical-repair pass and daily regression monitoring; confirmed low-risk defects are fixed in the same cycle.
 6. Re-establish current GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
 7. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 


### PR DESCRIPTION
## Closeout

Record final delivery evidence for the first repository-authoritative reader-source cycle.

- main PR #49 passed all expected Quality jobs after transient/corrected earlier attempts
- final reviewed head `39f5a3541316b190c3df316d9a51b59219ce9d7d`
- squash commit `b5264279e0d728ada0934479ef1d800792b8e5fb`
- `app-pages` and `gh-pages` both identify the exact squash commit
- generated Legado source guide has the intended canonical URL
- `WebNR Originals` catalog, terms, and CC0 TXT fixture exist in the exact application build
- dual GA4 and full-URL application assertions remained green
- current status advances to the 2026-08-07 analysis/source cycle and the 2026-08-08 reader-content slot

This is metadata-only. It changes no application or documentation-rendered content and should not create a new production deployment.