### PR TITLE
Record www.webnovel.win as the sole canonical WebNR site

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,8 +1,24 @@
 # Human-only blockers
 
-No human-only blockers.
+## `www.webnovel.win` Cloudflare production routing
 
-The connected Cloudflare accounts do not currently expose the `webnovel.win` zone, and Google Drive does not currently contain matching GA4 or Search Console exports. These data-source gaps are tracked in `status.md`; automation must continue using public-site, repository, CI, and deployment evidence rather than stopping or fabricating analytics.
+**Blocked action:** make `https://www.webnovel.win/` serve the current reviewed WebNR documentation/editorial build while keeping it the single canonical public documentation hostname.
+
+**Verified 2026-08-08 evidence:**
+
+- a cache-busted GitHub Actions routing diagnostic resolved `www.webnovel.win` to Cloudflare edge addresses and received HTTP 200 from Cloudflare for the root page;
+- that root still served the older `WebNR - Web Novel Reader` documentation/site shell, while `https://www.webnovel.win/build.json` returned HTTP 404, so the canonical hostname has no attributable current build identity;
+- `https://autoarchive.github.io/webNR/build.json` exposed the current documentation build commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`;
+- `https://app.webnovel.win/build.json` and `https://webnr.pages.dev/build.json` exposed the same current application commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3` and the Pages project served the reader application, not the documentation site;
+- historical pull request #40 records why the project temporarily moved documentation canonicals to the GitHub Pages project URL: the earlier `www` route was on Cloudflare, GitHub Pages reported no custom domain, and the available GitHub/Cloudflare connections could not change the required external routing.
+
+**Why automation cannot finish this step:** the currently connected tools provide repository administration and read-only public routing evidence, but no authenticated Cloudflare zone/Pages/Worker/custom-domain control for the `webnovel.win` zone. The GitHub Pages custom-domain fallback was already tested historically and must not be repeated as a substitute for fixing the actual Cloudflare route.
+
+**Minimal external action required:** using the Cloudflare account that controls `webnovel.win`, identify the Pages project, Worker route, or origin currently attached to `www.webnovel.win` and replace that stale route with a documentation deployment sourced from the reviewed `AutoArchive/webNR` default branch and built with the repository's MkDocs pipeline. Attach `www.webnovel.win` to that documentation deployment. Do **not** attach `www.webnovel.win` to `webnr.pages.dev`, because that Pages project is the reader application. Preserve `app.webnovel.win` for the reader application.
+
+**Acceptance after the external action:** automation resumes pull request #56, requires `https://www.webnovel.win/build.json` to expose the exact reviewed/squash commit, verifies the current 2026-08-08 reader article, canonical/sitemap/RSS output, GA4, and representative documentation directly on `www`, then completes the permanent production-evidence and closeout changes.
+
+The configured Google Drive folder currently contains no matching GA4 or Search Console exports. That data-source gap is not a human blocker and must continue to be reported as unavailable rather than zero.
 
 Merged automation branch cleanup is best-effort repository hygiene. A connector without a branch-deletion operation, or a harmless failure to delete an already-merged head branch, is not a blocker and must not be recorded here.
 

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -78,7 +78,7 @@ owner instruction recorded in the relevant pull request and daily report.
 ### Documentation build mirror
 
 - Provider: `github-actions` plus GitHub Pages
-- Workflow: `Publish WebNR documentation build mirror`
+- Current workflow: `Publish WebNR documentation`
 - Source: `gh-pages` branch
 - Mirror URL: `https://autoarchive.github.io/webNR/`
 - Custom domain: none

--- a/.github/seo-data/site.md
+++ b/.github/seo-data/site.md
@@ -2,9 +2,26 @@
 
 ## Identity
 
-- Canonical URL: `https://app.webnovel.win/`
+- Canonical public site URL: `https://www.webnovel.win/`
 - Site name: `WebNR`
+- Reader application URL: `https://app.webnovel.win/`
+- Documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Timezone: `America/Los_Angeles`
+
+`https://www.webnovel.win/` is the single canonical public origin for WebNR
+reader-facing content, documentation, blog articles, search indexing, canonical
+links, sitemap and RSS output, and public documentation links. No other hostname
+is an alternate public identity for those surfaces.
+
+`https://app.webnovel.win/` is the reader application runtime. It may own
+application routes, application source artifacts, application downloads, and
+application-specific metadata, but it is not an alternate origin for the public
+documentation and editorial site.
+
+`https://autoarchive.github.io/webNR/` is a generated documentation build mirror
+used for attributable builds and recovery. It must emit canonicals and discovery
+metadata pointing to `https://www.webnovel.win/`, must not claim the custom
+domain, and must never be promoted as the public canonical site.
 
 ## Repository
 
@@ -14,14 +31,15 @@
 
 ## Analytics
 
-- Runtime analytics required: yes
+- Runtime analytics required: yes, on both the canonical public site and reader application
 - Primary runtime provider: `google-analytics-4`
 - Runtime implementation location: `app/layout.tsx`, `config/constants.ts`, and `mkdocs.yml`
-- Runtime verification URL: `https://app.webnovel.win/`
+- Canonical public-site verification URL: `https://www.webnovel.win/`
+- Reader-application verification URL: `https://app.webnovel.win/`
 - URL reporting: `full-url`
 - Search analytics required: `google-search-console`
 - Search evidence route: Google Drive exports described below
-- Infrastructure analytics: unavailable until the connected Cloudflare account exposes `webnovel.win`
+- Infrastructure analytics: unavailable until an authenticated Cloudflare connection exposes the `webnovel.win` zone
 - Analytics payload policy: send the complete browser page URL, including query parameters such as imported URLs in `?add=...`; disable Google signals and ad-personalization signals; do not add custom events containing local file contents or reading progress
 
 The site owner explicitly requires GA4 and complete page-URL reporting. Agents
@@ -39,19 +57,44 @@ owner instruction recorded in the relevant pull request and daily report.
 
 ## Cloudflare data
 
-- Cloudflare enabled: no
+- Cloudflare analytics enabled: no
 - Zone hostname: `webnovel.win`
 - Preferred dataset: `httpRequestsAdaptiveGroups`
-- Availability note: the connected Cloudflare accounts do not currently expose this zone.
+- Availability note: the currently authenticated analytics connections do not expose this zone.
 
 ## Deployment
 
+### Canonical public documentation and editorial site
+
+- Canonical hostname: `www.webnovel.win`
+- Public edge observed on 2026-08-08: Cloudflare
+- Required source: the reviewed WebNR documentation build generated from the current default-branch commit
+- Verification URL: `https://www.webnovel.win/`
+- Required build identity URL: `https://www.webnovel.win/build.json`
+- Current routing control: unavailable from the connected tooling in this operating environment
+- Acceptance rule: the canonical hostname must expose the exact reviewed documentation build, current reader-facing articles, `G-DGH8HNQKE4`, and canonical/sitemap/RSS URLs under `https://www.webnovel.win/`
+- Prohibited substitution: do not make the GitHub Pages mirror or `app.webnovel.win` the canonical documentation address merely because the canonical hostname is temporarily stale or externally blocked
+
+### Documentation build mirror
+
+- Provider: `github-actions` plus GitHub Pages
+- Workflow: `Publish WebNR documentation build mirror`
+- Source: `gh-pages` branch
+- Mirror URL: `https://autoarchive.github.io/webNR/`
+- Custom domain: none
+- Purpose: attributable generated-build mirror and recovery evidence only
+- Acceptance rule: exact build identity and rendered content may be verified here, but all generated canonical, sitemap, RSS, and public documentation identity must point to `https://www.webnovel.win/`
+
+### Reader application
+
 - Provider: `github-actions`
 - Production workflow: `Deploy Next.js site to Pages`
-- Production environment: `app-pages branch`
+- Production source: `app-pages` branch
 - Verification URL: `https://app.webnovel.win/`
+- Public Cloudflare Pages mirror observed on 2026-08-08: `https://webnr.pages.dev/`
+- Boundary: the application and its source/download artifacts remain separate from the canonical documentation/editorial site
 
 Store only durable public metadata here. Public browser measurement IDs may be
 stored in runtime source. Never add private property IDs, Drive IDs, Cloudflare
-IDs, account identifiers, personal emails, credentials, raw analytics rows,
-cookies, authorization values, or private provider URLs.
+account IDs, personal emails, credentials, raw analytics rows, cookies,
+authorization values, or private provider URLs.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -5,31 +5,39 @@
 - Last completed product, source, and reader-content change: pull request #54, squash merge `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
 - Last successful attributable application deployment: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
 - Last successful attributable documentation deployment: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
+- Canonical public documentation and editorial URL: `https://www.webnovel.win/`
+- Canonical public-site state: externally routed through Cloudflare but stale and currently unattributable; `https://www.webnovel.win/build.json` returned HTTP 404 in the 2026-08-08 cache-busted routing diagnostic
 - Working reader URL: `https://app.webnovel.win/`
-- Working documentation URL: `https://autoarchive.github.io/webNR/`
+- Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
 - Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content check on 2026-08-08 exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
 
 ## Current signals
 
-- Runtime analytics is mandatory on both production sites.
-- Both sites use the single GA4 destination `G-DGH8HNQKE4`.
+- `https://www.webnovel.win/` is the sole canonical public identity for documentation, reader-facing articles, search indexing, canonical tags, sitemap, and RSS. A temporary delivery failure must never cause automation to promote another hostname as the canonical documentation address.
+- `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
+- `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. After the canonical-origin repair it must continue to emit `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
+- The 2026-08-08 routing diagnostic proved that `www.webnovel.win` and the current documentation mirror are different delivery paths: the mirror exposes exact commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`, while `www/build.json` returns 404 and the `www` root serves an older site shell.
+- The same diagnostic proved that `https://webnr.pages.dev/` is the current reader application mirror: its build identity matches `app.webnovel.win` at `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`. It must not be used as the documentation origin for `www`.
+- Pull request #56 is the active canonical-origin repair. Its repository-side target is to generate all documentation canonicals/sitemap/RSS/public links under `https://www.webnovel.win/` while keeping GitHub Pages as a noncanonical build mirror. Exact public completion remains blocked on the external Cloudflare route recorded in `block.md`.
+- Runtime analytics is mandatory on the canonical public site and reader application.
+- Both public surfaces use the single GA4 destination `G-DGH8HNQKE4`.
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
-- Connected Cloudflare accounts do not expose the `webnovel.win` zone. This does not block GitHub Pages production verification, GA4, Search Console, product delivery, content production, or source work.
-- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, single-GA4 output assertions, integrated-source output, and recorded public production evidence.
-- The reader guide `2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录` is in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/08/legal-free-novels-txt-collections/`, sitemap entry, and RSS item.
-- The earlier reader-discovery article `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南` remains in the exact documentation production build with canonical `https://autoarchive.github.io/webNR/blog/2026/08/06/legado-source-guide/`.
+- The currently authenticated Cloudflare analytics connections do not expose the `webnovel.win` zone. This no longer blocks routine repository/product work, but it does block the specific external production-routing repair for the canonical `www` hostname.
+- Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict documentation build, single-GA4 output assertions, integrated-source output, generated canonical/discovery output, and recorded public build evidence.
+- The reader guide `2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录` exists in the exact documentation build mirror. Pull request #56 changes its generated canonical, sitemap entry, and RSS URL to `https://www.webnovel.win/blog/2026/08/08/legal-free-novels-txt-collections/`.
+- The earlier reader-discovery article `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南` remains in the exact documentation build mirror. Pull request #56 changes its generated canonical to `https://www.webnovel.win/blog/2026/08/06/legado-source-guide/`.
 - `WebNR Originals` remains the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》.
 - `Aozora Bunko Starter` remains the second passing integrated source. The exact application production build contains its attributed four-work discovery catalog, links to official Aozora book cards, and no direct download URL.
 - `Standard Ebooks Starter` is the third passing integrated source. The exact application production build contains four official Standard Ebooks work-page links, source terms, jurisdiction caveats, and no copied or proxied ebook file.
 - Same-origin repository identity derives from the source directory when present, and stored repository name/count/freshness metadata refreshes during sync and `?repos=` re-import. Multiple WebNR-maintained sources no longer collapse to the generic hostname identity.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
-- Reader-content publishing targets one substantial production asset per rolling 48-hour window. The next dated editorial slot is 2026-08-10: reader-oriented comparison of English serial-fiction platforms.
-- Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt.
+- Reader-content publishing targets one substantial production asset per rolling 48-hour window, but the canonical-domain production incident preempts the next normal reader-content slot until safe progress on the blocker is exhausted.
+- Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt when no higher-priority production incident is active.
 - Current adapter/source queue includes Project Gutenberg, Wikisource, NDL Search/Digital Collections, Open Library, Library of Congress, Gallica, Project Runeberg, HathiTrust, DPLA, Google Books Full View, Project Madurai, Project Ben-Yehuda, and collection-specific Internet Archive research. Candidates remain subject to their exact API, attribution, rights, rate, access, and per-item conditions.
 - Standard Ebooks now has a production link-based discovery source that does not depend on full-feed access; direct reading remains deferred until EPUB support and rights fixtures exist.
 - Community Legado definitions remain isolated compatibility-corpus candidates until target-site authorization and health are audited.
@@ -39,11 +47,11 @@
 
 ## Active focus
 
-1. Prepare the 2026-08-10 reader comparison of English serial-fiction platforms using current reader-facing evidence, clear selection criteria, and no unsupported popularity claims.
-2. Continue daily source discovery: at least five candidates, three full audits, one passing integration attempt, plus rotating health checks of WebNR Originals, Aozora Bunko Starter, and Standard Ebooks Starter.
-3. Advance the next safe adapter design from Project Gutenberg, Wikisource, Project Madurai, Project Ben-Yehuda, HathiTrust, DPLA, Google Books, NDL, Open Library, Library of Congress, Gallica, or Project Runeberg based on explicit license/API/rate/rights evidence.
-4. Re-establish correctly routed GA4 and Search Console export evidence in the configured Drive folder without blocking product, content, or source work.
-5. Continue concentrated technical-repair and daily regression monitoring; confirmed low-risk defects are fixed in the same cycle.
+1. Restore `https://www.webnovel.win/` as the actually served current documentation/editorial site without changing its canonical identity: complete repository-side canonical output in pull request #56, obtain the external Cloudflare route change recorded in `block.md`, then require exact `/build.json`, current article, sitemap/RSS, GA4, and canonical evidence directly on `www`.
+2. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status during recovery.
+3. Preserve `https://app.webnovel.win/` and its source/download routes as the reader application while verifying that the domain repair does not repoint `www` to the application Pages project.
+4. Resume the 2026-08-10 reader comparison of English serial-fiction platforms after the canonical production incident is resolved or safely blocked with no further autonomous action available.
+5. Continue source discovery, adapter work, correctly routed GA4/Search Console evidence, and concentrated technical monitoring after the production-domain priority clears.
 6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 
 Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities. The two `Last successful attributable ... deployment` lines are stable machine-readable interfaces used by `scripts/verify-production-builds.mjs` and must retain their exact labels.


### PR DESCRIPTION
## Owner correction

Record `https://www.webnovel.win/` as the single real/canonical public WebNR address for documentation, reader-facing articles, search indexing, canonical tags, sitemap, RSS, and public documentation links.

This metadata-only pull request deliberately separates the durable repository contract from the still-blocked rendered-site migration in pull request #56.

## Durable boundaries

- `https://www.webnovel.win/`: sole canonical documentation/editorial/search identity
- `https://app.webnovel.win/`: reader application runtime only
- `https://autoarchive.github.io/webNR/`: attributable documentation build mirror only; never an alternate canonical identity
- `https://webnr.pages.dev/`: observed Cloudflare Pages mirror of the reader application, not the documentation origin

## Incident evidence

A cache-busted GitHub Actions routing diagnostic on 2026-08-08 established that:

- `www.webnovel.win` is served through Cloudflare but still serves an older `WebNR - Web Novel Reader` shell;
- `www.webnovel.win/build.json` returns HTTP 404, so the canonical hostname has no current attributable build identity;
- the GitHub Pages documentation mirror exposes current commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`;
- `app.webnovel.win` and `webnr.pages.dev` expose the current application commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`.

Historical pull request #40 explains the drift: on 2026-08-05 the project temporarily promoted the working GitHub Pages project URL because the old `www` Cloudflare route failed and the then-available tooling could not change the required external domain routing. That workaround must no longer be treated as canonical policy.

## Files

- `.github/seo-data/site.md`: canonical identity, app/mirror boundaries, deployment model, and prohibition on substituting another hostname
- `.github/seo-data/status.md`: current routing incident, exact public evidence, and priority ordering
- `.github/seo-data/block.md`: genuine Cloudflare routing blocker, why the current tools cannot perform it, minimal external action, and exact acceptance criteria

## Deployment impact

None. This PR changes only repository operating metadata under `.github/seo-data/**`. It does not modify MkDocs, application source, generated content, GitHub Pages output, Cloudflare configuration, or public runtime behavior and must not trigger an application or documentation deployment.

Pull request #56 remains the rendered canonical-output repair and must stay unmerged until the external Cloudflare `www` route can be corrected and exact public acceptance can be proven.

## Validation

- Web quality
- Documentation quality
- Production evidence for the unchanged currently attributable application/documentation-build baseline
- complete final review of the three metadata files, exact domain boundaries, incident evidence, public/private data boundary, deployment non-impact, mergeability, and absence of unrelated changes

## Closeout

After green CI and clean final review, squash-merge this metadata-only contract so future autonomous cycles read the corrected canonical policy from `main`. No production deployment wait is expected because rendered outputs are unchanged.