### PR TITLE
Prepare attributable documentation builds for canonical routing

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/nextjs.yml'
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'scripts/build-docs-production.sh'
       - 'scripts/verify-production-builds.mjs'
   workflow_dispatch:
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -98,12 +98,16 @@ jobs:
           cache-dependency-path: .github/requirements-docs.txt
       - name: Install pinned documentation dependencies
         run: pip install --requirement .github/requirements-docs.txt
-      - name: Build documentation strictly
-        run: mkdocs build --strict
+      - name: Build attributable documentation artifact
+        run: |
+          WEBNR_DOCS_BUILD_SHA="$(git rev-parse HEAD)" \
+          WEBNR_DOCS_BUILD_SOURCE='quality-ci' \
+          bash scripts/build-docs-production.sh
       - name: Validate documentation output
         run: |
           set -eu
           test -f site/index.html
+          test -f site/build.json
           test -f site/troubleshooting/txt-import/index.html
           test -f site/blog/2026/08/06/legado-source-guide/index.html
           test -f site/blog/2026/08/08/legal-free-novels-txt-collections/index.html

--- a/scripts/build-docs-production.sh
+++ b/scripts/build-docs-production.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_sha="${WEBNR_DOCS_BUILD_SHA:-${CF_PAGES_COMMIT_SHA:-}}"
+if [ -z "${build_sha}" ]; then
+  build_sha="$(git rev-parse HEAD)"
+fi
+
+if [[ ! "${build_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Invalid documentation build SHA: ${build_sha}" >&2
+  exit 1
+fi
+
+build_source="${WEBNR_DOCS_BUILD_SOURCE:-}"
+if [ -z "${build_source}" ]; then
+  if [ "${CF_PAGES:-}" = '1' ]; then
+    build_source='cloudflare-pages'
+  else
+    build_source='repository-docs-builder'
+  fi
+fi
+
+WEBNR_DOCS_BUILD_SHA="${build_sha}" \
+WEBNR_DOCS_BUILD_SOURCE="${build_source}" \
+python - <<'PY'
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+payload = {
+    "commit": os.environ["WEBNR_DOCS_BUILD_SHA"],
+    "builtAt": datetime.now(timezone.utc).isoformat(),
+    "source": os.environ["WEBNR_DOCS_BUILD_SOURCE"],
+}
+Path("docs/build.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+mkdocs build --strict
+
+# Domain ownership is configured at the serving platform. Never let a stale
+# source-tree CNAME make the generated artifact claim a GitHub Pages domain.
+rm -f site/CNAME
+
+test -f site/index.html
+test -f site/build.json
+grep -Fq "\"commit\": \"${build_sha}\"" site/build.json


### PR DESCRIPTION
## Purpose

Prepare a repository-owned, self-attributing documentation build entrypoint so the external Cloudflare route for `www.webnovel.win` can be repaired without inventing build commands or losing exact source identity.

This PR does **not** change the currently rendered documentation canonical origin, public Cloudflare routing, MkDocs `site_url`, or reader application behavior. The canonical-output migration remains in PR #56.

## Changes

- add `scripts/build-docs-production.sh`
  - consumes `WEBNR_DOCS_BUILD_SHA`, otherwise Cloudflare Pages `CF_PAGES_COMMIT_SHA`, otherwise local `git rev-parse HEAD`
  - writes `docs/build.json` with exact commit, UTC build time, and build source
  - runs `mkdocs build --strict`
  - removes any generated `site/CNAME` so domain ownership remains a serving-platform concern
  - requires `site/index.html`, `site/build.json`, and the exact commit marker
- make Documentation quality execute this exact build entrypoint and require `site/build.json`
- add the builder path to the reader application's deployment `paths-ignore`, so a docs-build-only change cannot deploy a new app artifact

## Why this is needed

The 2026-08-08 routing incident showed that `www.webnovel.win/build.json` is absent while the current GitHub Pages mirror and reader application both expose exact build identities. A future documentation deployment attached to the canonical Cloudflare hostname needs the same attributable identity before PR #56 can be safely merged and verified.

## Cloudflare compatibility

Cloudflare Pages provides `CF_PAGES_COMMIT_SHA`; the builder consumes that variable directly when present. The intended future documentation Pages configuration is therefore repository-owned rather than dashboard-specific:

- production branch: `main`
- install/build command: `python -m pip install --requirement .github/requirements-docs.txt && bash scripts/build-docs-production.sh`
- output directory: `site`
- Python: 3.12 for parity with repository CI

The external custom-domain/routing action remains recorded in `.github/seo-data/block.md`. Do not attach `www.webnovel.win` to the existing `webnr.pages.dev` application project.

## Deployment impact

No intended rendered deployment. The documentation publisher does not include this script or Quality/Next.js workflow paths in its production trigger set. The Next.js production workflow explicitly ignores this builder path. Cloudflare may create its normal PR preview for the existing application project, but that preview is not production evidence.

## Validation

- Web quality: unchanged application build, analytics, and source assertions
- Documentation quality: pinned dependencies, exact builder invocation, strict MkDocs output, exact `site/build.json`, and existing production-content assertions
- Production evidence: current application and documentation mirror remain unchanged and attributable
- final review of all three files, trigger boundaries, exact-SHA behavior, absence of credentials/private IDs, mergeability, and comments/threads

After green CI and clean final review, squash merge. No production deployment wait is expected because no rendered-site production trigger should fire.