### PR TITLE
Add Aozora reader source and repair source identity

### DIFF
--- a/.github/seo-data/daily/2026-08-07.md
+++ b/.github/seo-data/daily/2026-08-07.md
@@ -1,0 +1,118 @@
+# WebNR operations — 2026-08-07
+
+## Scope
+
+Complete the next repository-authoritative daily cycle after pull requests #49 and #50: re-check all available data routes and exact production, retest the first integrated source, audit the next source queue, repair the source-identity defect exposed by same-origin catalogs, integrate a second safe WebNR-maintained source, preserve the rolling reader-content cadence, and deliver through the normal PR/CI/deployment/closeout lifecycle.
+
+## Evidence and data quality
+
+- Local operating date: 2026-08-07 (`America/Los_Angeles`).
+- Starting `main`: `4004cf71197a87dc531a6a995dede4551b2cad44` after the metadata closeout for pull request #49.
+- Operational window: activity since the 2026-08-06 cycle plus the delayed final deployment/closeout completed on 2026-08-07.
+- Google Drive: the configured `webNR SEO Weekly CSV` folder still exists. A direct parent-folder query on 2026-08-07 returned no visible files, so GA4 and Search Console aggregates, 7-day comparisons, and 28-day comparisons remain unavailable rather than zero.
+- Cloudflare: the connected accounts still do not expose the `webnovel.win` zone according to the current repository state; infrastructure traffic remains unavailable and is not a blocker.
+- Application production: `app-pages/build.json` identifies `b5264279e0d728ada0934479ef1d800792b8e5fb`.
+- Documentation production: `gh-pages/build.json` identifies `b5264279e0d728ada0934479ef1d800792b8e5fb`.
+- Reader guide production: the exact documentation build contains `/blog/2026/08/06/legado-source-guide/` with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
+- Source production: the exact application build contains `WebNR Originals`, its source terms, catalog, and original CC0 TXT fixture.
+- Analytics implementation: the final successful application/documentation quality gates for the deployed commit verified both GA4 destinations. Application output retains full-browser-URL and pathname-plus-query expressions with Google signals and ad-personalization disabled.
+- Open contributor work remains contributor-owned. Dependabot or other contributor pull requests are observed but not taken over.
+
+## Analysis
+
+### Acquisition and search
+
+No finalized GA4 or Search Console export is currently visible in the configured Drive folder. Quantitative traffic, CTR, ranking, landing-page, and query-movement claims are therefore unavailable. The search decision continues to follow durable reader questions and the dated editorial plan instead of inventing demand. The newly deployed Legado guide is inside the rolling 48-hour content window, so a second long-form article is not due on 2026-08-07; the next dated content slot remains 2026-08-08.
+
+### Content and community
+
+The Legado source guide is now present in exact production and answers the scheduled source-finding question. No separate public-community sample is required for today's source-integration task. Public discussion evidence remains reserved for assignments that make community claims. The next reader asset will cover legal free novels and TXT collections and can incorporate the public/authorized source audits accumulated on 2026-08-06 and 2026-08-07.
+
+### Product and delivery
+
+The first same-origin source exposed a source-identity defect: `fetchRepoIndex()` derived repository names only from the hostname. Every WebNR-maintained source under `app.webnovel.win/sources/...` therefore received the same generic name `app`, making multiple vetted catalogs hard to distinguish in Discover. The current repair derives the repository identity from the source directory when available and refreshes stored repository metadata during both manual sync and `?repos=` re-import. This repairs new additions and lets previously stored same-origin sources acquire the corrected identity on their next sync.
+
+No other confirmed low-risk production defect was established from today's available evidence. Dependency audit, lint, typecheck, production build, strict documentation build, analytics assertions, and production-evidence checks remain the authoritative regression gates for the source change.
+
+### Source health
+
+`WebNR Originals` remains present in the exact application production build with its YAML catalog, source terms, and CC0 TXT fixture. Its same-origin static design has no third-party authentication, scraping, CORS, payment, DRM, or captcha dependency. The source-identity repair is the only confirmed source UX regression found in today's retest.
+
+## Candidate discovery
+
+At least five new source or collection candidates were added to the queue today:
+
+1. **National Diet Library Digital Collections / NDL Search** — Japanese bibliographic and digitized-material discovery through SRU, OpenSearch, OAI-PMH, open metadata subsets, persistent item URIs, and IIIF for eligible public material.
+2. **Open Library** — low-volume public book-discovery APIs plus monthly bulk data dumps; useful for reader discovery and availability links rather than as a high-traffic backend.
+3. **Library of Congress digital collections** — public JSON/YAML APIs without an API key, with rate limits and heterogeneous per-item rights/format data.
+4. **Gallica / Bibliothèque nationale de France** — a large public digital library with SRU/IIIF/data APIs and explicit content-use conditions; per-item and commercial-use rules require careful handling.
+5. **Project Runeberg** — Nordic digitized literature with strong public-domain value but copyright scope that varies by work and reader jurisdiction.
+
+Carried candidates from the prior queue were also deepened today: **Aozora Bunko** and **Wikisource**.
+
+## Full source audits
+
+### Aozora Bunko — accepted as a link-based source and integrated
+
+Official Aozora policy allows its book-card and shelf metadata to be downloaded and reused as bibliographic data under CC BY 4.0. Its linking rules allow links to book cards without permission and allow direct file links when the underlying work is out of copyright or otherwise freely reusable. Aozora also warns that translations have independent copyright and that individual files/data can contain errors.
+
+The current public cards confirm that common works are offered as ZIP-compressed ruby text in Shift_JIS plus XHTML. WebNR does not yet have a tested Aozora ZIP/Shift_JIS/ruby adapter, so today's safe integration is deliberately link-based: four verified official book cards are exposed through a same-origin WebNR catalog with no fabricated download URL. The selected starter entries are `吾輩は猫である`, `羅生門`, `走れメロス`, and `よだかの星`.
+
+Decision: integrate `https://app.webnovel.win/sources/aozora-starter` as a WebNR-maintained discovery source, attribute reused metadata to Aozora under CC BY 4.0, keep individual content on Aozora, and defer direct reading until format/encoding/annotation and per-work rights tests exist.
+
+### Wikisource — accepted for adapter design, deferred from runtime integration
+
+Wikisource requires hosted works to be public domain or released under CC BY-SA, while copyrightable editor contributions are licensed under CC BY-SA and GFDL. Its WS Export tool supports EPUB, PDF, and other export formats across language projects. These properties make Wikisource valuable for legal discovery and future export-based adapters, but a generic WebNR runtime source needs language-specific metadata, attribution, export-format handling, and per-work status checks.
+
+Decision: keep Wikisource in the adapter queue, prefer official work pages/exports and attribution, and avoid pretending that one global source definition can safely represent every language project and work status.
+
+### National Diet Library / NDL Search — accepted for discovery research, deferred from integration
+
+NDL Search exposes search APIs through SRU/OpenSearch/OpenURL and harvesting through OAI-PMH. NDL states that some API purposes or data providers require an application or provider permission; provider metadata can have its own credit requirements. The provider list includes open-data subsets, while digitized-content reuse conditions remain separate from metadata reuse. NDL Digital Collections also exposes persistent identifiers and IIIF manifests for eligible internet-public material.
+
+Decision: retain NDL as a high-value Japanese discovery candidate, but do not integrate until the exact provider subset, attribution, API-use procedure, request volume, and item-level content-rights behavior are fixed in a versioned adapter contract.
+
+## Other candidate findings
+
+- **Open Library:** official 2026 developer guidance explicitly supports open-source/mission-aligned low-volume human-facing discovery, asks clients to cache, identify themselves for regular use, limits unidentified requests to roughly 1 request/second and identified requests to roughly 3 requests/second, and directs bulk consumers to monthly dumps. Candidate for a low-frequency discovery adapter, not a general backend.
+- **Library of Congress:** public JSON/YAML APIs require no key and enforce rate limits. Candidate for link-based discovery of digitized material; item formats and rights are heterogeneous and require per-item handling.
+- **Gallica:** free/open browsing plus SRU/IIIF/data interfaces are available, but Gallica publishes explicit reuse conditions and separate commercial-use requirements. Candidate for a French discovery adapter after rights and API behavior are narrowed.
+- **Project Runeberg:** useful Nordic public-domain corpus candidate; its own copyright guidance emphasizes life-plus-70 and jurisdiction differences, so per-item review is required before redistribution or direct import.
+
+## Decisions
+
+1. **Technical:** repair same-origin source identity by deriving names from repository paths and refreshing stored metadata on sync/import.
+2. **Content:** keep the deployed Legado guide as the qualifying rolling-48-hour reader asset; prepare the scheduled 2026-08-08 legal-free-novel/TXT directory rather than creating a thin extra page today.
+3. **Source:** integrate Aozora Bunko Starter as a link-based, attributed, same-origin source; keep Wikisource and NDL in adapter design; add Open Library, Library of Congress, Gallica, and Project Runeberg to the candidate queue.
+4. **Search:** no new standalone search page today; use the next scheduled reader directory to expose the strongest verified public/authorized source routes and link to the existing Legado guide.
+5. **Community:** no community-wide claim or new community page today because no dedicated reproducible public sample was required for this source task.
+6. **Measurement:** preserve the dual-GA4 full-URL implementation, continue to mark GA4/GSC export evidence unavailable, and do not translate missing provider rows into zero traffic.
+
+## Work in progress
+
+- Branch: `seo/aozora-source-2026-08-07`
+- Add `public/sources/aozora-starter/search_index.yml` with four verified official Aozora book-card links.
+- Add `public/sources/aozora-starter/README.txt` with attribution, source terms, current link-only behavior, and last-verification date.
+- Change repository-name derivation from hostname-only to source-directory identity.
+- Refresh repository identity and counts during manual sync and `?repos=` re-import so existing same-origin sources repair themselves.
+- Extend Web quality to require both the WebNR Originals and Aozora source artifacts.
+- Shared-skill check: latest upstream remains `e7338af051ee9621b3033912d5c5751c7ebc241a`; the two commits after pinned `f6e9479e7d979620985ae6125cefc5e614978ea3` only add/clarify an optional static-site snapshot helper, so no pointer update is required for this outcome.
+
+## Delivery
+
+- Main pull request: pending
+- Expected checks: Web quality, Documentation quality, Production evidence
+- Final reviewed head: pending
+- Main squash commit: pending
+- Exact application deployment: pending
+- Documentation deployment: expected unchanged unless rendered documentation changes
+- Public Aozora source verification: pending
+- Closeout pull request: pending
+
+## Uncertainty and next evidence
+
+- GA4 and Search Console exports need to reappear in the configured Drive folder before traffic or search-movement conclusions can resume.
+- Aozora direct reading requires a tested ZIP/Shift_JIS/ruby-text or XHTML adapter and per-work rights handling; today's integration intentionally exposes official work pages only.
+- Wikisource needs a language-aware attribution/export design.
+- NDL needs an exact provider/use-contract decision before automated API integration.
+- The 2026-08-08 reader directory should use today's verified source policies and distinguish discovery links, direct imports, format adapters, and jurisdiction-dependent rights.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -53,7 +53,7 @@ jobs:
           grep -R -Fq 'window.location.pathname + window.location.search' out
           grep -R -Fq 'allow_google_signals' out
           grep -R -Fq 'allow_ad_personalization_signals' out
-      - name: Validate first-party source output
+      - name: Validate source output
         run: |
           set -eu
           test -f out/sources/webnr-originals/search_index.yml
@@ -62,6 +62,12 @@ jobs:
           grep -Fq 'title: 灯下索引' out/sources/webnr-originals/search_index.yml
           grep -Fq 'license: CC0-1.0' out/sources/webnr-originals/search_index.yml
           grep -Fq '《灯下索引》' out/sources/webnr-originals/stories/lantern-index.txt
+          test -f out/sources/aozora-starter/search_index.yml
+          test -f out/sources/aozora-starter/README.txt
+          grep -Fq 'title: 吾輩は猫である' out/sources/aozora-starter/search_index.yml
+          grep -Fq 'title: 羅生門' out/sources/aozora-starter/search_index.yml
+          grep -Fq 'license: CC-BY-4.0-metadata' out/sources/aozora-starter/search_index.yml
+          grep -Fq 'https://www.aozora.gr.jp/cards/000148/card789.html' out/sources/aozora-starter/search_index.yml
 
   docs:
     name: Documentation quality

--- a/app/components/discover/index.tsx
+++ b/app/components/discover/index.tsx
@@ -104,6 +104,13 @@ export function DiscoverView({ onViewChange }: DiscoverViewProps) {
       const index = await syncRepository(repo);
       const updatedRepo: LocalRepo = {
         ...repo,
+        meta: {
+          ...repo.meta,
+          name: index.name,
+          lastUpdated: index.lastSync,
+          novels: index.novels.length,
+          updatedNovels: index.updatedNovels,
+        },
         index,
         lastSync: new Date().toISOString(),
       };

--- a/app/lib/discover.ts
+++ b/app/lib/discover.ts
@@ -88,6 +88,19 @@ function siblingPath(entryPath: string, filename: string): string {
   return slash >= 0 ? `${entryPath.slice(0, slash + 1)}${filename}` : filename;
 }
 
+function repositoryName(indexUrl: URL): string {
+  const pathSegments = indexUrl.pathname.split('/').filter(Boolean);
+  const directory = pathSegments.length > 1 ? pathSegments[pathSegments.length - 2] : '';
+  if (directory) {
+    try {
+      return decodeURIComponent(directory);
+    } catch {
+      return directory;
+    }
+  }
+  return indexUrl.hostname;
+}
+
 // Repository management functions
 export async function fetchRepoIndex(url: string): Promise<RepoIndex> {
   try {
@@ -168,10 +181,8 @@ export async function fetchRepoIndex(url: string): Promise<RepoIndex> {
       });
     }
 
-    const repoName = indexUrl.hostname.split('.')[0];
-
     return {
-      name: repoName,
+      name: repositoryName(indexUrl),
       novels,
       updatedNovels: novels.length,
       lastSync: new Date().toISOString(),

--- a/app/lib/url-handlers.ts
+++ b/app/lib/url-handlers.ts
@@ -88,6 +88,13 @@ export async function handleRepoImport(
           const index = await syncRepository(existingRepo);
           const refreshedRepo: LocalRepo = {
             ...existingRepo,
+            meta: {
+              ...existingRepo.meta,
+              name: index.name,
+              lastUpdated: index.lastSync,
+              novels: index.novels.length,
+              updatedNovels: index.updatedNovels,
+            },
             index,
             lastSync: new Date().toISOString(),
           };

--- a/public/sources/aozora-starter/README.txt
+++ b/public/sources/aozora-starter/README.txt
@@ -5,6 +5,10 @@ Repository URL
 --------------
 https://app.webnovel.win/sources/aozora-starter
 
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Faozora-starter
+
 Purpose
 -------
 This WebNR-maintained source is a small, link-based discovery catalog for selected

--- a/public/sources/aozora-starter/README.txt
+++ b/public/sources/aozora-starter/README.txt
@@ -1,0 +1,43 @@
+青空文庫 Starter / Aozora Bunko Starter
+=======================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/aozora-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small, link-based discovery catalog for selected
+works in 青空文庫 (Aozora Bunko). It helps readers find the official book cards
+without pretending that WebNR can already ingest Aozora's ZIP/Shift_JIS text
+packages directly.
+
+Data and attribution
+--------------------
+Titles, authors, and official book-card links are derived from Aozora Bunko's
+public book-card/shelf data. Aozora Bunko states that its book-card and shelf
+metadata may be downloaded and reused under Creative Commons Attribution 4.0
+International.
+
+Source: https://www.aozora.gr.jp/
+Reuse criteria: https://www.aozora.gr.jp/guide/kijyunn.html
+Linking criteria: https://www.aozora.gr.jp/guide/linkkijyunn.html
+License for reused metadata: CC BY 4.0
+
+Content boundary
+----------------
+This starter catalog does not copy Aozora book files and does not deep-link their
+download files. Each item links to the official Aozora book card. Aozora notes that
+translation copyright and per-work rights still matter even when an original
+work is old, so future direct-import support will retain per-item rights checks.
+
+Current WebNR behavior
+----------------------
+The items are discovery links only. Aozora commonly distributes ruby text as ZIP
+archives encoded in Shift_JIS and also provides XHTML. WebNR will add direct
+reading only after a tested adapter can handle the relevant format, encoding,
+annotations, and rights information safely.
+
+Last verified
+-------------
+2026-08-07

--- a/public/sources/aozora-starter/search_index.yml
+++ b/public/sources/aozora-starter/search_index.yml
@@ -1,0 +1,59 @@
+aozora/wagahai-wa-neko-de-aru.md:
+  title: 吾輩は猫である
+  author: 夏目 漱石
+  description: 青空文庫の公式図書カードへのリンク。WebNR では現在、作品ページの発見用として提供し、ZIP/Shift_JIS 本文の直接取り込みは行わない。
+  page_url: https://www.aozora.gr.jp/cards/000148/card789.html
+  source: 青空文庫
+  license: CC-BY-4.0-metadata
+  tags:
+    - 青空文庫
+    - 日本文学
+    - 小説
+  categories:
+    - 公開テキスト案内
+  region: ja-JP
+
+aozora/rashomon.md:
+  title: 羅生門
+  author: 芥川 竜之介
+  description: 青空文庫の公式図書カードへのリンク。WebNR では現在、作品ページの発見用として提供し、ZIP/Shift_JIS 本文の直接取り込みは行わない。
+  page_url: https://www.aozora.gr.jp/cards/000879/card127.html
+  source: 青空文庫
+  license: CC-BY-4.0-metadata
+  tags:
+    - 青空文庫
+    - 日本文学
+    - 短編
+  categories:
+    - 公開テキスト案内
+  region: ja-JP
+
+aozora/hashire-merosu.md:
+  title: 走れメロス
+  author: 太宰 治
+  description: 青空文庫の公式図書カードへのリンク。WebNR では現在、作品ページの発見用として提供し、ZIP/Shift_JIS 本文の直接取り込みは行わない。
+  page_url: https://www.aozora.gr.jp/cards/000035/card1567.html
+  source: 青空文庫
+  license: CC-BY-4.0-metadata
+  tags:
+    - 青空文庫
+    - 日本文学
+    - 短編
+  categories:
+    - 公開テキスト案内
+  region: ja-JP
+
+aozora/yodaka-no-hoshi.md:
+  title: よだかの星
+  author: 宮沢 賢治
+  description: 青空文庫の公式図書カードへのリンク。WebNR では現在、作品ページの発見用として提供し、ZIP/Shift_JIS 本文の直接取り込みは行わない。
+  page_url: https://www.aozora.gr.jp/cards/000081/card473.html
+  source: 青空文庫
+  license: CC-BY-4.0-metadata
+  tags:
+    - 青空文庫
+    - 日本文学
+    - 童話
+  categories:
+    - 公開テキスト案内
+  region: ja-JP


### PR DESCRIPTION
## Outcome

Complete the 2026-08-07 source-growth cycle by integrating a second safe WebNR-maintained catalog and repairing the source-identity defect exposed by multiple same-origin repositories.

## Source integration

Add `https://app.webnovel.win/sources/aozora-starter` as a link-based Aozora Bunko discovery source.

- four verified official book-card links: `吾輩は猫である`, `羅生門`, `走れメロス`, and `よだかの星`
- metadata attribution to Aozora Bunko under its documented CC BY 4.0 book-card/shelf-data terms
- no copied Aozora book files and no direct file deep-links
- no fabricated download URL
- explicit link-only boundary until ZIP/Shift_JIS/ruby/XHTML handling and per-work rights checks have versioned tests
- one-click `?repos=` route documented in the source README

## Technical repair

`fetchRepoIndex()` previously derived repository identity from hostname only. Every source under `app.webnovel.win/sources/...` therefore appeared as the same generic `app` repository.

This change:

- derives repository identity from the source directory when present
- refreshes stored repository name/count/freshness metadata during manual sync
- applies the same repair to existing `?repos=` imports on refresh
- leaves unknown novel metadata unknown

## Daily analysis and source queue

The 2026-08-07 operating record documents:

- Google Drive folder still present but exposing no visible GA4/GSC exports; missing remains unavailable, not zero
- exact production identity for the reader guide and WebNR Originals
- at least five new candidate sources: NDL Digital Collections/Search, Open Library, Library of Congress, Gallica, Project Runeberg
- three full audits: Aozora Bunko, Wikisource, and NDL Search/Digital Collections
- carried candidate findings for low-volume/open-data adapter design
- six required daily decisions covering technical, content, source, search, community, and measurement

## Shared skill

Latest upstream remains `e7338af051ee9621b3033912d5c5751c7ebc241a`. The two commits after pinned `f6e9479e7d979620985ae6125cefc5e614978ea3` only add and clarify an optional static-site snapshot helper, so this source outcome does not opt in or move the submodule pointer.

## Expected validation

- dependency audit
- ESLint
- TypeScript
- Next.js production build
- dual-GA4/full-URL output assertions
- WebNR Originals output assertions
- Aozora starter source and attribution assertions
- strict MkDocs build and existing reader-guide checks
- recorded production evidence for the current unaffected deployment

After green CI, review the complete final diff, generated artifacts, repository identity behavior, Aozora attribution/links, absent-download behavior, analytics, and unaffected routes from scratch before squash merge.

## Production acceptance

Application:

- exact squash commit reaches `app-pages`
- `/sources/aozora-starter/search_index.yml` and README are present
- source directory identity is `aozora-starter`, not the generic hostname `app`
- existing WebNR Originals source remains present
- link-only entries expose official Aozora book-card actions and no invalid import action
- both GA4 IDs and full-URL configuration remain present

Documentation is not modified by this main change and should remain on its existing attributable build.

## Rollback

Revert the squash commit to remove the Aozora catalog and source-identity changes together. Existing locally stored user repositories remain browser-local and can still be removed or re-added by the user.