### PR TITLE
Close out the WebNR production routing repair

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,24 +1,6 @@
 # Human-only blockers
 
-## `www.webnovel.win` Cloudflare production routing
-
-**Blocked action:** make `https://www.webnovel.win/` serve the current reviewed WebNR documentation/editorial build while keeping it the single canonical public documentation hostname.
-
-**Verified 2026-08-08 evidence:**
-
-- a cache-busted GitHub Actions routing diagnostic resolved `www.webnovel.win` to Cloudflare edge addresses and received HTTP 200 from Cloudflare for the root page;
-- that root still served the older `WebNR - Web Novel Reader` documentation/site shell, while `https://www.webnovel.win/build.json` returned HTTP 404, so the canonical hostname has no attributable current build identity;
-- `https://autoarchive.github.io/webNR/build.json` exposed the current documentation build commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`;
-- `https://app.webnovel.win/build.json` and `https://webnr.pages.dev/build.json` exposed the same current application commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3` and the Pages project served the reader application, not the documentation site;
-- historical pull request #40 records why the project temporarily moved documentation canonicals to the GitHub Pages project URL: the earlier `www` route was on Cloudflare, GitHub Pages reported no custom domain, and the available GitHub/Cloudflare connections could not change the required external routing;
-- pull request #58 merged the repository-owned `scripts/build-docs-production.sh` entrypoint to `main`, so a documentation Pages deployment can now emit an exact `/build.json` from Cloudflare's commit SHA without dashboard-specific build logic;
-- pull request #59 is the active rendered-site repair. Repository-side Quality run `31277096343` passed Web quality, Documentation quality, and Production evidence; its generated documentation uses `www.webnovel.win` canonicals, sitemap, RSS, current reader articles, and single GA4 while keeping GitHub Pages noncanonical.
-
-**Why automation cannot finish this step:** the currently connected tools provide repository administration and read-only public routing evidence, but no authenticated Cloudflare zone/Pages/Worker/custom-domain control for the `webnovel.win` zone. The GitHub Pages custom-domain fallback was already tested historically and must not be repeated as a substitute for fixing the actual Cloudflare route.
-
-**Minimal external action required:** using the Cloudflare account that controls `webnovel.win`, create or select a documentation Pages deployment sourced from `AutoArchive/webNR` with production branch `main`; set the build command to `python -m pip install --requirement .github/requirements-docs.txt && bash scripts/build-docs-production.sh`, output directory to `site`, and `PYTHON_VERSION=3.12`; then attach `www.webnovel.win` to that documentation deployment. If `www.webnovel.win` is currently attached to a stale Pages project, Worker route, or other origin, replace that attachment. Do **not** attach `www.webnovel.win` to `webnr.pages.dev`, because that Pages project is the reader application. Preserve `app.webnovel.win` for the reader application.
-
-**Acceptance after the external action:** automation resumes pull request #59, first requires `https://www.webnovel.win/build.json` to expose the exact current `main` documentation commit and current reader content from the documentation project, then re-runs/final-reviews #59 and squash-merges it with the exact head SHA. After merge, it waits for both the Cloudflare documentation deployment and GitHub Pages build mirror, requires `www/build.json` to equal the squash commit, verifies the 2026-08-06 and 2026-08-08 reader articles, `www` canonical/sitemap/RSS output, `G-DGH8HNQKE4`, and the unaffected `app.webnovel.win` reader, then completes permanent production-evidence and closeout changes.
+No current human-only production blocker is recorded. The `www.webnovel.win` Cloudflare routing incident was resolved on 2026-08-09 and accepted against exact public build identity, current reader articles, canonical/sitemap/RSS output, the single GA4 destination, and the separate reader application.
 
 The configured Google Drive folder currently contains no matching GA4 or Search Console exports. That data-source gap is not a human blocker and must continue to be reported as unavailable rather than zero.
 

--- a/.github/seo-data/daily/2026-08-09.md
+++ b/.github/seo-data/daily/2026-08-09.md
@@ -1,0 +1,24 @@
+# WebNR daily operations — 2026-08-09
+
+## Production-routing closeout
+
+- Pull request #61 repaired the Cloudflare documentation builder by invoking MkDocs through Python and restoring full git history for revision/RSS metadata. Its preview and main deployment passed.
+- The stale legacy Cloudflare project released `www.webnovel.win`; the hostname is now attached to the independent `webnr-docs` project built from `AutoArchive/webNR` `main`. The `webnr` project remains the reader application and still owns `app.webnovel.win`.
+- Pull request #59 was refreshed onto current `main`, passed Web quality, Documentation quality, Production evidence, and both Cloudflare preview checks, then squash-merged as `a6e9256369b0b2c29f3c80e428708e0b2da4894c`.
+
+## Public acceptance
+
+- `www.webnovel.win/build.json` identifies the exact squash commit with source `cloudflare-pages`; the root, sitemap, RSS, and the 2026-08-06 and 2026-08-08 reader articles return HTTP 200.
+- Both article pages emit `www.webnovel.win` canonicals; sitemap and RSS use the canonical hostname; generated documentation contains only the configured historical GA4 destination.
+- `app.webnovel.win/build.json` identifies the same source commit with source `github-actions`; the reader deployment workflow passed after Cloudflare propagation completed.
+- The GitHub Pages documentation mirror identifies the same source commit and remains noncanonical.
+
+## Evidence boundary
+
+This closeout proves repository, deployment, route, and rendered-output state. It does not claim traffic, ranking, indexing, or conversion improvement. GA4 and Search Console exports remain unavailable rather than zero, and Cloudflare aggregate traffic is not exposed to repository automation.
+
+## Repository state
+
+The obsolete human-only routing blocker is removed. Current machine-readable application and documentation deployment baselines are updated to the exact accepted commit so the permanent Production evidence gate evaluates current public state instead of waiting for the retired build.
+
+The first post-repair dependency PR exposed one more stale assertion: the permanent verifier still required the GitHub Pages mirror URL inside rendered troubleshooting HTML even though pull request #59 correctly made the mirror emit the `www` canonical and removed the mirror origin. The verifier now requires the `www` troubleshooting canonical and rejects the mirror origin.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,10 +3,11 @@
 ## Current state
 
 - Last completed product, source, and reader-content change: pull request #54, squash merge `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
-- Last successful attributable application deployment: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
-- Last successful attributable documentation deployment: `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`
+- Last completed production-routing change: pull request #59, squash merge `a6e9256369b0b2c29f3c80e428708e0b2da4894c`
+- Last successful attributable application deployment: `a6e9256369b0b2c29f3c80e428708e0b2da4894c`
+- Last successful attributable documentation deployment: `a6e9256369b0b2c29f3c80e428708e0b2da4894c`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
-- Canonical public-site state: externally routed through Cloudflare but stale and currently unattributable; `https://www.webnovel.win/build.json` returned HTTP 404 in the 2026-08-08 cache-busted routing diagnostic
+- Canonical public-site state: current and attributable on the independent `webnr-docs` Cloudflare Pages project; `https://www.webnovel.win/build.json` exposes the exact production-routing squash commit
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
@@ -18,28 +19,28 @@
 - `https://www.webnovel.win/` is the sole canonical public identity for documentation, reader-facing articles, search indexing, canonical tags, sitemap, and RSS. A temporary delivery failure must never cause automation to promote another hostname as the canonical documentation address.
 - `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
 - `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. After the canonical-origin repair it must continue to emit `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
-- The 2026-08-08 routing diagnostic proved that `www.webnovel.win` and the current documentation mirror are different delivery paths: the mirror exposes exact commit `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`, while `www/build.json` returns 404 and the `www` root serves an older site shell.
-- The same diagnostic proved that `https://webnr.pages.dev/` is the current reader application mirror: its build identity matches `app.webnovel.win` at `ec8ebc389c613fd9d5386ebf20f93a17f6fd51f3`. It must not be used as the documentation origin for `www`.
+- The stale legacy Cloudflare project no longer owns `www.webnovel.win`. The canonical hostname now serves the independent `webnr-docs` project from `main`; its exact build marker, current articles, canonicals, sitemap, RSS, and single GA4 destination were verified after pull request #59 merged.
+- `https://webnr.pages.dev/` remains the reader application mirror: its build identity matches `app.webnovel.win` at `a6e9256369b0b2c29f3c80e428708e0b2da4894c`. It must not be used as the documentation origin for `www`.
 - Pull request #57 merged the durable canonical contract to `main`: `www.webnovel.win` is the sole documentation/editorial/search identity, `app.webnovel.win` is reader runtime, and GitHub Pages is a noncanonical build mirror.
 - Pull request #58 merged the repository-owned `scripts/build-docs-production.sh` entrypoint to `main`. It consumes an explicit build SHA or Cloudflare Pages commit SHA, writes exact public `build.json`, performs a strict MkDocs build, and is exercised by Documentation quality.
-- Pull request #59 is the active rendered canonical-origin repair. Its seven-file diff generates documentation canonicals/sitemap/RSS/public links under `https://www.webnovel.win/`, points project/support/article links to `www`, and keeps GitHub Pages as a no-CNAME build mirror. Quality run `31277096343` passed Web quality, Documentation quality, and Production evidence. Exact public completion remains blocked on the external Cloudflare route recorded in `block.md`.
+- Pull request #59 merged the rendered canonical-origin repair. Its seven-file diff generates documentation canonicals/sitemap/RSS/public links under `https://www.webnovel.win/`, points project/support/article links to `www`, and keeps GitHub Pages as a no-CNAME build mirror. Main quality, documentation-mirror deployment, Cloudflare documentation deployment, reader deployment, and exact public acceptance all passed.
 - Pull request #56 was closed unmerged after #57 and #58 split its durable prerequisites into `main`; #59 supersedes it from a clean current-main base.
 - Runtime analytics is mandatory on the canonical public site and reader application.
 - Both public surfaces use the single GA4 destination `G-DGH8HNQKE4`.
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
-- The currently authenticated Cloudflare analytics connections do not expose the `webnovel.win` zone. This no longer blocks routine repository/product work, but it does block the specific external production-routing repair for the canonical `www` hostname.
+- The production route is no longer blocked. Cloudflare aggregate traffic remains unavailable to repository automation and must not be inferred from deployment or HTTP evidence.
 - Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict attributable documentation build, single-GA4 output assertions, integrated-source output, generated canonical/discovery output, and recorded public build evidence.
-- The reader guide `2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录` exists in the exact documentation build mirror. Pull request #59 changes its generated canonical, sitemap entry, and RSS URL to `https://www.webnovel.win/blog/2026/08/08/legal-free-novels-txt-collections/`.
-- The earlier reader-discovery article `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南` remains in the exact documentation build mirror. Pull request #59 changes its generated canonical to `https://www.webnovel.win/blog/2026/08/06/legado-source-guide/`.
-- `WebNR Originals` remains the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》; pull request #59 changes its article page URL to the canonical `www` guide while preserving the `app` text download URL.
+- The reader guide `2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录` is live at `https://www.webnovel.win/blog/2026/08/08/legal-free-novels-txt-collections/` with matching canonical, sitemap, RSS, static HTML, and single GA4 output.
+- The earlier reader-discovery article `2026 年 Legado 书源在哪里找？一份面向读者的查找与验源指南` is live at `https://www.webnovel.win/blog/2026/08/06/legado-source-guide/` with the matching canonical.
+- `WebNR Originals` remains the first passing integrated source. The exact application production build contains its source terms, YAML catalog, and original CC0 TXT fixture 《灯下索引》; its article page uses the canonical `www` guide while preserving the `app` text download URL.
 - `Aozora Bunko Starter` remains the second passing integrated source. The exact application production build contains its attributed four-work discovery catalog, links to official Aozora book cards, and no direct download URL.
 - `Standard Ebooks Starter` is the third passing integrated source. The exact application production build contains four official Standard Ebooks work-page links, source terms, jurisdiction caveats, and no copied or proxied ebook file.
 - Same-origin repository identity derives from the source directory when present, and stored repository name/count/freshness metadata refreshes during sync and `?repos=` re-import. Multiple WebNR-maintained sources no longer collapse to the generic hostname identity.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
-- Reader-content publishing targets one substantial production asset per rolling 48-hour window, but the canonical-domain production incident preempts the next normal reader-content slot until safe progress on the blocker is exhausted.
+- Reader-content publishing targets one substantial production asset per rolling 48-hour window; the resolved canonical-domain incident no longer preempts the next normal reader-content slot.
 - Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt when no higher-priority production incident is active.
 - Current adapter/source queue includes Project Gutenberg, Wikisource, NDL Search/Digital Collections, Open Library, Library of Congress, Gallica, Project Runeberg, HathiTrust, DPLA, Google Books Full View, Project Madurai, Project Ben-Yehuda, and collection-specific Internet Archive research. Candidates remain subject to their exact API, attribution, rights, rate, access, and per-item conditions.
 - Standard Ebooks now has a production link-based discovery source that does not depend on full-feed access; direct reading remains deferred until EPUB support and rights fixtures exist.
@@ -50,10 +51,10 @@
 
 ## Active focus
 
-1. Restore `https://www.webnovel.win/` as the actually served current documentation/editorial site without changing its canonical identity: use the repository-owned documentation build command recorded in `block.md`, obtain the external Cloudflare route change, require exact current-main `/build.json` and reader content directly on `www`, then resume/final-review/squash-merge pull request #59 and verify the exact squash commit on public production.
-2. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status during recovery.
-3. Preserve `https://app.webnovel.win/` and its source/download routes as the reader application while verifying that the domain repair does not repoint `www` to the application Pages project.
-4. Resume the 2026-08-10 reader comparison of English serial-fiction platforms after the canonical production incident is resolved or safely blocked with no further autonomous action available.
+1. Keep `https://www.webnovel.win/` on the independent documentation project, require exact build identity after rendered-site changes, and prevent the stale legacy project or reader project from reclaiming the hostname.
+2. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status.
+3. Preserve `https://app.webnovel.win/` and its source/download routes as the separate reader application.
+4. Resume the 2026-08-10 reader comparison of English serial-fiction platforms now that the canonical production incident is closed.
 5. Continue source discovery, adapter work, correctly routed GA4/Search Console evidence, and concentrated technical monitoring after the production-domain priority clears.
 6. Continue backup/restore, browser-storage migration, E2E, accessibility, offline, release, EPUB, and Legado capability work as product support for the reader program.
 

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -79,7 +79,8 @@ async function verifyTarget(target) {
             const contentMatches = contentResponse.ok
               && html.includes('TXT import troubleshooting')
               && html.includes('TXT 导入排障')
-              && html.includes('https://autoarchive.github.io/webNR/');
+              && html.includes('https://www.webnovel.win/troubleshooting/txt-import/')
+              && !html.includes('https://autoarchive.github.io/webNR/');
             lastObserved = JSON.stringify({
               build: buildEvidence,
               content: { status: contentResponse.status, headers: selectedHeaders(contentResponse), contentMatches },


### PR DESCRIPTION
## Summary

- record the exact accepted application and documentation deployment from PR #59
- remove the resolved Cloudflare routing blocker and update current operating priorities
- update permanent production evidence to require the canonical www URL on the GitHub Pages mirror and reject the mirror origin
- add the 2026-08-09 production-routing closeout evidence

## Validation

- local permanent production verifier passes against both exact public builds
- www root, sitemap, RSS, two current reader articles, canonicals, and single GA4 destination were verified after PR #59
- app.webnovel.win is healthy and identifies the same source commit
- git diff --check passes

This is a closeout and verifier correction. It does not claim traffic, ranking, indexing, or conversion improvement.