### PR TITLE
Close out the 2026-08-08 free-reading cycle

### DIFF
--- a/.github/seo-data/daily/2026-08-08.md
+++ b/.github/seo-data/daily/2026-08-08.md
@@ -8,42 +8,44 @@ Complete the 2026-08-08 repository-authoritative cycle: verify the owner-correct
 
 - Local operating date: 2026-08-08 (`America/Los_Angeles`).
 - Starting `main`: `070c150575e7b69414226c60e2cb1a70c5310d7a`, merged through pull request #53 after the owner corrected WebNR back to one historical GA4 destination.
-- Starting application production: `app-pages/build.json` identifies `070c150575e7b69414226c60e2cb1a70c5310d7a`, built on 2026-08-08.
-- Starting documentation production: `gh-pages/build.json` identifies the same `070c150575e7b69414226c60e2cb1a70c5310d7a` source commit.
+- Starting application production: `app-pages/build.json` identified `070c150575e7b69414226c60e2cb1a70c5310d7a`, built on 2026-08-08.
+- Starting documentation production: `gh-pages/build.json` identified the same `070c150575e7b69414226c60e2cb1a70c5310d7a` source commit.
 - Analytics contract: both public surfaces retain the single destination `G-DGH8HNQKE4`; the obsolete `G-NL0WV2XMJN` destination is rejected by CI. The reader preserves full-URL reporting, including query strings and `?add=...`, while Google signals and ad-personalization signals remain disabled.
 - Google Drive: the configured `webNR SEO Weekly CSV` folder is accessible, but a direct parent-folder listing on 2026-08-08 returned no visible export files. GA4 and Search Console aggregates, 7-day comparisons, 28-day comparisons, CTR, landing-page movement, and query movement remain unavailable rather than zero.
 - Cloudflare: the connected account state recorded by the repository still does not expose `webnovel.win`; infrastructure traffic remains unavailable and non-blocking.
 - Open WebNR automation pull requests: none at the start of this cycle. Open repository issues: none found.
-- Existing source-health baseline: the exact application production branch still contains `WebNR Originals` and `Aozora Bunko Starter` source artifacts. Their last completed source-cycle evidence remains valid; today's main change also keeps both source-output assertions in CI.
-- Reader-content cadence: the 2026-08-06 Legado source guide was the prior qualifying asset; the dated 2026-08-08 slot is now due and therefore must reach documentation production in this cycle.
+- Existing source-health baseline: the exact application production branch contained `WebNR Originals` and `Aozora Bunko Starter` source artifacts. The final main change preserved both and added permanent CI assertions for the new Standard Ebooks source.
+- Reader-content cadence: the 2026-08-06 Legado source guide was the prior qualifying asset; the dated 2026-08-08 slot was due and is now in production.
 
 ## Data analysis
 
 ### Acquisition and search
 
-No finalized GA4 or Search Console export is visible in the configured Drive folder, so this cycle makes no numerical claim about users, sessions, clicks, impressions, CTR, rankings, countries, devices, landing pages, or query growth. The search decision is based on the explicit reader question already scheduled for 2026-08-08 and on verified source availability rather than inferred traffic.
+No finalized GA4 or Search Console export is visible in the configured Drive folder, so this cycle makes no numerical claim about users, sessions, clicks, impressions, CTR, rankings, countries, devices, landing pages, or query growth. The search decision is based on the explicit reader question scheduled for 2026-08-08 and on verified source availability rather than inferred traffic.
 
-The current documentation production still contains the Legado source-finding article under a stable canonical. Today's new page answers the adjacent intent — where a reader can legally find free novels, public-domain literature, author-authorized text, and TXT/ebook collections — and links naturally back to the Legado source guide rather than creating a keyword variant.
+The current documentation production contains the Legado source-finding article under a stable canonical. The new page answers the adjacent intent — where a reader can legally find free novels, public-domain literature, author-authorized text, and TXT/ebook collections — and links naturally back to the Legado source guide rather than creating a keyword variant.
 
 ### Content and community
 
-Today's asset is a practical reader directory, not a community-consensus article, so no social-platform sampling is required. The page uses current first-hand source checks and official project pages. Public-community analysis remains reserved for the later discussion-radar and community-map assignments where a reproducible sample is part of the claim.
+The asset is a practical reader directory, not a community-consensus article, so no social-platform sampling was required. The page uses current first-hand source checks and official project pages. Public-community analysis remains reserved for the later discussion-radar and community-map assignments where a reproducible sample is part of the claim.
 
 The article distinguishes direct TXT use, official discovery links, format adapters, institution full-view access, and jurisdiction-dependent rights. It does not publish a generic title dump or claim that one project's public-domain determination applies worldwide.
 
 ### Product and delivery
 
-The owner correction in #53 is already exact in both deployment branches and in CI: `G-DGH8HNQKE4` is required and the obsolete destination is rejected. No additional runtime analytics defect is established from current production evidence.
+The owner correction in #53 was exact in both starting deployment branches and in CI: `G-DGH8HNQKE4` was required and the obsolete destination was rejected. No additional runtime analytics defect was established from production evidence.
 
-A supporting-record wording drift remains: older generic analysis/calendar wording still mentions “both configured GA4 destinations” even though `daily-task.md`, `site.md`, `status.md`, the late 2026-08-07 correction, runtime source, CI, and both deployed builds now define one destination. This is a repository-contract wording defect rather than a production measurement defect; it will be corrected in the metadata closeout after today's rendered work has exact delivery evidence.
+A supporting-record wording drift remained: older generic analysis/calendar wording mentioned “both configured GA4 destinations” even though `daily-task.md`, `site.md`, `status.md`, the late 2026-08-07 correction, runtime source, CI, and deployed builds now define one destination. The metadata closeout corrects those generic records to the configured single destination without rewriting historical daily evidence.
 
-No other confirmed low-risk runtime regression was established before implementation. Dependency audit, lint, typecheck, production application build, strict documentation build, integrated-source assertions, analytics assertions, and Production evidence remain the authoritative regression gates.
+The first PR attempt exposed a second evidence defect before merge: `status.md` still recorded the pre-#53 application/documentation commits even though both public deployment branches already pointed at #53. The permanent Production evidence job correctly stayed busy against the mismatched record. The same branch repaired the recorded baseline to `070c150575e7b69414226c60e2cb1a70c5310d7a`; the replacement Quality run then passed Production evidence. This is treated as a same-cycle technical repair, not as missing traffic or a human blocker.
+
+No other confirmed low-risk runtime regression was established. Dependency audit, lint, typecheck, production application build, strict documentation build, integrated-source assertions, analytics assertions, and Production evidence all passed on the final reviewed head.
 
 ### Shared skill review
 
 Pinned skill at cycle start: `f6e9479e7d979620985ae6125cefc5e614978ea3`.
 
-Reviewed upstream through `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`. The three upstream commits add an optional static-site snapshot helper and, importantly, bind weekly GA4 CSV exports to an explicit private property ID and adjacent private source manifest instead of display-name matching. That change directly addresses the class of same-name GA4 routing collision recorded by the owner correction. The update preserves consumer-owned SEO-data layout and adds no required public identifiers, so this cycle adopts the new pinned pointer.
+Reviewed upstream through `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`. The three upstream commits add an optional static-site snapshot helper and, importantly, bind weekly GA4 CSV exports to an explicit private property ID and adjacent private source manifest instead of display-name matching. That change directly addresses the class of same-name GA4 routing collision recorded by the owner correction. The update preserves consumer-owned SEO-data layout and adds no required public identifiers, so this cycle adopted the new pinned pointer.
 
 ## Source discovery
 
@@ -66,7 +68,7 @@ Official Standard Ebooks pages identify the project as a producer of free, caref
 
 Fresh checks confirmed official pages for `Pride and Prejudice`, `Frankenstein`, `The Picture of Dorian Gray`, and `The Time Machine`, each with online reading and ebook download routes. WebNR still has a truthful TXT-only local-format boundary, so today's safe integration stores only WebNR-authored descriptions plus title, author, and official work-page links. It copies no EPUB/AZW3/KEPUB files and exposes no fake TXT import action.
 
-Decision: integrate `https://app.webnovel.win/sources/standard-ebooks-starter` as the third WebNR-maintained source. Defer direct Standard Ebooks reading until a real EPUB parser, safe rendering policy, versioned fixtures, and per-item rights path exist. Do not depend on a full feed whose access path has not been explicitly adopted and tested.
+Decision: integrated `https://app.webnovel.win/sources/standard-ebooks-starter` as the third WebNR-maintained source. Direct Standard Ebooks reading remains deferred until a real EPUB parser, safe rendering policy, versioned fixtures, and per-item rights path exist. The starter does not depend on a full feed whose access path has not been explicitly adopted and tested.
 
 ### Project Madurai — accepted for adapter design, deferred from runtime integration
 
@@ -93,33 +95,37 @@ Decision: keep Project Ben-Yehuda in the regional adapter queue and require the 
 
 ## Existing source health
 
-- **WebNR Originals:** production artifact remains present; no third-party network, login, payment, captcha, or rights dependency is introduced by today's change.
-- **Aozora Bunko Starter:** production artifact remains present with official book-card links and no direct-download URL. No direct ZIP/Shift_JIS/ruby claim is added today.
-- Today's Quality workflow will retain existing assertions for both sources and add assertions for the Standard Ebooks Starter source.
+- **WebNR Originals:** retained in the exact new application production build; CI verifies its index, terms, CC0 fixture, and title.
+- **Aozora Bunko Starter:** retained in the exact new application production build with official book-card links and no direct-download URL; CI verifies representative titles, attribution marker, and official card link.
+- **Standard Ebooks Starter:** present in the exact new application production build with four official work-page entries and source terms. It remains link-only and contains no copied ebook files.
 
 ## Required decisions
 
-1. **Technical:** no new production runtime defect established; correct the remaining single-vs-dual GA4 wording drift during closeout after rendered delivery is verified.
-2. **Content:** publish the scheduled legal-free-novels/TXT directory now; it is due in the rolling 48-hour cadence and answers a distinct reader question.
-3. **Source:** integrate Standard Ebooks Starter as link-based discovery; retain Project Madurai and Project Ben-Yehuda for fixture-driven adapter work; retain HathiTrust/DPLA/Google Books/Internet Archive as discovery candidates with explicit rights/access boundaries.
-4. **Search:** create the genuinely missing free-reading directory, link it to the Legado guide, and require stable canonical, sitemap/RSS inclusion, static HTML, and exact documentation build identity.
-5. **Community:** no community-wide claim today; preserve the scheduled later discussion-radar sampling work rather than manufacture social evidence.
-6. **Measurement:** preserve the single `G-DGH8HNQKE4` full-URL implementation and continue marking GA4/GSC exports unavailable until correctly routed files reappear. Adopt the reviewed shared-skill export-source binding so future exports can be tied to an explicit private property source.
+1. **Technical:** repaired the stale recorded deployment baseline and corrected remaining generic dual-GA4 wording in closeout; no unresolved production defect remains from this cycle.
+2. **Content:** published the scheduled legal-free-novels/TXT directory; it satisfies the rolling 48-hour reader-content slot and answers a distinct reader question.
+3. **Source:** integrated Standard Ebooks Starter as link-based discovery; retained Project Madurai and Project Ben-Yehuda for fixture-driven adapter work; retained HathiTrust/DPLA/Google Books/Internet Archive as discovery candidates with explicit rights/access boundaries.
+4. **Search:** published the genuinely missing free-reading directory, linked it to the Legado guide, and verified its canonical, sitemap entry, RSS item, static HTML, and exact documentation build identity.
+5. **Community:** no community-wide claim was made today; the scheduled later discussion-radar sampling work remains the appropriate place for community inference.
+6. **Measurement:** preserved the single `G-DGH8HNQKE4` full-URL implementation, continued to mark GA4/GSC exports unavailable, and adopted the reviewed shared-skill export-source binding so future exports can be tied to an explicit private property source.
 
-## Main change plan and acceptance
+## Main delivery
 
-Main branch: `seo/free-novels-standard-ebooks-2026-08-08`.
+- Main pull request: #54 `Publish legal free novels guide and Standard Ebooks source`.
+- Final reviewed head: `4b4acb865b6978f739435dd21a2b62df9ea8ce0e`.
+- Final Quality run: `31269500150`.
+- Quality result: Web quality succeeded; Documentation quality succeeded; Production evidence succeeded.
+- From-scratch review after green CI: complete final diff, seven changed paths, commits, source boundaries, fresh official work-page links, shared-skill pointer, single-GA4 behavior, generated article/source assertions, mergeability, and representative unaffected content were reviewed. No unresolved review thread remained.
+- Squash merge: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`.
+- Application production: `app-pages/build.json` identifies `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`, built at `2026-08-08T17:30:52.360Z`.
+- Documentation production: `gh-pages/build.json` identifies `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`, built at `2026-08-08T17:30:43.452741+00:00`.
+- Application acceptance: `sources/standard-ebooks-starter/search_index.yml` and `README.txt` exist in the exact app production branch; the catalog contains the four intended official work-page links and no ebook download URL.
+- Documentation acceptance: `blog/2026/08/08/legal-free-novels-txt-collections/index.html` exists in the exact docs production branch with the intended canonical and single `G-DGH8HNQKE4` loader.
+- Search discovery acceptance: `sitemap.xml` includes the new canonical and `feed_rss_created.xml` includes the new article as the newest item.
+- Existing content/source acceptance: the prior Legado guide, TXT troubleshooting checks, WebNR Originals, and Aozora Bunko Starter all remained covered by the successful Quality workflow.
+- Rollback: revert `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3` if the rendered content or source integration needs to be withdrawn; browser-local user data is not mutated by this release.
 
-Planned rendered outcomes:
+## Closeout
 
-- documentation article: `/blog/2026/08/08/legal-free-novels-txt-collections/`;
-- app source: `/sources/standard-ebooks-starter/search_index.yml` plus source terms;
-- current single-GA4 behavior preserved in application and documentation;
-- WebNR Originals and Aozora Bunko Starter preserved;
-- pinned shared skill moves to reviewed `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`.
+This closeout updates only repository-owned operating metadata and corrects generic single-GA4 wording drift. It does not change application or documentation rendered output, so it should not trigger another production deployment. Its own pull request must still pass all expected Quality jobs, including permanent Production evidence against `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`, receive a fresh complete diff review, and squash-merge before the 2026-08-08 cycle is complete.
 
-Required CI before merge: dependency audit, ESLint, TypeScript, Next.js production build, source-output assertions for all three integrated sources, single-GA4/full-URL assertions, strict MkDocs build, generated 2026-08-08 article checks, and Production evidence for the currently recorded baseline.
-
-After green CI, the complete base-to-head diff, every commit, generated outputs, external links/rights claims, source actions, analytics behavior, skill pointer, and unaffected reader routes must be reviewed from the original daily task before squash merge.
-
-Delivery fields remain pending until CI, final review, squash merge, exact app/docs production, public acceptance, and metadata closeout complete.
+Next dated reader-content slot: **2026-08-10**, a reader-oriented comparison of English serial-fiction platforms. Daily source discovery, audits, integration attempts, source health, technical monitoring, and measurement checks continue before then.

--- a/.github/seo-data/data-analysis.md
+++ b/.github/seo-data/data-analysis.md
@@ -17,7 +17,7 @@ aggregates, evidence status, comparisons, decisions, and delivery results.
 Read every source that is currently available and label unavailable sources
 truthfully:
 
-1. **GA4** — both configured WebNR destinations, using finalized exports or
+1. **GA4** — the configured WebNR destination, using finalized exports or
    connected provider evidence when available.
 2. **Google Search Console** — query, page, country, device, search appearance,
    date, indexing, and sitemap evidence when available.
@@ -26,8 +26,8 @@ truthfully:
 4. **GitHub and delivery** — pull requests, issues, CI, dependency audit,
    deployments, build identities, workflow failures, and release state.
 5. **Public production** — application and documentation routes, status codes,
-   canonical, robots, sitemap, rendered content, dual GA4, important user flows,
-   and source-health checks.
+   canonical, robots, sitemap, rendered content, configured GA4, important user
+   flows, and source-health checks.
 6. **Reader-content evidence** — publication dates, internal links, indexed pages,
    landing-page performance, query coverage, referrals, and content freshness.
 7. **Source program evidence** — candidates discovered, candidates fully audited,

--- a/.github/seo-data/editorial-calendar.md
+++ b/.github/seo-data/editorial-calendar.md
@@ -79,6 +79,6 @@ A scheduled asset is complete only when:
 - source, platform, app, and channel facts have current verification dates;
 - related pages and relevant WebNR import routes are linked naturally;
 - canonical, sitemap, static rendered HTML, and intended navigation are correct;
-- both configured GA4 destinations and the exact build identity remain present;
+- the configured GA4 destination and the exact build identity remain present;
 - the real pull request, CI, squash merge, production deployment, and public page
   verification have completed.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,9 +2,9 @@
 
 ## Current state
 
-- Last completed product, source, and reader-content change: pull request #51, squash merge `dbb83c0005787d13db9ed13caa15012e89f21953`
-- Last successful attributable application deployment: `070c150575e7b69414226c60e2cb1a70c5310d7a`
-- Last successful attributable documentation deployment: `070c150575e7b69414226c60e2cb1a70c5310d7a`
+- Last completed product, source, and reader-content change: pull request #54, squash merge `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
+- Last successful attributable application deployment: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
+- Last successful attributable documentation deployment: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
@@ -20,25 +20,27 @@
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
 - Connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GitHub Pages production verification, GA4, Search Console, product delivery, content production, or source work.
 - Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, single-GA4 output assertions, integrated-source output, and recorded public production evidence.
-- The first reader-discovery article, `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南`, remains in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
+- The reader guide `2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录` is in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/08/legal-free-novels-txt-collections/`, sitemap entry, and RSS item.
+- The earlier reader-discovery article `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南` remains in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
 - `WebNR Originals` remains the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》.
-- `Aozora Bunko Starter` is the second passing integrated source. The exact application production build contains its attributed four-work discovery catalog, links to official Aozora book cards, and no direct download URL.
-- Same-origin repository identity now derives from the source directory when present, and stored repository name/count/freshness metadata refreshes during sync and `?repos=` re-import. Multiple WebNR-maintained sources no longer collapse to the generic hostname identity.
+- `Aozora Bunko Starter` remains the second passing integrated source. The exact application production build contains its attributed four-work discovery catalog, links to official Aozora book cards, and no direct download URL.
+- `Standard Ebooks Starter` is the third passing integrated source. The exact application production build contains four official Standard Ebooks work-page links, source terms, jurisdiction caveats, and no copied or proxied ebook file.
+- Same-origin repository identity derives from the source directory when present, and stored repository name/count/freshness metadata refreshes during sync and `?repos=` re-import. Multiple WebNR-maintained sources no longer collapse to the generic hostname identity.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
-- Reader-content publishing targets one substantial production asset per rolling 48-hour window. The 2026-08-08 asset on legal free novels and TXT collections is in delivery during the current cycle.
+- Reader-content publishing targets one substantial production asset per rolling 48-hour window. The next dated editorial slot is 2026-08-10: reader-oriented comparison of English serial-fiction platforms.
 - Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt.
 - Current adapter/source queue includes Project Gutenberg, Wikisource, NDL Search/Digital Collections, Open Library, Library of Congress, Gallica, Project Runeberg, HathiTrust, DPLA, Google Books Full View, Project Madurai, Project Ben-Yehuda, and collection-specific Internet Archive research. Candidates remain subject to their exact API, attribution, rights, rate, access, and per-item conditions.
-- Standard Ebooks is moving from a deferred feed candidate to a link-based discovery source that does not depend on full-feed access.
+- Standard Ebooks now has a production link-based discovery source that does not depend on full-feed access; direct reading remains deferred until EPUB support and rights fixtures exist.
 - Community Legado definitions remain isolated compatibility-corpus candidates until target-site authorization and health are audited.
 - Legado compatibility claims remain tied to tested capability levels and fixture-suite versions.
-- The pinned shared skill now includes explicit private GA4 property binding and adjacent source-manifest validation for weekly exports, preventing same-name property display labels from silently selecting the wrong property.
+- The pinned shared skill includes explicit private GA4 property binding and adjacent source-manifest validation for weekly exports, preventing same-name property display labels from silently selecting the wrong property.
 - Branch cleanup is best-effort and nonblocking.
 
 ## Active focus
 
-1. Complete PR/CI/deployment/public verification for the 2026-08-08 legal-free-novels reader directory and Standard Ebooks Starter source, then close it out truthfully.
-2. Continue daily source discovery: at least five candidates, three full audits, one passing integration attempt, plus rotating health checks of WebNR Originals, Aozora Bunko Starter, and newly integrated sources.
+1. Prepare the 2026-08-10 reader comparison of English serial-fiction platforms using current reader-facing evidence, clear selection criteria, and no unsupported popularity claims.
+2. Continue daily source discovery: at least five candidates, three full audits, one passing integration attempt, plus rotating health checks of WebNR Originals, Aozora Bunko Starter, and Standard Ebooks Starter.
 3. Advance the next safe adapter design from Project Gutenberg, Wikisource, Project Madurai, Project Ben-Yehuda, HathiTrust, DPLA, Google Books, NDL, Open Library, Library of Congress, Gallica, or Project Runeberg based on explicit license/API/rate/rights evidence.
 4. Re-establish correctly routed GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
 5. Continue concentrated technical-repair and daily regression monitoring; confirmed low-risk defects are fixed in the same cycle.


### PR DESCRIPTION
## Closeout

Record the completed 2026-08-08 WebNR reader-content and source-growth cycle after pull request #54 reached exact application and documentation production.

## Verified delivery

- main change: pull request #54
- final reviewed head: `4b4acb865b6978f739435dd21a2b62df9ea8ce0e`
- final Quality run `31269500150`: Web quality, Documentation quality, and Production evidence all succeeded
- squash commit: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
- exact application production: `app-pages/build.json` identifies the squash commit, built at `2026-08-08T17:30:52.360Z`
- exact documentation production: `gh-pages/build.json` identifies the squash commit, built at `2026-08-08T17:30:43.452741+00:00`
- Standard Ebooks Starter exists in the exact application build with four official work-page links and no copied ebook file
- the 2026-08-08 legal-free-novels/TXT reader directory exists in the exact documentation build with intended canonical, sitemap entry, RSS item, and single GA4
- current Google Drive folder remains accessible but exposes no GA4/GSC exports; unavailable remains unavailable rather than zero

## Contract repair

The owner corrected WebNR back to the single GA4 destination `G-DGH8HNQKE4` in #53. This closeout removes the remaining generic dual-destination wording from `data-analysis.md` and `editorial-calendar.md` without rewriting historical daily records. It also records the same-cycle repair of stale deployment labels that initially pointed Production evidence at pre-#53 builds.

## Files

- `.github/seo-data/daily/2026-08-08.md`
- `.github/seo-data/data-analysis.md`
- `.github/seo-data/editorial-calendar.md`
- `.github/seo-data/status.md`

## Scope and deployment

Metadata-only closeout. It changes no application or documentation-rendered content and should not trigger another production deployment. The two stable deployment labels in `status.md` now point to the exact #54 source commit consumed by `scripts/verify-production-builds.mjs`.

## Expected checks

- Web quality
- Documentation quality
- Production evidence

After green CI, review the complete four-file diff from the repository-authoritative daily task, verify exact commit labels, single-GA4 wording, next editorial slot, data qualifications, and absence of rendered-site changes, then squash-merge with the expected head SHA.