### PR TITLE
Close out the 2026-08-07 Aozora source cycle

### DIFF
--- a/.github/seo-data/daily/2026-08-07.md
+++ b/.github/seo-data/daily/2026-08-07.md
@@ -2,112 +2,104 @@
 
 ## Scope
 
-Complete the next repository-authoritative daily cycle after pull requests #49 and #50: re-check all available data routes and exact production, retest the first integrated source, audit the next source queue, repair the source-identity defect exposed by same-origin catalogs, integrate a second safe WebNR-maintained source, preserve the rolling reader-content cadence, and deliver through the normal PR/CI/deployment/closeout lifecycle.
+Complete the next repository-authoritative daily cycle after pull requests #49 and #50: re-check all available data routes and exact production, retest the first integrated source, audit the next source queue, repair the same-origin source-identity defect, integrate a second safe WebNR-maintained source, preserve the rolling reader-content cadence, and close the work through the normal PR/CI/deployment lifecycle.
 
 ## Evidence and data quality
 
 - Local operating date: 2026-08-07 (`America/Los_Angeles`).
-- Starting `main`: `4004cf71197a87dc531a6a995dede4551b2cad44` after the metadata closeout for pull request #49.
-- Operational window: activity since the 2026-08-06 cycle plus the delayed final deployment/closeout completed on 2026-08-07.
-- Google Drive: the configured `webNR SEO Weekly CSV` folder still exists. A direct parent-folder query on 2026-08-07 returned no visible files, so GA4 and Search Console aggregates, 7-day comparisons, and 28-day comparisons remain unavailable rather than zero.
-- Cloudflare: the connected accounts still do not expose the `webnovel.win` zone according to the current repository state; infrastructure traffic remains unavailable and is not a blocker.
-- Application production: `app-pages/build.json` identifies `b5264279e0d728ada0934479ef1d800792b8e5fb`.
-- Documentation production: `gh-pages/build.json` identifies `b5264279e0d728ada0934479ef1d800792b8e5fb`.
-- Reader guide production: the exact documentation build contains `/blog/2026/08/06/legado-source-guide/` with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
-- Source production: the exact application build contains `WebNR Originals`, its source terms, catalog, and original CC0 TXT fixture.
-- Analytics implementation: the final successful application/documentation quality gates for the deployed commit verified both GA4 destinations. Application output retains full-browser-URL and pathname-plus-query expressions with Google signals and ad-personalization disabled.
-- Open contributor work remains contributor-owned. Dependabot or other contributor pull requests are observed but not taken over.
+- Starting `main`: `4004cf71197a87dc531a6a995dede4551b2cad44`.
+- Google Drive: the configured `webNR SEO Weekly CSV` folder still exists, but a direct parent-folder query on 2026-08-07 returned no visible files. GA4 and Search Console aggregates, 7-day comparisons, and 28-day comparisons remain unavailable rather than zero.
+- Cloudflare: the connected accounts still do not expose the `webnovel.win` zone according to current repository state; infrastructure traffic remains unavailable and is not a blocker.
+- Starting application production: `app-pages/build.json` identified `b5264279e0d728ada0934479ef1d800792b8e5fb`.
+- Starting documentation production: `gh-pages/build.json` identified `b5264279e0d728ada0934479ef1d800792b8e5fb`.
+- The deployed reader guide `/blog/2026/08/06/legado-source-guide/` remained inside the rolling 48-hour reader-content window; the next dated reader-content slot remains 2026-08-08.
+- The exact starting application build contained `WebNR Originals`, its source terms, YAML catalog, and original CC0 TXT fixture.
+- Open contributor work remained contributor-owned and was not taken over.
 
 ## Analysis
 
 ### Acquisition and search
 
-No finalized GA4 or Search Console export is currently visible in the configured Drive folder. Quantitative traffic, CTR, ranking, landing-page, and query-movement claims are therefore unavailable. The search decision continues to follow durable reader questions and the dated editorial plan instead of inventing demand. The newly deployed Legado guide is inside the rolling 48-hour content window, so a second long-form article is not due on 2026-08-07; the next dated content slot remains 2026-08-08.
+No finalized GA4 or Search Console export is visible in the configured Drive folder. Quantitative traffic, CTR, ranking, landing-page, and query-movement claims are therefore unavailable. The search decision continues to follow durable reader questions and the dated editorial plan rather than inventing demand. The 2026-08-06 Legado guide satisfies the rolling 48-hour content requirement for this cycle.
 
 ### Content and community
 
-The Legado source guide is now present in exact production and answers the scheduled source-finding question. No separate public-community sample is required for today's source-integration task. Public discussion evidence remains reserved for assignments that make community claims. The next reader asset will cover legal free novels and TXT collections and can incorporate the public/authorized source audits accumulated on 2026-08-06 and 2026-08-07.
+No separate public-community sample was required for today's source-integration task because no community-wide claim is being published. The next reader asset will cover legal free novels and TXT collections and can use the public/authorized source audits accumulated on 2026-08-06 and 2026-08-07.
 
 ### Product and delivery
 
-The first same-origin source exposed a source-identity defect: `fetchRepoIndex()` derived repository names only from the hostname. Every WebNR-maintained source under `app.webnovel.win/sources/...` therefore received the same generic name `app`, making multiple vetted catalogs hard to distinguish in Discover. The current repair derives the repository identity from the source directory when available and refreshes stored repository metadata during both manual sync and `?repos=` re-import. This repairs new additions and lets previously stored same-origin sources acquire the corrected identity on their next sync.
+The first same-origin source exposed a concrete source-identity defect: repository identity was derived only from hostname, so multiple WebNR-maintained sources under `app.webnovel.win/sources/...` appeared as the same generic repository. The repair derives repository identity from the source directory when present and refreshes stored repository metadata during both manual sync and `?repos=` re-import. Previously stored same-origin repositories therefore acquire the corrected identity on their next refresh.
 
-No other confirmed low-risk production defect was established from today's available evidence. Dependency audit, lint, typecheck, production build, strict documentation build, analytics assertions, and production-evidence checks remain the authoritative regression gates for the source change.
+No other confirmed low-risk production defect was established from today's available evidence. Dependency audit, lint, typecheck, production build, strict documentation build, analytics assertions, source-output checks, and production-evidence checks remained the authoritative regression gates.
 
 ### Source health
 
-`WebNR Originals` remains present in the exact application production build with its YAML catalog, source terms, and CC0 TXT fixture. Its same-origin static design has no third-party authentication, scraping, CORS, payment, DRM, or captcha dependency. The source-identity repair is the only confirmed source UX regression found in today's retest.
+`WebNR Originals` remained healthy in the exact starting application build. Its same-origin static design has no third-party authentication, scraping, CORS, payment, DRM, or captcha dependency. The same-origin identity defect was the only confirmed source UX regression found in the daily retest.
 
 ## Candidate discovery
 
-At least five new source or collection candidates were added to the queue today:
+At least five new source or collection candidates were added to the queue:
 
-1. **National Diet Library Digital Collections / NDL Search** — Japanese bibliographic and digitized-material discovery through SRU, OpenSearch, OAI-PMH, open metadata subsets, persistent item URIs, and IIIF for eligible public material.
-2. **Open Library** — low-volume public book-discovery APIs plus monthly bulk data dumps; useful for reader discovery and availability links rather than as a high-traffic backend.
-3. **Library of Congress digital collections** — public JSON/YAML APIs without an API key, with rate limits and heterogeneous per-item rights/format data.
-4. **Gallica / Bibliothèque nationale de France** — a large public digital library with SRU/IIIF/data APIs and explicit content-use conditions; per-item and commercial-use rules require careful handling.
-5. **Project Runeberg** — Nordic digitized literature with strong public-domain value but copyright scope that varies by work and reader jurisdiction.
+1. **National Diet Library Digital Collections / NDL Search** — Japanese bibliographic and digitized-material discovery using official search/harvest interfaces and eligible public material.
+2. **Open Library** — low-volume public book-discovery APIs plus bulk data dumps; useful for human-facing discovery and availability links.
+3. **Library of Congress digital collections** — public JSON/YAML APIs with rate limits and heterogeneous per-item rights/format data.
+4. **Gallica / Bibliothèque nationale de France** — public digital-library search/data interfaces with explicit reuse conditions and per-item handling needs.
+5. **Project Runeberg** — Nordic digitized literature with strong public-domain value and work/jurisdiction-specific copyright boundaries.
 
-Carried candidates from the prior queue were also deepened today: **Aozora Bunko** and **Wikisource**.
+Carried candidates from the prior queue were also deepened: **Aozora Bunko** and **Wikisource**.
 
 ## Full source audits
 
-### Aozora Bunko — accepted as a link-based source and integrated
+### Aozora Bunko — accepted and integrated as a link-based source
 
-Official Aozora policy allows its book-card and shelf metadata to be downloaded and reused as bibliographic data under CC BY 4.0. Its linking rules allow links to book cards without permission and allow direct file links when the underlying work is out of copyright or otherwise freely reusable. Aozora also warns that translations have independent copyright and that individual files/data can contain errors.
+Official Aozora policy states that book-card and shelf bibliographic data can be reused under CC BY 4.0. Its linking rules permit links to individual book cards without prior permission. Aozora separately distinguishes copyright status of individual works and translations, and its files may use ZIP-compressed ruby text in Shift_JIS plus XHTML.
 
-The current public cards confirm that common works are offered as ZIP-compressed ruby text in Shift_JIS plus XHTML. WebNR does not yet have a tested Aozora ZIP/Shift_JIS/ruby adapter, so today's safe integration is deliberately link-based: four verified official book cards are exposed through a same-origin WebNR catalog with no fabricated download URL. The selected starter entries are `吾輩は猫である`, `羅生門`, `走れメロス`, and `よだかの星`.
+Independent verification on 2026-08-07 confirmed the official book cards for `吾輩は猫である`, `羅生門`, `走れメロス`, and `よだかの星`. Because WebNR does not yet have a tested ZIP/Shift_JIS/ruby adapter, the safe integration is deliberately link-based: the catalog reuses attributed metadata and links to official book cards, while copying no Aozora book files and exposing no fabricated direct-download URL.
 
-Decision: integrate `https://app.webnovel.win/sources/aozora-starter` as a WebNR-maintained discovery source, attribute reused metadata to Aozora under CC BY 4.0, keep individual content on Aozora, and defer direct reading until format/encoding/annotation and per-work rights tests exist.
+Decision: integrate `https://app.webnovel.win/sources/aozora-starter` as a WebNR-maintained discovery source and defer direct reading until format, encoding, annotation, and per-work rights handling have versioned tests.
 
 ### Wikisource — accepted for adapter design, deferred from runtime integration
 
-Wikisource requires hosted works to be public domain or released under CC BY-SA, while copyrightable editor contributions are licensed under CC BY-SA and GFDL. Its WS Export tool supports EPUB, PDF, and other export formats across language projects. These properties make Wikisource valuable for legal discovery and future export-based adapters, but a generic WebNR runtime source needs language-specific metadata, attribution, export-format handling, and per-work status checks.
+Wikisource is valuable for legal discovery and export-based adapters, but a generic WebNR runtime source needs language-specific metadata, attribution, export-format handling, and per-work status checks.
 
-Decision: keep Wikisource in the adapter queue, prefer official work pages/exports and attribution, and avoid pretending that one global source definition can safely represent every language project and work status.
+Decision: keep Wikisource in the adapter queue and prefer official work pages/exports with explicit attribution.
 
 ### National Diet Library / NDL Search — accepted for discovery research, deferred from integration
 
-NDL Search exposes search APIs through SRU/OpenSearch/OpenURL and harvesting through OAI-PMH. NDL states that some API purposes or data providers require an application or provider permission; provider metadata can have its own credit requirements. The provider list includes open-data subsets, while digitized-content reuse conditions remain separate from metadata reuse. NDL Digital Collections also exposes persistent identifiers and IIIF manifests for eligible internet-public material.
+NDL Search exposes official search and harvesting interfaces, but exact provider subsets, attribution, API-use procedure, request volume, and item-level content-rights behavior need a versioned adapter contract before runtime integration.
 
-Decision: retain NDL as a high-value Japanese discovery candidate, but do not integrate until the exact provider subset, attribution, API-use procedure, request volume, and item-level content-rights behavior are fixed in a versioned adapter contract.
+Decision: retain NDL as a high-value Japanese discovery candidate and defer integration until those boundaries are fixed and tested.
 
 ## Other candidate findings
 
-- **Open Library:** official 2026 developer guidance explicitly supports open-source/mission-aligned low-volume human-facing discovery, asks clients to cache, identify themselves for regular use, limits unidentified requests to roughly 1 request/second and identified requests to roughly 3 requests/second, and directs bulk consumers to monthly dumps. Candidate for a low-frequency discovery adapter, not a general backend.
-- **Library of Congress:** public JSON/YAML APIs require no key and enforce rate limits. Candidate for link-based discovery of digitized material; item formats and rights are heterogeneous and require per-item handling.
-- **Gallica:** free/open browsing plus SRU/IIIF/data interfaces are available, but Gallica publishes explicit reuse conditions and separate commercial-use requirements. Candidate for a French discovery adapter after rights and API behavior are narrowed.
-- **Project Runeberg:** useful Nordic public-domain corpus candidate; its own copyright guidance emphasizes life-plus-70 and jurisdiction differences, so per-item review is required before redistribution or direct import.
+- **Open Library:** suitable for low-frequency reader discovery when clients identify themselves, cache responsibly, and respect documented request limits; bulk usage should use dumps.
+- **Library of Congress:** suitable for link-based discovery after per-item format and rights handling is made explicit.
+- **Gallica:** suitable for a future French discovery adapter after reuse and API behavior are narrowed.
+- **Project Runeberg:** useful Nordic corpus candidate with per-item and jurisdiction-aware rights review.
 
 ## Decisions
 
-1. **Technical:** repair same-origin source identity by deriving names from repository paths and refreshing stored metadata on sync/import.
-2. **Content:** keep the deployed Legado guide as the qualifying rolling-48-hour reader asset; prepare the scheduled 2026-08-08 legal-free-novel/TXT directory rather than creating a thin extra page today.
-3. **Source:** integrate Aozora Bunko Starter as a link-based, attributed, same-origin source; keep Wikisource and NDL in adapter design; add Open Library, Library of Congress, Gallica, and Project Runeberg to the candidate queue.
-4. **Search:** no new standalone search page today; use the next scheduled reader directory to expose the strongest verified public/authorized source routes and link to the existing Legado guide.
-5. **Community:** no community-wide claim or new community page today because no dedicated reproducible public sample was required for this source task.
-6. **Measurement:** preserve the dual-GA4 full-URL implementation, continue to mark GA4/GSC export evidence unavailable, and do not translate missing provider rows into zero traffic.
+1. **Technical:** repair same-origin source identity and refresh stored metadata on sync/import.
+2. **Content:** keep the deployed Legado guide as the qualifying rolling-48-hour reader asset; prepare the scheduled 2026-08-08 legal-free-novel/TXT directory rather than create a thin extra page.
+3. **Source:** integrate Aozora Bunko Starter; keep Wikisource and NDL in adapter design; add Open Library, Library of Congress, Gallica, and Project Runeberg to the queue.
+4. **Search:** no standalone search page today; use the next scheduled reader directory to expose the strongest verified public/authorized routes and link to the Legado guide.
+5. **Community:** no community-wide claim or page today because no dedicated reproducible public sample was needed.
+6. **Measurement:** preserve dual-GA4 full-URL behavior and continue to mark GA4/GSC exports unavailable rather than zero.
 
-## Work in progress
+## Delivery and verification
 
-- Branch: `seo/aozora-source-2026-08-07`
-- Add `public/sources/aozora-starter/search_index.yml` with four verified official Aozora book-card links.
-- Add `public/sources/aozora-starter/README.txt` with attribution, source terms, current link-only behavior, and last-verification date.
-- Change repository-name derivation from hostname-only to source-directory identity.
-- Refresh repository identity and counts during manual sync and `?repos=` re-import so existing same-origin sources repair themselves.
-- Extend Web quality to require both the WebNR Originals and Aozora source artifacts.
-- Shared-skill check: latest upstream remains `e7338af051ee9621b3033912d5c5751c7ebc241a`; the two commits after pinned `f6e9479e7d979620985ae6125cefc5e614978ea3` only add/clarify an optional static-site snapshot helper, so no pointer update is required for this outcome.
-
-## Delivery
-
-- Main pull request: pending
-- Expected checks: Web quality, Documentation quality, Production evidence
-- Final reviewed head: pending
-- Main squash commit: pending
-- Exact application deployment: pending
-- Documentation deployment: expected unchanged unless rendered documentation changes
-- Public Aozora source verification: pending
-- Closeout pull request: pending
+- Main pull request: `#51` — `Add Aozora reader source and repair source identity`.
+- Final reviewed head: `6ea1c004f8fef0c038f9ee453c8420106b13fa9b`.
+- Quality run: `31199194474`, success.
+- Successful expected jobs: Web quality, Documentation quality, Production evidence.
+- Web quality covered dependency audit, lint, typecheck, production build, dual-GA4/full-URL assertions, WebNR Originals output, and Aozora source output.
+- Final from-scratch review rechecked the complete diff, source identity behavior, Aozora attribution and official links, absence of invalid download actions, source safety, analytics behavior, and unaffected documentation scope.
+- Main squash commit: `dbb83c0005787d13db9ed13caa15012e89f21953`.
+- Exact application production artifact: `app-pages/build.json` identifies `dbb83c0005787d13db9ed13caa15012e89f21953`, built at `2026-08-07T16:52:00.355Z`.
+- Exact deployed Aozora catalog: `app-pages/sources/aozora-starter/search_index.yml` contains the four verified book-card entries and no direct download URL.
+- Exact deployed application output retains the WebNR canonical, both configured GA4 destinations, and the existing full-URL analytics implementation validated by CI.
+- Documentation was not changed by #51; its attributable deployment remains `b5264279e0d728ada0934479ef1d800792b8e5fb`.
+- A metadata-only closeout PR records these final facts and does not require another application deployment.
 
 ## Uncertainty and next evidence
 
@@ -115,4 +107,4 @@ Decision: retain NDL as a high-value Japanese discovery candidate, but do not in
 - Aozora direct reading requires a tested ZIP/Shift_JIS/ruby-text or XHTML adapter and per-work rights handling; today's integration intentionally exposes official work pages only.
 - Wikisource needs a language-aware attribution/export design.
 - NDL needs an exact provider/use-contract decision before automated API integration.
-- The 2026-08-08 reader directory should use today's verified source policies and distinguish discovery links, direct imports, format adapters, and jurisdiction-dependent rights.
+- The 2026-08-08 reader directory should distinguish discovery links, direct imports, format adapters, and jurisdiction-dependent rights.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,13 +2,13 @@
 
 ## Current state
 
-- Last completed product, source, and reader-content change: pull request #49, squash merge `b5264279e0d728ada0934479ef1d800792b8e5fb`
-- Last successful attributable application deployment: `b5264279e0d728ada0934479ef1d800792b8e5fb`
+- Last completed product, source, and reader-content change: pull request #51, squash merge `dbb83c0005787d13db9ed13caa15012e89f21953`
+- Last successful attributable application deployment: `dbb83c0005787d13db9ed13caa15012e89f21953`
 - Last successful attributable documentation deployment: `b5264279e0d728ada0934479ef1d800792b8e5fb`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `f6e9479e7d979620985ae6125cefc5e614978ea3`
-- Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content checks have not exposed matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
+- Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content check on 2026-08-07 exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
 
 ## Current signals
@@ -19,26 +19,28 @@
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
 - Connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GitHub Pages production verification, GA4, Search Console, product delivery, content production, or source work.
-- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, dual-GA4 output assertions, first-party source output, and recorded public production evidence.
-- The first reader-discovery article, `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南`, is present in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
-- `WebNR Originals` is the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》.
-- Repository ingestion now preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
+- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, dual-GA4 output assertions, integrated-source output, and recorded public production evidence.
+- The first reader-discovery article, `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南`, remains in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
+- `WebNR Originals` remains the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》.
+- `Aozora Bunko Starter` is the second passing integrated source. The exact application production build contains its attributed four-work discovery catalog, links to official Aozora book cards, and no direct download URL.
+- Same-origin repository identity now derives from the source directory when present, and stored repository name/count/freshness metadata refreshes during sync and `?repos=` re-import. Multiple WebNR-maintained sources no longer collapse to the generic hostname identity.
+- Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
 - Reader-content publishing targets one substantial production asset per rolling 48-hour window. The next dated editorial slot is 2026-08-08: legal free novels and TXT collections.
 - Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt.
-- Project Gutenberg is the next adapter-design candidate under its official catalog, rate, linking, trademark, per-item licensing, and jurisdiction rules. Standard Ebooks remains deferred pending an applicable feed-access route.
+- Current adapter/source queue includes Project Gutenberg, Wikisource, NDL Search/Digital Collections, Open Library, Library of Congress, Gallica, and Project Runeberg. Candidates remain subject to their exact API, attribution, rights, rate, and per-item conditions.
+- Standard Ebooks remains deferred pending an applicable feed-access route.
 - Community Legado definitions remain isolated compatibility-corpus candidates until target-site authorization and health are audited.
 - Legado compatibility claims remain tied to tested capability levels and fixture-suite versions.
 - Branch cleanup is best-effort and nonblocking.
 
 ## Active focus
 
-1. Complete the metadata closeout for pull request #49 without changing rendered production output.
-2. Run the 2026-08-07 data-analysis pass and source-health checks against the new exact production build.
-3. Discover at least five new source candidates, fully audit at least three, and target another safe source integration; prioritize Project Gutenberg-compatible catalog design and public/authorized regional collections.
-4. Prepare the 2026-08-08 reader asset on legal free novels and TXT collections without inventing demand where GA4/GSC exports remain unavailable.
-5. Continue the concentrated technical-repair pass and daily regression monitoring; confirmed low-risk defects are fixed in the same cycle.
-6. Re-establish current GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
-7. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
+1. Publish and verify the 2026-08-08 reader asset on legal free novels and TXT collections, using the strongest audited public-domain and authorized routes and distinguishing discovery links from direct imports.
+2. Continue daily source discovery: at least five candidates, three full audits, one passing integration attempt, plus rotating health checks of WebNR Originals and Aozora Bunko Starter.
+3. Advance the next safe adapter design from Project Gutenberg, Wikisource, NDL, Open Library, Library of Congress, Gallica, or Project Runeberg based on explicit license/API/rate/rights evidence.
+4. Re-establish current GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
+5. Continue concentrated technical-repair and daily regression monitoring; confirmed low-risk defects are fixed in the same cycle.
+6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 
 Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities. The two `Last successful attributable ... deployment` lines are stable machine-readable interfaces used by `scripts/verify-production-builds.mjs` and must retain their exact labels.


### PR DESCRIPTION
## Outcome

Record the completed 2026-08-07 WebNR source-growth cycle after pull request #51 reached exact application production.

## Verified delivery

- main change: pull request #51
- final reviewed head: `6ea1c004f8fef0c038f9ee453c8420106b13fa9b`
- Quality run `31199194474`: Web quality, Documentation quality, and Production evidence all succeeded
- squash commit: `dbb83c0005787d13db9ed13caa15012e89f21953`
- exact application production: `app-pages/build.json` identifies the squash commit, built at `2026-08-07T16:52:00.355Z`
- deployed Aozora source: four attributed official book-card links with no direct download URL
- documentation unchanged and remains attributable to `b5264279e0d728ada0934479ef1d800792b8e5fb`
- current Google Drive folder is accessible but exposes no matching GA4/GSC exports; missing data remains unavailable rather than zero

## Files

- `.github/seo-data/daily/2026-08-07.md`
- `.github/seo-data/status.md`

## Scope and deployment

Metadata-only closeout. It updates public-safe operating records and the two stable deployment labels consumed by `scripts/verify-production-builds.mjs`. It does not alter rendered application or documentation output and should not trigger another production deployment.

## Expected checks

- Web quality
- Documentation quality
- Production evidence

After green CI, review the complete two-file diff from the repository-authoritative daily task, confirm the exact deployment labels and data qualifications, then squash-merge with the expected head SHA.