### PR TITLE
Publish legal free novels guide and Standard Ebooks source

### DIFF
--- a/.github/seo-data/daily/2026-08-08.md
+++ b/.github/seo-data/daily/2026-08-08.md
@@ -1,0 +1,125 @@
+# WebNR operations — 2026-08-08
+
+## Scope
+
+Complete the 2026-08-08 repository-authoritative cycle: verify the owner-corrected single-GA4 production state, inspect all available data routes, retest existing integrated sources, discover and audit the next free-reading source queue, publish the scheduled legal-free-novels/TXT reader directory, integrate one safe passing source, review the current shared skill upstream, and carry every rendered change through PR, CI, exact deployment, public verification, and metadata closeout.
+
+## Evidence and data quality
+
+- Local operating date: 2026-08-08 (`America/Los_Angeles`).
+- Starting `main`: `070c150575e7b69414226c60e2cb1a70c5310d7a`, merged through pull request #53 after the owner corrected WebNR back to one historical GA4 destination.
+- Starting application production: `app-pages/build.json` identifies `070c150575e7b69414226c60e2cb1a70c5310d7a`, built on 2026-08-08.
+- Starting documentation production: `gh-pages/build.json` identifies the same `070c150575e7b69414226c60e2cb1a70c5310d7a` source commit.
+- Analytics contract: both public surfaces retain the single destination `G-DGH8HNQKE4`; the obsolete `G-NL0WV2XMJN` destination is rejected by CI. The reader preserves full-URL reporting, including query strings and `?add=...`, while Google signals and ad-personalization signals remain disabled.
+- Google Drive: the configured `webNR SEO Weekly CSV` folder is accessible, but a direct parent-folder listing on 2026-08-08 returned no visible export files. GA4 and Search Console aggregates, 7-day comparisons, 28-day comparisons, CTR, landing-page movement, and query movement remain unavailable rather than zero.
+- Cloudflare: the connected account state recorded by the repository still does not expose `webnovel.win`; infrastructure traffic remains unavailable and non-blocking.
+- Open WebNR automation pull requests: none at the start of this cycle. Open repository issues: none found.
+- Existing source-health baseline: the exact application production branch still contains `WebNR Originals` and `Aozora Bunko Starter` source artifacts. Their last completed source-cycle evidence remains valid; today's main change also keeps both source-output assertions in CI.
+- Reader-content cadence: the 2026-08-06 Legado source guide was the prior qualifying asset; the dated 2026-08-08 slot is now due and therefore must reach documentation production in this cycle.
+
+## Data analysis
+
+### Acquisition and search
+
+No finalized GA4 or Search Console export is visible in the configured Drive folder, so this cycle makes no numerical claim about users, sessions, clicks, impressions, CTR, rankings, countries, devices, landing pages, or query growth. The search decision is based on the explicit reader question already scheduled for 2026-08-08 and on verified source availability rather than inferred traffic.
+
+The current documentation production still contains the Legado source-finding article under a stable canonical. Today's new page answers the adjacent intent — where a reader can legally find free novels, public-domain literature, author-authorized text, and TXT/ebook collections — and links naturally back to the Legado source guide rather than creating a keyword variant.
+
+### Content and community
+
+Today's asset is a practical reader directory, not a community-consensus article, so no social-platform sampling is required. The page uses current first-hand source checks and official project pages. Public-community analysis remains reserved for the later discussion-radar and community-map assignments where a reproducible sample is part of the claim.
+
+The article distinguishes direct TXT use, official discovery links, format adapters, institution full-view access, and jurisdiction-dependent rights. It does not publish a generic title dump or claim that one project's public-domain determination applies worldwide.
+
+### Product and delivery
+
+The owner correction in #53 is already exact in both deployment branches and in CI: `G-DGH8HNQKE4` is required and the obsolete destination is rejected. No additional runtime analytics defect is established from current production evidence.
+
+A supporting-record wording drift remains: older generic analysis/calendar wording still mentions “both configured GA4 destinations” even though `daily-task.md`, `site.md`, `status.md`, the late 2026-08-07 correction, runtime source, CI, and both deployed builds now define one destination. This is a repository-contract wording defect rather than a production measurement defect; it will be corrected in the metadata closeout after today's rendered work has exact delivery evidence.
+
+No other confirmed low-risk runtime regression was established before implementation. Dependency audit, lint, typecheck, production application build, strict documentation build, integrated-source assertions, analytics assertions, and Production evidence remain the authoritative regression gates.
+
+### Shared skill review
+
+Pinned skill at cycle start: `f6e9479e7d979620985ae6125cefc5e614978ea3`.
+
+Reviewed upstream through `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`. The three upstream commits add an optional static-site snapshot helper and, importantly, bind weekly GA4 CSV exports to an explicit private property ID and adjacent private source manifest instead of display-name matching. That change directly addresses the class of same-name GA4 routing collision recorded by the owner correction. The update preserves consumer-owned SEO-data layout and adds no required public identifiers, so this cycle adopts the new pinned pointer.
+
+## Source discovery
+
+At least five new source/collection directions were added beyond the current active queue:
+
+1. **HathiTrust Digital Library** — institutional full-view discovery with item- and digitization-specific download restrictions.
+2. **Digital Public Library of America (DPLA)** — permissively reusable aggregation metadata with item content rights retained by contributing institutions.
+3. **Google Books Full View / Books API** — bibliographic and current-viewability discovery whose full-view/download status can depend on rights and user location.
+4. **Internet Archive Texts / metadata** — broad collection discovery; generic integration is deferred because item rights and access models vary widely.
+5. **Project Madurai** — free Tamil electronic texts, including public-domain and author-consented works, with Unicode/TSCII/PDF format boundaries.
+6. **Project Ben-Yehuda** — free Hebrew digital literature with explicit public-domain and permission-published status information.
+
+The previously audited Standard Ebooks candidate was reopened with a narrower integration design: stable official work-page discovery rather than a dependency on full catalog feeds.
+
+## Full source audits
+
+### Standard Ebooks — accepted and integrated as a link-based discovery source
+
+Official Standard Ebooks pages identify the project as a producer of free, carefully prepared electronic editions and state that content produced by or for Standard Ebooks is dedicated to the public domain under CC0 1.0. Individual work pages state their current United States copyright assessment and warn readers outside the United States to check local law.
+
+Fresh checks confirmed official pages for `Pride and Prejudice`, `Frankenstein`, `The Picture of Dorian Gray`, and `The Time Machine`, each with online reading and ebook download routes. WebNR still has a truthful TXT-only local-format boundary, so today's safe integration stores only WebNR-authored descriptions plus title, author, and official work-page links. It copies no EPUB/AZW3/KEPUB files and exposes no fake TXT import action.
+
+Decision: integrate `https://app.webnovel.win/sources/standard-ebooks-starter` as the third WebNR-maintained source. Defer direct Standard Ebooks reading until a real EPUB parser, safe rendering policy, versioned fixtures, and per-item rights path exist. Do not depend on a full feed whose access path has not been explicitly adopted and tested.
+
+### Project Madurai — accepted for adapter design, deferred from runtime integration
+
+Project Madurai describes itself as an open volunteer initiative that prepares and distributes free electronic editions of Tamil literary classics. Its FAQ states that collection works are public domain or included with appropriate author consent. The archive contains multiple generations of formats and encodings, including TSCII and Unicode HTML/PDF.
+
+Reader value is high, especially for regional-language coverage, but a production source requires explicit handling for encoding, work-level status, URL patterns, and the project's distribution wording. A blanket full-archive import would hide those differences.
+
+Decision: retain as a high-value Tamil adapter candidate. Build future fixtures from clearly Unicode and rights-explained entries before any official WebNR integration.
+
+### Project Ben-Yehuda — accepted for adapter design, deferred from runtime integration
+
+Project Ben-Yehuda publishes free searchable electronic editions of Hebrew literature. Its public project pages describe works whose copyright has expired or for which publication permission was granted, and its work interface exposes rights-status filtering and export/download functions.
+
+This makes rights state unusually useful as catalog metadata, but a safe WebNR adapter still needs versioned tests for work status, text/export routes, language directionality, and provenance retention.
+
+Decision: keep Project Ben-Yehuda in the regional adapter queue and require the origin rights label and work page to survive normalization.
+
+## Other candidate findings
+
+- **HathiTrust:** Full View is valuable for discovery; full-download ability varies by item, user status, and digitization source, so keep it link-based until an exact access-state adapter exists.
+- **DPLA:** aggregation metadata is useful and openly reusable, while actual item media/text remains governed by the contributing institution's rights statement.
+- **Google Books:** `accessInfo` and Full View can describe current discoverability/viewability, but they must not be converted into a universal content license.
+- **Internet Archive:** retain as a collection-specific research candidate rather than a generic book source because rights and access models are heterogeneous.
+
+## Existing source health
+
+- **WebNR Originals:** production artifact remains present; no third-party network, login, payment, captcha, or rights dependency is introduced by today's change.
+- **Aozora Bunko Starter:** production artifact remains present with official book-card links and no direct-download URL. No direct ZIP/Shift_JIS/ruby claim is added today.
+- Today's Quality workflow will retain existing assertions for both sources and add assertions for the Standard Ebooks Starter source.
+
+## Required decisions
+
+1. **Technical:** no new production runtime defect established; correct the remaining single-vs-dual GA4 wording drift during closeout after rendered delivery is verified.
+2. **Content:** publish the scheduled legal-free-novels/TXT directory now; it is due in the rolling 48-hour cadence and answers a distinct reader question.
+3. **Source:** integrate Standard Ebooks Starter as link-based discovery; retain Project Madurai and Project Ben-Yehuda for fixture-driven adapter work; retain HathiTrust/DPLA/Google Books/Internet Archive as discovery candidates with explicit rights/access boundaries.
+4. **Search:** create the genuinely missing free-reading directory, link it to the Legado guide, and require stable canonical, sitemap/RSS inclusion, static HTML, and exact documentation build identity.
+5. **Community:** no community-wide claim today; preserve the scheduled later discussion-radar sampling work rather than manufacture social evidence.
+6. **Measurement:** preserve the single `G-DGH8HNQKE4` full-URL implementation and continue marking GA4/GSC exports unavailable until correctly routed files reappear. Adopt the reviewed shared-skill export-source binding so future exports can be tied to an explicit private property source.
+
+## Main change plan and acceptance
+
+Main branch: `seo/free-novels-standard-ebooks-2026-08-08`.
+
+Planned rendered outcomes:
+
+- documentation article: `/blog/2026/08/08/legal-free-novels-txt-collections/`;
+- app source: `/sources/standard-ebooks-starter/search_index.yml` plus source terms;
+- current single-GA4 behavior preserved in application and documentation;
+- WebNR Originals and Aozora Bunko Starter preserved;
+- pinned shared skill moves to reviewed `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`.
+
+Required CI before merge: dependency audit, ESLint, TypeScript, Next.js production build, source-output assertions for all three integrated sources, single-GA4/full-URL assertions, strict MkDocs build, generated 2026-08-08 article checks, and Production evidence for the currently recorded baseline.
+
+After green CI, the complete base-to-head diff, every commit, generated outputs, external links/rights claims, source actions, analytics behavior, skill pointer, and unaffected reader routes must be reviewed from the original daily task before squash merge.
+
+Delivery fields remain pending until CI, final review, squash merge, exact app/docs production, public acceptance, and metadata closeout complete.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,12 +3,12 @@
 ## Current state
 
 - Last completed product, source, and reader-content change: pull request #51, squash merge `dbb83c0005787d13db9ed13caa15012e89f21953`
-- Last successful attributable application deployment: `dbb83c0005787d13db9ed13caa15012e89f21953`
-- Last successful attributable documentation deployment: `b5264279e0d728ada0934479ef1d800792b8e5fb`
+- Last successful attributable application deployment: `070c150575e7b69414226c60e2cb1a70c5310d7a`
+- Last successful attributable documentation deployment: `070c150575e7b69414226c60e2cb1a70c5310d7a`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
-- Current skill submodule: `f6e9479e7d979620985ae6125cefc5e614978ea3`
-- Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content check on 2026-08-07 exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
+- Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
+- Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content check on 2026-08-08 exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
 
 ## Current signals
@@ -26,20 +26,21 @@
 - Same-origin repository identity now derives from the source directory when present, and stored repository name/count/freshness metadata refreshes during sync and `?repos=` re-import. Multiple WebNR-maintained sources no longer collapse to the generic hostname identity.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
-- Reader-content publishing targets one substantial production asset per rolling 48-hour window. The next dated editorial slot is 2026-08-08: legal free novels and TXT collections.
+- Reader-content publishing targets one substantial production asset per rolling 48-hour window. The 2026-08-08 asset on legal free novels and TXT collections is in delivery during the current cycle.
 - Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt.
-- Current adapter/source queue includes Project Gutenberg, Wikisource, NDL Search/Digital Collections, Open Library, Library of Congress, Gallica, and Project Runeberg. Candidates remain subject to their exact API, attribution, rights, rate, and per-item conditions.
-- Standard Ebooks remains deferred pending an applicable feed-access route.
+- Current adapter/source queue includes Project Gutenberg, Wikisource, NDL Search/Digital Collections, Open Library, Library of Congress, Gallica, Project Runeberg, HathiTrust, DPLA, Google Books Full View, Project Madurai, Project Ben-Yehuda, and collection-specific Internet Archive research. Candidates remain subject to their exact API, attribution, rights, rate, access, and per-item conditions.
+- Standard Ebooks is moving from a deferred feed candidate to a link-based discovery source that does not depend on full-feed access.
 - Community Legado definitions remain isolated compatibility-corpus candidates until target-site authorization and health are audited.
 - Legado compatibility claims remain tied to tested capability levels and fixture-suite versions.
+- The pinned shared skill now includes explicit private GA4 property binding and adjacent source-manifest validation for weekly exports, preventing same-name property display labels from silently selecting the wrong property.
 - Branch cleanup is best-effort and nonblocking.
 
 ## Active focus
 
-1. Publish and verify the 2026-08-08 reader asset on legal free novels and TXT collections, using the strongest audited public-domain and authorized routes and distinguishing discovery links from direct imports.
-2. Continue daily source discovery: at least five candidates, three full audits, one passing integration attempt, plus rotating health checks of WebNR Originals and Aozora Bunko Starter.
-3. Advance the next safe adapter design from Project Gutenberg, Wikisource, NDL, Open Library, Library of Congress, Gallica, or Project Runeberg based on explicit license/API/rate/rights evidence.
-4. Re-establish current GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
+1. Complete PR/CI/deployment/public verification for the 2026-08-08 legal-free-novels reader directory and Standard Ebooks Starter source, then close it out truthfully.
+2. Continue daily source discovery: at least five candidates, three full audits, one passing integration attempt, plus rotating health checks of WebNR Originals, Aozora Bunko Starter, and newly integrated sources.
+3. Advance the next safe adapter design from Project Gutenberg, Wikisource, Project Madurai, Project Ben-Yehuda, HathiTrust, DPLA, Google Books, NDL, Open Library, Library of Congress, Gallica, or Project Runeberg based on explicit license/API/rate/rights evidence.
+4. Re-establish correctly routed GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
 5. Continue concentrated technical-repair and daily regression monitoring; confirmed low-risk defects are fixed in the same cycle.
 6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -71,6 +71,14 @@ jobs:
           grep -Fq 'title: 羅生門' out/sources/aozora-starter/search_index.yml
           grep -Fq 'license: CC-BY-4.0-metadata' out/sources/aozora-starter/search_index.yml
           grep -Fq 'https://www.aozora.gr.jp/cards/000148/card789.html' out/sources/aozora-starter/search_index.yml
+          test -f out/sources/standard-ebooks-starter/search_index.yml
+          test -f out/sources/standard-ebooks-starter/README.txt
+          grep -Fq 'title: Pride and Prejudice' out/sources/standard-ebooks-starter/search_index.yml
+          grep -Fq 'title: Frankenstein' out/sources/standard-ebooks-starter/search_index.yml
+          grep -Fq 'title: The Picture of Dorian Gray' out/sources/standard-ebooks-starter/search_index.yml
+          grep -Fq 'title: The Time Machine' out/sources/standard-ebooks-starter/search_index.yml
+          grep -Fq 'license: CC0-1.0-standard-ebooks' out/sources/standard-ebooks-starter/search_index.yml
+          grep -Fq 'https://standardebooks.org/ebooks/jane-austen/pride-and-prejudice' out/sources/standard-ebooks-starter/search_index.yml
 
   docs:
     name: Documentation quality
@@ -98,12 +106,17 @@ jobs:
           test -f site/index.html
           test -f site/troubleshooting/txt-import/index.html
           test -f site/blog/2026/08/06/legado-source-guide/index.html
+          test -f site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
           grep -Fq 'AutoArchive/webNR' site/index.html
           grep -Fq 'https://autoarchive.github.io/webNR/' site/index.html
           grep -Fq 'TXT import troubleshooting' site/troubleshooting/txt-import/index.html
           grep -Fq 'TXT 导入排障' site/troubleshooting/txt-import/index.html
           grep -Fq '2026 年 Legado 书源在哪里找' site/blog/2026/08/06/legado-source-guide/index.html
           grep -Fq 'WebNR Originals' site/blog/2026/08/06/legado-source-guide/index.html
+          grep -Fq '2026 年哪里能合法免费看小说' site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
+          grep -Fq 'Standard Ebooks Starter' site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
+          grep -Fq 'Project Madurai' site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
+          grep -Fq 'Project Ben-Yehuda' site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
           grep -R -Fq 'G-DGH8HNQKE4' site
           if grep -R -Fq 'G-NL0WV2XMJN' site; then
             echo 'Obsolete secondary GA4 destination found in documentation output' >&2

--- a/docs/blog/posts/2026-08-08-legal-free-novels-txt-collections.md
+++ b/docs/blog/posts/2026-08-08-legal-free-novels-txt-collections.md
@@ -1,0 +1,149 @@
+---
+title: 2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录
+date: 2026-08-08
+slug: legal-free-novels-txt-collections
+description: 面向读者整理 2026 年仍可核验的公版、作者授权和开放数字图书馆路线，并区分可以直接读、只能跳转发现、需要逐本判断版权和目前尚不适合 WebNR 直接导入的来源。
+categories:
+  - Reader guides
+  - Sources
+---
+
+# 2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录
+
+**直接答案：** 想找长期稳定、来源清楚的免费小说，优先顺序可以很简单：先看明确公版或由作者授权的数字图书馆，再看开放电子书项目和机构馆藏，最后才把搜索引擎、镜像站和社区分享当作发现线索。对 WebNR 用户而言，当前最容易直接阅读的是明确允许分发的 TXT；EPUB、扫描 PDF、特殊编码文本和只提供作品页的馆藏，应该先作为发现链接，等阅读器具备对应解析器和逐本权利判断后再开放直接导入。
+
+本文于 **2026 年 8 月 8 日**重新核验来源项目的官方页面、版权说明、访问方式和 WebNR 当前能力。今天同时上线一个新的 **Standard Ebooks Starter** 发现源，读者可以把四部经典小说的官方作品页加入 WebNR 来源列表：
+
+[添加 Standard Ebooks Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fstandard-ebooks-starter){ .md-button .md-button--primary }
+
+这个源只提供官方作品页链接，不复制 EPUB，也不把电子书下载地址伪装成 TXT。此前已经上线的 [Legado 书源查找与验源指南](2026-08-06-legado-source-guide.md) 解释了为什么“规则文件公开”与“内容可以合法获取”必须分开判断；本文把重点放在读者真正可以使用的免费阅读路线。
+
+## 先看一张表：不同“免费来源”其实不是同一种东西
+
+| 来源类型 | 读者能得到什么 | WebNR 当前适合的方式 | 最容易忽略的边界 |
+| --- | --- | --- | --- |
+| 作者授权或项目原创 TXT | 直接文本文件 | 可以直接导入或建立静态目录 | 授权范围是否允许再分发 |
+| 公版电子书项目 | 在线阅读、EPUB、作品页、目录 Feed | 先做作品发现；TXT 可直接读，EPUB 等解析器完成后再接入 | 公版状态随国家/地区而变化 |
+| 国家图书馆与数字馆藏 | 作品页、扫描件、全文或元数据 | 作品发现和跳转 | “可查看”不等于“可批量下载或再分发” |
+| Wikisource 等协作文本库 | 网页正文、导出文件、版本历史 | 语言/作品级 adapter | 页面许可、原作版权和译文版权可能不同 |
+| 搜索与聚合 API | 元数据、可读状态、落地页 | 发现层，不当作内容许可证 | API 返回“可见”不代表内容可自由复制 |
+
+这里最关键的判断是：**免费访问、公共领域、开放许可、机构允许下载、允许机器访问、允许第三方再分发，是六个不同问题。** 一个页面在浏览器里免费打开，只说明此刻可以访问；WebNR 若要把它变成长期可维护的书源，还需要知道来源是谁、作品权利状态、请求方式、格式、编码和失败边界。
+
+## 第一组：最适合普通读者长期收藏的免费项目
+
+### Standard Ebooks：适合想要排版精良英文经典的人
+
+[Standard Ebooks](https://standardebooks.org/) 把公版文学制作成高质量电子书，并提供在线阅读、兼容 EPUB、Kindle/Kobo 格式以及作品源码。项目说明由 Standard Ebooks 制作的内容采用 **CC0 1.0**；每本书的页面又单独提示作品在美国是否被认为已经没有版权限制，并提醒美国以外读者核对所在地法律。
+
+今天核验的四个官方页面是：
+
+- [Pride and Prejudice — Jane Austen](https://standardebooks.org/ebooks/jane-austen/pride-and-prejudice)
+- [Frankenstein — Mary Shelley](https://standardebooks.org/ebooks/mary-shelley/frankenstein)
+- [The Picture of Dorian Gray — Oscar Wilde](https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray)
+- [The Time Machine — H. G. Wells](https://standardebooks.org/ebooks/h-g-wells/the-time-machine)
+
+这些页面都能直接在线阅读，也提供电子书下载。WebNR 目前仍以 TXT 为正式支持格式，因此今天的集成选择“**链接到官方作品页**”，而不是做一个看似方便、实际没有经过 EPUB 安全测试的下载按钮。这样读者马上获得稳定入口，同时阅读器不会虚假宣称已经支持一种格式。
+
+Standard Ebooks 还提供 OPDS/Atom/RSS 形式的电子书 Feed，不过完整 Feed 存在不同访问路径。今天的 Starter 不依赖这些 Feed；后续只有在明确符合公开或开源项目访问条件并建立固定测试后，才会升级为自动目录 adapter。
+
+### Project Gutenberg：目录巨大，但机器访问要走机器路线
+
+[Project Gutenberg](https://www.gutenberg.org/) 是最常见的英文免费电子书入口之一。它的目录以美国版权判断为基础，既有美国公共领域作品，也可能保留历史上经权利人授权发布的条目。因此“Gutenberg 上有”并不适合被简化成“全世界都属于公版”。
+
+对普通读者，直接打开作品落地页最清楚。对程序和书源，项目明确区分主网站的人类访问与机器人/批量访问，并提供机器可读目录、镜像和离线元数据路线。WebNR 后续的 Gutenberg adapter 应当使用这些官方机器入口、缓存目录结果、保持低频，并尽量链接作品页，而不是让每个客户端反复抓取主站网页或把第三方镜像当作权威来源。
+
+Gutenberg 因此很适合作为“大目录发现层”：它能回答“这本经典有没有合法免费版本”，但具体下载、再分发以及所在法域是否已进入公共领域，仍需要看单本作品与当地法律。
+
+### 青空文库：日文经典入口已经可以在 WebNR 里发现
+
+[青空文库](https://www.aozora.gr.jp/) 是日本文学的重要免费数字项目。WebNR 已经上线 **Aozora Bunko Starter**，当前包含《吾輩は猫である》《羅生門》《走れメロス》《よだかの星》四个经过核验的官方图书卡链接。
+
+青空文库的图书卡/书架数据有明确的再利用条件，但具体作品仍需考虑原作、译文等权利状态；文件格式还常见 ZIP、Shift_JIS、青空文库注记和 XHTML。WebNR 因此先把它做成作品发现源。等 ZIP、编码和 ruby 注记解析有版本化测试后，才适合讨论直接阅读。
+
+这个策略对其他区域图书馆同样适用：**先把稳定、官方、可解释的作品入口交给读者，再逐步增加格式能力。**
+
+### Project Madurai：泰米尔语电子文本的区域性宝库
+
+[Project Madurai](https://www.projectmadurai.org/) 是一个长期运行的志愿数字化项目，目标是制作并免费发布泰米尔文学电子文本。官方说明称收藏中的作品来自公共领域，或已经得到相应作者/权利方许可；其档案同时保留早期 TSCII 编码和较新的 Unicode HTML/PDF 版本。
+
+它非常适合成为 WebNR 的区域来源候选，不过接入方式需要比“抓一个 TXT 链接”更细：不同年代文件的字符编码、HTML 结构、PDF 与纯文本能力不一致，早期档案还带有个人使用措辞。今天的决定是保留为高价值 adapter 候选，优先从明确 Unicode、作品状态和下载条件的条目建立 fixture，而不是一口气索引整个档案。
+
+### Project Ben-Yehuda：公版与明确授权并存的希伯来语数字图书馆
+
+[Project Ben-Yehuda](https://benyehuda.org/) 把希伯来文学制作成免费、可搜索的数字版本。项目自己的介绍明确说明，站内作品主要来自版权已经到期的内容，或取得了出版许可；作品列表还把“公共领域”“经授权发布”等权利状态直接作为筛选条件，并提供文本/电子书导出能力。
+
+这类站点对 WebNR 很有价值，因为“作品为什么能公开”本身就是目录数据的一部分。今天把它加入区域来源队列，下一步应使用官方作品状态与导出接口做小规模 fixture，确保每个条目都保留原始作品页和权利标签。
+
+## 第二组：非常有用，但更适合作为发现层
+
+### Wikisource：适合从网页和导出开始，不适合把整个站视为一种许可证
+
+[Wikisource](https://wikisource.org/) 的不同语言项目拥有大量可阅读文本，并有 EPUB/PDF 等导出能力。它的优势是版本历史、校对和页面级来源清楚；复杂之处是原作、译文、编辑贡献以及不同语言项目的具体信息需要逐项处理。
+
+WebNR 已把 Wikisource 留在 adapter 队列。合理设计是保存语言、作品页、导出方式和许可/版权模板，而不是只根据“Wikimedia”这个品牌给整站贴一个统一权利标签。
+
+### Project Runeberg：北欧文学很强，法域判断必须跟着作者和译者走
+
+[Project Runeberg](https://runeberg.org/) 长期数字化北欧文学，并明确说明它按照版权期限谨慎发布作品。对于北欧经典发现，它提供了独特价值；对于全球读者，作者、译者、版本和所在地版权期限仍可能产生差异。
+
+因此它适合做区域发现与逐本链接，不适合生成“整个 Runeberg 都可以任意再分发”的结论。
+
+### HathiTrust：Full View 很有价值，下载权限仍要看条目和数字化来源
+
+[HathiTrust Digital Library](https://www.hathitrust.org/) 汇集大量图书馆数字化内容。没有登录的用户也能阅读许多 **Full View** 条目；但整本下载能力受作品状态、登录资格以及数字化来源影响，Google 扫描的条目尤其可能有下载限制。
+
+对 WebNR 来说，HathiTrust 很适合作为“是否存在机构完整视图”的发现信号，暂时不适合作为统一直链下载源。一个未来 adapter 应明确区分 Full View、Search-only、下载限制和作品落地页。
+
+## 第三组：搜索能力很强，但元数据本身不是内容授权
+
+今天还新增核验了几类发现候选：
+
+- **Digital Public Library of America (DPLA)**：聚合元数据采用非常宽松的开放政策，很适合发现美国机构收藏；实际图片、扫描件或文本仍由各提供机构的 rights statement 决定。
+- **Library of Congress JSON API**：不需要 API key 就能查询大量公开元数据，适合低频目录发现；条目格式与权利状态具有异质性，需要保留作品页和逐项 rights 信息。
+- **Google Books API / Full View**：能提供书目、预览/可读状态和购买/落地信息；Full View 与下载能力会随作品权利和用户所在地变化，所以应把 `accessInfo` 当成“当前可读性信号”，而不是全局公版证明。
+- **Internet Archive Texts**：拥有庞大文本与元数据集合，但不同项目、借阅模型和单本作品的权利状态差异很大。WebNR 可以研究元数据/明确开放集合，通用“Internet Archive 全站下载源”则缺少足够窄的权利边界。
+
+这些来源证明了一件很实用的事：一个好的阅读器目录不必把所有书都自己托管。**发现层负责告诉读者哪里有可靠版本；导入层只处理已经满足格式、访问和权利条件的内容。**
+
+## 如果你只想“找一本文本马上读”，怎么选
+
+可以按下面的顺序降低踩坑概率：
+
+1. **先搜索作者或项目官方页面。** 作者自己发布的 TXT、明确授权下载页、项目原创内容最容易判断。
+2. **再找公版项目的作品页。** Standard Ebooks、Project Gutenberg、青空文库、Project Madurai、Project Ben-Yehuda、Project Runeberg 都比无来源 TXT 打包站更容易追溯。
+3. **需要更多版本时再去机构馆藏。** Wikisource、HathiTrust、DPLA、Library of Congress、Google Books 可以帮助确定版本、扫描件和可读状态。
+4. **看到“TXT 全集”“万能书源”先检查来源。** 文件名、网盘地址和“免费”标签本身不能回答作者、版本、授权和法域问题。
+5. **给 WebNR 导入时看格式。** 当前可靠路径是 TXT 与已验证的文本 URL；EPUB、ZIP、特殊编码和复杂网页规则应该等对应能力通过测试。
+
+一个来源如果只有文件、没有作者和 metadata，并不必然不能用。WebNR 的规则是：可以从文件名生成展示标题，未知作者保持 Unknown；但**绝不通过猜测补作者、许可、发布日期或热度**。比起漂亮但虚构的目录，一个诚实的“未知”更容易在以后被纠正。
+
+## 今天的来源审计与接入结果
+
+本轮重新核验了现有 WebNR Originals 和 Aozora Bunko Starter，并扩展了免费阅读候选池。新增发现方向包括 HathiTrust、DPLA、Google Books Full View、Internet Archive Texts、Project Madurai 和 Project Ben-Yehuda。
+
+深入审计后形成三个直接结论：
+
+- **Standard Ebooks：通过，今天接入。** 使用官方作品页和项目自己的 CC0/版权说明，只做 link-based discovery，不使用受条件约束的完整 Feed，也不复制 EPUB。
+- **Project Madurai：通过读者价值审计，等待编码/权利 fixture。** 免费电子文本价值高，先从 Unicode 和权利说明明确的条目做 adapter。
+- **Project Ben-Yehuda：通过读者价值审计，等待权利状态/导出 fixture。** 站点直接区分公版和授权发布，适合做保留权利标签的区域目录。
+
+新的 **Standard Ebooks Starter** 因此成为 WebNR 第三个正式来源。它的作用不是取代 Standard Ebooks，而是给 WebNR 用户一个可验证的作品发现入口；任何阅读和下载仍回到官方作品页。
+
+## 为什么今天没有直接接一个“大型 TXT 合集”
+
+TXT 合集非常适合 WebNR，但“没有 metadata”与“没有来源依据”是两回事。前者可以解决：文件名就能先成为标题，未知字段保持未知。后者不能靠技术补齐：如果不知道文本来自哪里、是否公版或获授权，就不能因为文件格式方便而把它包装成官方推荐源。
+
+所以接下来的 TXT 工作会优先寻找三类集合：作者明确授权发布、项目自身原创/开放许可、公共领域项目明确允许分发的文本包。Project Madurai、Project Ben-Yehuda 和部分区域数字项目都可能提供这样的材料，但要先逐项把许可措辞、编码和文件入口做成可重复测试。
+
+## 下一步
+
+今天之后，免费阅读目录会持续更新来源健康和接入能力，而不是停在一篇“资源推荐”。接下来最值得做的是：
+
+- 为 Project Gutenberg 建立目录缓存、作品落地页优先的低频 adapter；
+- 为 Wikisource 固定语言、导出与归属 fixture；
+- 为 Project Madurai 测试 Unicode/TSCII 编码边界；
+- 为 Project Ben-Yehuda 保留公版/授权状态并测试文本导出；
+- 等 WebNR 的 EPUB 安全解析器完成后，把 Standard Ebooks 从发现源升级为真正可读的格式适配器。
+
+免费小说资源的长期价值来自三件事同时成立：**读者找得到，来源讲得清，阅读器真的能稳定处理。** WebNR 会把这三件事分别验证，再把通过的部分逐步连起来。

--- a/public/sources/standard-ebooks-starter/README.txt
+++ b/public/sources/standard-ebooks-starter/README.txt
@@ -1,0 +1,56 @@
+Standard Ebooks Starter
+=======================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/standard-ebooks-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fstandard-ebooks-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small, link-based discovery catalog for selected
+Standard Ebooks editions. It gives readers stable origin pages for legally free
+classic fiction without pretending that WebNR already supports EPUB import.
+
+Source and reuse boundary
+-------------------------
+Standard Ebooks states that content produced by or for Standard Ebooks is
+dedicated to the public domain under CC0 1.0. Its individual ebook pages also
+state whether an edition is thought to be free of copyright restrictions in the
+United States and remind readers outside the United States to check local law.
+
+Source: https://standardebooks.org/
+Catalog: https://standardebooks.org/ebooks
+Copyright policy: https://standardebooks.org/contribute/copyright
+Ebook feeds: https://standardebooks.org/feeds
+License for Standard Ebooks-produced content: CC0 1.0
+
+This starter catalog stores only WebNR-authored descriptions plus title, author,
+and official Standard Ebooks page links. It does not copy or proxy ebook files.
+The legal status of an underlying literary work remains jurisdiction-dependent.
+
+Current WebNR behavior
+----------------------
+The entries are discovery links only. Standard Ebooks offers online reading and
+EPUB-family downloads, while WebNR's current supported local book format is TXT.
+Direct Standard Ebooks import will be evaluated only after WebNR has a real EPUB
+parser, a safe rendering policy, versioned fixtures, and a per-item rights path.
+
+The full Standard Ebooks OPDS feeds are not used by this starter source. This
+avoids depending on feed access paths that may have account, patron, contributor,
+or qualifying-project conditions. A later adapter may use an explicitly permitted
+feed or another documented public interface after the access contract is tested.
+
+Included discovery pages
+------------------------
+- Pride and Prejudice — Jane Austen
+- Frankenstein — Mary Shelley
+- The Picture of Dorian Gray — Oscar Wilde
+- The Time Machine — H. G. Wells
+
+Last verified
+-------------
+2026-08-08

--- a/public/sources/standard-ebooks-starter/search_index.yml
+++ b/public/sources/standard-ebooks-starter/search_index.yml
@@ -1,0 +1,60 @@
+standard-ebooks/pride-and-prejudice.md:
+  title: Pride and Prejudice
+  author: Jane Austen
+  description: Standard Ebooks 的官方作品页。WebNR 当前把它作为合法免费阅读发现入口，不复制 EPUB 文件，也不伪装成 TXT 直链。
+  page_url: https://standardebooks.org/ebooks/jane-austen/pride-and-prejudice
+  source: Standard Ebooks
+  license: CC0-1.0-standard-ebooks
+  tags:
+    - Standard Ebooks
+    - Public domain
+    - Fiction
+  categories:
+    - Free reading discovery
+  region: en-US
+
+standard-ebooks/frankenstein.md:
+  title: Frankenstein
+  author: Mary Shelley
+  description: Standard Ebooks 的官方作品页。页面提供在线阅读与电子书下载；WebNR 当前仅提供发现链接，等待安全 EPUB 解析器后再评估直接导入。
+  page_url: https://standardebooks.org/ebooks/mary-shelley/frankenstein
+  source: Standard Ebooks
+  license: CC0-1.0-standard-ebooks
+  tags:
+    - Standard Ebooks
+    - Public domain
+    - Horror
+    - Science fiction
+  categories:
+    - Free reading discovery
+  region: en-US
+
+standard-ebooks/the-picture-of-dorian-gray.md:
+  title: The Picture of Dorian Gray
+  author: Oscar Wilde
+  description: Standard Ebooks 的官方作品页。WebNR 当前链接到来源页面并保留法域版权提示，不缓存或重新分发第三方文件。
+  page_url: https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray
+  source: Standard Ebooks
+  license: CC0-1.0-standard-ebooks
+  tags:
+    - Standard Ebooks
+    - Public domain
+    - Fiction
+  categories:
+    - Free reading discovery
+  region: en-US
+
+standard-ebooks/the-time-machine.md:
+  title: The Time Machine
+  author: H. G. Wells
+  description: Standard Ebooks 的官方作品页。WebNR 当前提供作品发现与跳转，不把来源站的 EPUB、AZW3 或 KEPUB 文件包装成 TXT 下载。
+  page_url: https://standardebooks.org/ebooks/h-g-wells/the-time-machine
+  source: Standard Ebooks
+  license: CC0-1.0-standard-ebooks
+  tags:
+    - Standard Ebooks
+    - Public domain
+    - Science fiction
+  categories:
+    - Free reading discovery
+  region: en-US


### PR DESCRIPTION
## Outcome

Complete the 2026-08-08 reader-content and source-growth assignment from the repository-authoritative daily task.

## Reader asset

Publish `2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录` at the dated 2026-08-08 blog path. The guide distinguishes public-domain status, author authorization, free access, institutional Full View, discovery metadata, direct imports, format adapters, and jurisdiction-specific rights instead of treating every free page as redistributable content.

It covers current verified routes including Standard Ebooks, Project Gutenberg, Aozora Bunko, Project Madurai, Project Ben-Yehuda, Wikisource, Project Runeberg, HathiTrust, DPLA, Library of Congress/Google Books-style discovery, and Internet Archive as a rights-heterogeneous research candidate. It links back to the existing Legado source guide and gives the practical answer near the top.

## Passing source integration

Add `https://app.webnovel.win/sources/standard-ebooks-starter` as WebNR's third maintained source.

- four fresh official work-page links: `Pride and Prejudice`, `Frankenstein`, `The Picture of Dorian Gray`, and `The Time Machine`
- link-based discovery only; no copied or proxied EPUB/AZW3/KEPUB files
- no fake TXT download action while WebNR remains TXT-only
- Standard Ebooks-produced content is identified with its CC0 boundary; underlying literary-work copyright remains jurisdiction-dependent
- full-feed access is deliberately not required by this starter source

## Daily analysis and source queue

The 2026-08-08 record documents:

- exact starting app/docs production at owner-corrected commit `070c150575e7b69414226c60e2cb1a70c5310d7a`
- single GA4 `G-DGH8HNQKE4`, full-URL policy, and obsolete-destination rejection
- configured Drive folder accessible but still exposing no GA4/GSC exports; unavailable remains unavailable, not zero
- six new candidate directions: HathiTrust, DPLA, Google Books Full View, Internet Archive Texts/metadata, Project Madurai, and Project Ben-Yehuda
- full audits of Standard Ebooks, Project Madurai, and Project Ben-Yehuda
- rotating health checks for WebNR Originals and Aozora Bunko Starter through retained output assertions
- six explicit technical/content/source/search/community/measurement decisions

## Shared skill update

Move `.github/seo-skills` from `f6e9479e7d979620985ae6125cefc5e614978ea3` to reviewed `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`.

The three upstream commits add an optional static-site snapshot helper and bind GA4 weekly exports to explicit private property IDs plus adjacent private source manifests. This is compatible with WebNR and directly addresses the same-name GA4 property routing-collision class recorded by the owner correction. No private property ID or raw provider data enters this repository.

## Expected validation

- dependency audit
- ESLint
- TypeScript
- Next.js production build
- single-GA4/full-URL assertions and obsolete-destination rejection
- source-output assertions for WebNR Originals, Aozora Bunko Starter, and Standard Ebooks Starter
- strict MkDocs build
- generated 2026-08-06 and 2026-08-08 reader-page assertions
- Production evidence for the current recorded public baseline

After every expected job is green, restart review from the daily task and inspect the complete final diff, all commits, generated outputs, source/license boundaries, external links, submodule movement, analytics behavior, mergeability, and affected/unaffected routes before squash merge.

## Production acceptance

Application:

- exact squash commit reaches `app-pages`
- `/sources/standard-ebooks-starter/search_index.yml` and `README.txt` are present
- the four official Standard Ebooks work pages remain the only item actions
- existing WebNR Originals and Aozora source artifacts remain present
- `G-DGH8HNQKE4` full-URL behavior remains and `G-NL0WV2XMJN` is absent

Documentation:

- exact squash commit reaches `gh-pages`
- `/blog/2026/08/08/legal-free-novels-txt-collections/` renders the full guide
- canonical/sitemap/RSS/static HTML are generated by the existing strict MkDocs pipeline
- the existing Legado guide and TXT troubleshooting content remain present
- single-GA4 output remains correct

## Rollback

Revert the squash commit to remove the new guide, Standard Ebooks discovery catalog, added CI assertions, daily record, and submodule pointer together. Existing browser-local user books and repositories are not mutated.