### PR TITLE
Fix Cloudflare documentation build entrypoint

### DIFF
--- a/scripts/build-docs-production.sh
+++ b/scripts/build-docs-production.sh
@@ -36,6 +36,10 @@ payload = {
 Path("docs/build.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
 
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+  git fetch --unshallow --tags
+fi
+
 python -m mkdocs build --strict
 
 # Domain ownership is configured at the serving platform. Never let a stale

--- a/scripts/build-docs-production.sh
+++ b/scripts/build-docs-production.sh
@@ -36,7 +36,7 @@ payload = {
 Path("docs/build.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 PY
 
-mkdocs build --strict
+python -m mkdocs build --strict
 
 # Domain ownership is configured at the serving platform. Never let a stale
 # source-tree CNAME make the generated artifact claim a GitHub Pages domain.


### PR DESCRIPTION
## Summary
- invoke MkDocs through the active Python interpreter in the production documentation builder
- unshallow CI clones before plugins read Git revision history
- preserve the existing strict build and build identity checks

## Root cause
The first Cloudflare build installed dependencies but the standalone mkdocs launcher was not on PATH. After correcting that, mkdocs-rss-plugin failed while inspecting Cloudflare's shallow clone. The builder now uses the interpreter module entrypoint and restores full Git history only when the checkout is shallow.

## Validation
- Git Bash syntax check passed for scripts/build-docs-production.sh
- git diff --check passed
- production verification will use the new Cloudflare Pages project before any canonical-domain cutover