### PR TITLE
Close WebNR Cloudflare production-routing incident

### DIFF
--- a/.github/seo-data/block.md
+++ b/.github/seo-data/block.md
@@ -1,56 +1,18 @@
 # Human-only blockers
 
-## `webnovel.win` Cloudflare production routing
+No human-only blocker is active as of 2026-08-09.
 
-Two Cloudflare-served production hostnames are stale relative to reviewed repository artifacts.
+The Cloudflare production-routing incident is resolved:
 
-### Canonical documentation route
+- `www.webnovel.win` is the sole canonical documentation/editorial/search hostname on the independent `webnr-docs` Pages project and exposes an exact attributable build;
+- `app.webnovel.win` remains the reader runtime on the separate `webnr` Pages project and exposes the exact reviewed application artifact;
+- GitHub Pages remains a noncanonical documentation build mirror;
+- automatic preview deployments are disabled on both Cloudflare projects, while production branch deployments remain enabled;
+- the documentation project excludes pure `.github/seo-data/*` changes from build triggers so a status-only closeout cannot invalidate its own production record.
 
-**Blocked action:** make `https://www.webnovel.win/` serve the current reviewed WebNR documentation/editorial build while keeping it the single canonical public documentation hostname.
+The configured Google Drive folder still contains no matching GA4 or Search Console exports. That data-source gap is unavailable, not zero, and is not a human blocker.
 
-**Verified evidence:**
-
-- cache-busted routing diagnostics resolved `www.webnovel.win` to Cloudflare edge addresses and received HTTP 200 for the root page, but the root served the older `WebNR - Web Novel Reader` site shell while `https://www.webnovel.win/build.json` returned HTTP 404;
-- `https://autoarchive.github.io/webNR/` is the noncanonical documentation build mirror and currently exposes exact reviewed commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`;
-- the mirror contains the 2026-08-09 WebNR Legado web-alternative article and emits `www.webnovel.win` canonical/discovery metadata;
-- pull requests #57, #58, #61 and #59 completed the repository-side canonical contract, attributable MkDocs build entrypoint, shallow-checkout repair and rendered canonical-output repair.
-
-### Reader application route
-
-**Blocked action:** make `https://app.webnovel.win/` serve the latest reviewed application artifact from pull request #62.
-
-**Verified evidence:**
-
-- pull request #62 merged as `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and the `app-pages` artifact branch contains a `build.json` for that exact commit;
-- closeout Production evidence run `31303434565` independently verified the documentation mirror at `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`;
-- the same run made 42 cache-busted requests to `https://app.webnovel.win/build.json` from GitHub Actions between 08:24 and 08:31 UTC on 2026-08-09;
-- every request was served by Cloudflare and returned the older commit `a6e9256369b0b2c29f3c80e428708e0b2da4894c`, built at `2026-08-09T07:57:41.833Z`;
-- therefore `app-pages` branch publication is not sufficient proof of production application deployment, and pull request #62's PWA registration repair, keyboard accessibility repair and auxiliary Legado UI statement are not yet verified on the public reader hostname.
-
-### Why automation cannot finish these steps
-
-The remaining mutations are outside the repository and require control of the Cloudflare configuration currently serving `webnovel.win`. Repository code, application/documentation artifacts, exact build identities, canonical metadata, and the noncanonical documentation mirror are ready. The current tool environment exposes GitHub repository control and public routing evidence but no authenticated write control for the Cloudflare account/zone/projects serving `webnovel.win`; no installable Cloudflare control plugin was available in the current plugin catalog.
-
-Repointing GitHub Pages to the custom domain or treating `app-pages` as public production would hide the real routing problem rather than repair it.
-
-### Minimal external action required
-
-Using the Cloudflare account that controls `webnovel.win`:
-
-1. **Documentation:** create or select a documentation Pages deployment sourced from `AutoArchive/webNR`, production branch `main`; set build command to `python -m pip install --requirement .github/requirements-docs.txt && bash scripts/build-docs-production.sh`, output directory `site`, and `PYTHON_VERSION=3.12`; attach `www.webnovel.win` to that documentation deployment. If `www` is currently attached to a stale Pages project, Worker route, or other origin, replace that attachment. Do **not** attach `www.webnovel.win` to the reader project.
-2. **Reader:** identify the Cloudflare route/project currently serving `app.webnovel.win` and reconnect it to the application deployment path that receives the current `app-pages`/reader build. Remove or replace the stale origin/cache/project binding that continues to serve `a6e9256369b0b2c29f3c80e428708e0b2da4894c`. Preserve `app.webnovel.win` as the reader runtime.
-
-### Acceptance after the external action
-
-- `https://www.webnovel.win/build.json` exposes the current rendered documentation commit (currently `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` until another rendered-site change supersedes it);
-- `www` directly serves the 2026-08-06 Legado source guide, 2026-08-08 legal free-reading guide, and 2026-08-09 WebNR Legado web-alternative article;
-- canonical tags, sitemap and RSS remain on `www.webnovel.win`;
-- `https://app.webnovel.win/build.json` exposes the current reader application artifact (currently `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` until superseded);
-- the public reader shows the auxiliary Legado statement and passes the Service Worker, local TXT/URL import, persistence, keyboard and error-recovery acceptance paths represented by the permanent Chromium suite;
-- GA4 `G-DGH8HNQKE4` remains present with the owner-selected full-URL reader behavior;
-- `www.webnovel.win` remains documentation/editorial/search and `app.webnovel.win` remains the reader application.
-
-The configured Google Drive folder currently contains no matching GA4 or Search Console exports. That data-source gap is not a human blocker and must continue to be reported as unavailable rather than zero.
+The optional `webnovel.win` apex alias has no DNS record. It is not the canonical hostname and is not treated as a production outage.
 
 Merged automation branch cleanup is best-effort repository hygiene. A connector without a branch-deletion operation, or a harmless failure to delete an already-merged head branch, is not a blocker and must not be recorded here.
 

--- a/.github/seo-data/daily/2026-08-09.md
+++ b/.github/seo-data/daily/2026-08-09.md
@@ -73,24 +73,35 @@ After squash merge `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`:
 - the `app-pages` deployment artifact branch contains `build.json` for exact commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`, source `github-actions`;
 - the `gh-pages` documentation build mirror contains `build.json` for exact commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`, source `github-pages-build-mirror`;
 - the public GitHub Pages documentation mirror was independently verified at exact commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and contains `blog/2026/08/09/webnr-legado-web-alternative/`;
-- the public `https://app.webnovel.win/build.json` remained at `a6e9256369b0b2c29f3c80e428708e0b2da4894c` for 42 cache-busted checks from GitHub Actions, despite the newer `app-pages` artifact. Therefore the application changes from #62 are **not yet verified live on the reader production hostname**.
+- the public `https://app.webnovel.win/build.json` remained at `a6e9256369b0b2c29f3c80e428708e0b2da4894c` for 42 cache-busted checks from GitHub Actions, despite the newer `app-pages` artifact. That historical failed run correctly detected the stale route; it was not rewritten after recovery.
 
 The GitHub Pages documentation output remains a build mirror, not the canonical documentation hostname. The `app-pages` branch is an application deployment artifact, not proof that the Cloudflare-served reader hostname has advanced.
 
-## Remaining external blockers
+## Production route recovery
 
-Two public Cloudflare-served hostnames are stale relative to repository artifacts:
+The authenticated Cloudflare environment exposed two separate Pages projects and an account-wide deployment queue:
 
-1. `https://www.webnovel.win/` remains the sole canonical documentation/editorial/search hostname, but its serving route still exposes an older site shell and lacks an attributable current `build.json`.
-2. `https://app.webnovel.win/` remains the reader runtime, but its public `build.json` still exposes `a6e9256369b0b2c29f3c80e428708e0b2da4894c` while the `app-pages` artifact contains #62 commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`.
+- `webnr-docs`, production branch `main`, owns `www.webnovel.win` and builds the MkDocs documentation site;
+- `webnr`, production branch `app-pages`, owns `app.webnovel.win` and the reader Pages mirror;
+- obsolete reader and documentation previews had accumulated ahead of the two intended production builds.
 
-The repository-side builds and deployment artifacts are ready. The current tool environment has no authenticated Cloudflare write control for the `webnovel.win` routing/projects, so neither stale public route can be corrected from this session.
+Only superseded preview deployments were canceled. The intended production deployments then completed and public cache-busted checks verified:
 
-Do not promote GitHub Pages to canonical and do not treat `app-pages` as public-runtime proof. After external Cloudflare routing is repaired, verify the exact intended build on both hostnames, the new 2026-08-09 article on `www`, the auxiliary Legado statement and PWA repair on the reader, canonical/sitemap/RSS on `www`, GA4 `G-DGH8HNQKE4`, and the reader/documentation hostname separation.
+- `https://www.webnovel.win/build.json` exposes exact main commit `4639c8197a0525bdca0cd85f4034ef5a8677c220`, source `cloudflare-pages`;
+- `https://app.webnovel.win/build.json` exposes exact pull request #62 squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`, source `github-actions`;
+- the canonical 2026-08-09 Legado web-alternative article returns HTTP 200 with a `www.webnovel.win` canonical;
+- the sitemap and RSS both contain that article;
+- the public reader contains the auxiliary Legado statement and the single historical GA4 destination.
+
+To prevent recurrence, automatic preview-branch deployments are disabled on both Pages projects while automatic production deployments remain enabled. The documentation project also excludes pure `.github/seo-data/*` changes from build triggers. A commit that changes any other path still builds normally, but a metadata-only closeout no longer creates a new canonical documentation build that invalidates its own exact status record.
+
+GitHub Pages remains a noncanonical documentation build mirror. The `app-pages` branch remains an application artifact; future production completion still requires the public hostname to expose the intended exact build.
+
+No human-only production-routing blocker remains. The optional apex hostname still has no DNS record and is not the canonical public identity.
 
 ## Next work
 
 - keep Chromium user journeys as a permanent regression gate;
 - continue backup/restore, migration, offline and accessibility improvements;
 - continue fixture-backed clean-room Legado compatibility;
-- resume reader-facing editorial/source schedule while truthfully distinguishing repository artifacts, the working documentation build mirror, and the two stale Cloudflare-served production routes.
+- resume the reader-facing editorial/source schedule while preserving the canonical documentation, reader runtime, and noncanonical mirror boundaries.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,12 +3,13 @@
 ## Current state
 
 - Last merged product and reader-content change: pull request #62, squash merge `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
-- Last successful attributable application deployment: `a6e9256369b0b2c29f3c80e428708e0b2da4894c`
+- Last successful attributable application deployment: `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
 - Last successful attributable documentation deployment: `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
+- Last successful canonical Cloudflare documentation deployment: `4639c8197a0525bdca0cd85f4034ef5a8677c220`
 - Latest application deployment artifact branch commit: `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
-- Canonical public-site state: externally routed through Cloudflare but stale and currently unattributable; the latest verified routing evidence still exposes the older `WebNR - Web Novel Reader` site shell rather than the current reviewed documentation build
-- Reader public-site state: `https://app.webnovel.win/build.json` still exposes `a6e9256369b0b2c29f3c80e428708e0b2da4894c`; pull request #62's newer application artifact has not reached or been verified on the public reader hostname
+- Canonical public-site state: healthy and attributable on the independent `webnr-docs` Cloudflare Pages project; `https://www.webnovel.win/build.json` exposes exact main commit `4639c8197a0525bdca0cd85f4034ef5a8677c220`
+- Reader public-site state: healthy and attributable on the separate `webnr` Cloudflare Pages project; `https://app.webnovel.win/build.json` exposes exact pull request #62 squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
@@ -22,43 +23,44 @@
 - `https://www.webnovel.win/` is the sole canonical public identity for documentation, reader-facing articles, search indexing, canonical tags, sitemap, and RSS. A temporary delivery failure must never cause automation to promote another hostname as the canonical documentation address.
 - `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
 - `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. It emits `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
-- The `app-pages` artifact branch contains exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`, but the Cloudflare-served `app.webnovel.win` public runtime still returns `a6e9256369b0b2c29f3c80e428708e0b2da4894c`. The artifact branch is therefore not treated as successful public deployment evidence.
+- The `app-pages` artifact branch and the Cloudflare-served `app.webnovel.win` public runtime both expose exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`. Public acceptance also found the auxiliary Legado statement and the single historical GA4 destination in the rendered reader.
 - The public GitHub Pages documentation build mirror exposes exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and labels itself `github-pages-build-mirror`.
 - The documentation mirror contains the generated article `WebNR：给 Legado 用户的一个独立网页端替代选择` at mirror path `/blog/2026/08/09/webnr-legado-web-alternative/`, with intended canonical `https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/`.
 - Pull request #62 final Quality run `31303061815` passed Web quality, Documentation quality, Production evidence against the pre-merge production baseline, and Chromium user journeys.
 - Chromium job `93218999672` ran eight tests across desktop Chromium and Pixel 7 emulation; all eight passed. The suite covers first use, manifest and Service Worker registration, local TXT import, rendered reading content, IndexedDB persistence, keyboard reopen, CORS-allowed URL import and recoverable invalid-input errors.
 - The Chromium gate found and repaired a real PWA bug: an `afterInteractive` registration script could attach its `window.load` listener after the load event had already fired. Registration now runs immediately when the document is already complete.
 - The same cycle repaired mouse-only library activation. Novel rows now expose button semantics, keyboard focus, Enter/Space activation and visible focus treatment.
-- Closeout Quality run `31303434565` independently verified the exact documentation mirror at `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`, but correctly failed Production evidence because the public application hostname remained at `a6e9256369b0b2c29f3c80e428708e0b2da4894c` for 42 cache-busted requests. This is now recorded as an external routing/deployment blocker rather than overwritten as a successful application deployment.
+- Closeout Quality run `31303434565` independently verified the exact documentation mirror at `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and correctly exposed the then-stale application route. The Cloudflare production deployment subsequently advanced `app.webnovel.win` to the same exact commit, resolving that incident without rewriting the historical failed run.
 - Production-evidence logic follows the current topology: `app.webnovel.win` is the public reader target; GitHub Pages is the attributable documentation build mirror and must emit `www.webnovel.win` canonical output.
 - The 2026-08-08 routing diagnostic proved that `www.webnovel.win` and the documentation mirror are different delivery paths: the mirror exposed an exact reviewed build while `www/build.json` returned 404 and the `www` root served an older site shell.
 - `https://webnr.pages.dev/` is a reader-application mirror/project and must not be used as the documentation origin for `www`.
 - Pull request #57 established the durable canonical contract; pull request #58 added the repository-owned documentation build entrypoint; pull request #61 repaired shallow-checkout history for that build; pull request #59 merged the rendered canonical-origin source repair as `a6e9256369b0b2c29f3c80e428708e0b2da4894c`.
-- Repository-side documentation canonical generation is complete. The remaining `www` serving-path change is the external Cloudflare blocker recorded in `block.md`.
+- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The canonical site exposes exact main commit `4639c8197a0525bdca0cd85f4034ef5a8677c220`, the three current reader guides, `www` canonicals, sitemap, RSS, and the single historical GA4 destination.
 - Runtime analytics is mandatory on the canonical public site and reader application.
 - Both public surfaces use the single GA4 destination `G-DGH8HNQKE4`.
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
-- The currently authenticated connections do not expose write control for the Cloudflare routing/projects serving `webnovel.win`. This blocks both the canonical documentation route repair and the stale application production route repair.
+- The authenticated Cloudflare environment now exposes and controls both WebNR Pages projects. `webnr-docs` owns only `www.webnovel.win`; `webnr` owns only `app.webnovel.win` and its Pages mirror.
+- Automatic preview-branch deployments are disabled on both Pages projects because repository Quality and Chromium jobs provide the review gates and the old previews created an account-wide production queue. Production branch deployments remain enabled.
+- The documentation project excludes pure `.github/seo-data/*` changes from build triggers. Any commit containing other changed paths still builds normally, while status-only closeouts no longer create a new documentation commit that immediately invalidates their own recorded production evidence.
 - Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict attributable documentation build, single-GA4 output assertions, integrated-source output, generated canonical/discovery output, recorded public build evidence, and real Chromium desktop/mobile journeys.
 - The reader guides from 2026-08-06 and 2026-08-08 remain in the exact documentation build mirror with `www.webnovel.win` canonical output.
 - `WebNR Originals`, `Aozora Bunko Starter`, and `Standard Ebooks Starter` remain the three passing integrated sources from prior source-growth cycles.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
-- Local TXT and supported text-URL import are available on the last verified public reader build. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
-- Reader-content publishing targets one substantial production asset per rolling 48-hour window. Repository and mirror publication can continue while the canonical-domain routing blocker is accurately disclosed; canonical production completion still requires `www` to serve the reviewed build.
+- Local TXT and supported text-URL import are available on the current verified public reader build. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
+- Reader-content publishing targets one substantial production asset per rolling 48-hour window. Canonical production completion requires exact public build evidence rather than an artifact branch alone.
 - Daily source operations target at least five discovered candidates, three full audits, and one passing integration attempt when no higher-priority production incident is active.
 - Community Legado definitions remain isolated compatibility-corpus candidates until target-site authorization and health are audited.
 - Branch cleanup is best-effort and nonblocking.
 
 ## Active focus
 
-1. Repair the Cloudflare-served `app.webnovel.win` route so it exposes the current `app-pages` artifact and verify pull request #62's browser-facing changes on the public reader hostname.
-2. Keep `https://www.webnovel.win/` as the sole canonical documentation/editorial identity while its external Cloudflare routing blocker remains open; require `/build.json` and current reader content on `www` before declaring canonical production restored.
-3. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status.
-4. Keep the new Chromium desktop/mobile journeys as a permanent gate and expand them alongside backup/restore, storage migration, offline behavior and accessibility improvements.
-5. Continue the reader-facing editorial schedule; the Legado web-alternative explanation is complete in source and the build mirror, while the next scheduled reader topic is the English serial-fiction platform comparison.
-6. Continue daily source discovery, adapter work, correctly routed GA4/Search Console evidence, and concentrated technical monitoring.
-7. Continue real EPUB and fixture-backed clean-room Legado capability work as product support for the reader program.
+1. Keep `https://www.webnovel.win/` as the sole canonical documentation/editorial identity and `https://app.webnovel.win/` as the reader runtime; require exact public build evidence after future rendered-site changes.
+2. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status.
+3. Keep the Chromium desktop/mobile journeys as a permanent gate and expand them alongside backup/restore, storage migration, offline behavior and accessibility improvements.
+4. Continue the reader-facing editorial schedule; the Legado web-alternative explanation is live, while the next scheduled reader topic is the English serial-fiction platform comparison.
+5. Continue daily source discovery, adapter work, correctly routed GA4/Search Console evidence, and concentrated technical monitoring.
+6. Continue real EPUB and fixture-backed clean-room Legado capability work as product support for the reader program.
 
 Detailed historical evidence remains in `.github/seo-data/daily/`. This file contains current verified operating facts and priorities. The two `Last successful attributable ... deployment` lines are stable machine-readable interfaces used by `scripts/verify-production-builds.mjs` and must retain their exact labels.


### PR DESCRIPTION
## Summary
- record exact public application and canonical documentation builds after Cloudflare recovery
- remove the resolved human-only routing blocker without rewriting the historical failed deployment run
- document preview-queue prevention and the metadata-only documentation build exclusion

## Verification
- local production-evidence verifier passed against app.webnovel.win and the GitHub Pages documentation mirror
- public www article, canonical, sitemap, RSS, reader Legado statement, and single GA4 destination were checked cache-busted
- git diff --check passed

This PR changes only .github/seo-data files, so the configured Pages watch-path exclusion keeps the verified canonical documentation build stable.