### PR TITLE
docs: refresh current development guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `npm run build` - Build production application
 - `npm run start` - Start production server
 - `npm run lint` - Run ESLint with Next.js rules
+- `npm run typecheck` - Run the TypeScript type check
 - `npm run generate-icons` - Generate PWA icons using scripts/generate-icons.js
 
 ## Project Architecture
 
 ### Core Application Structure
 
-WebNR is a client-side web novel reader built with Next.js 15, React 19, and TypeScript. The architecture follows a modular component-based design:
+WebNR is a client-side web novel reader built with Next.js 16.3, React 19, and TypeScript. The architecture follows a modular component-based design:
 
 **Storage Layer (`app/lib/storage.ts`)**
 - Uses IndexedDB for offline-first data persistence
@@ -68,8 +69,11 @@ WebNR is a client-side web novel reader built with Next.js 15, React 19, and Typ
 
 ### Testing & Quality
 
-- Jest configured with TypeScript support
 - ESLint with Next.js and TypeScript rules
+- TypeScript checking through `npm run typecheck`
+- Production application build through `npm run build`
+- Playwright Chromium user-journey tests under `tests/e2e/`, run in CI on desktop Chromium and Pixel 7 emulation
 - Quality CI requires GA4 in generated application and documentation output
+- Quality CI validates maintained source output, exact recorded production evidence, and both documentation and application builds
 - Deployment workflows verify GA4 on both production domains
-- No automated unit/E2E tests currently implemented - add tests when implementing new features
+- Add or update regression coverage when implementing behavior that changes a tested reader journey


### PR DESCRIPTION
## Summary
- correct repository guidance from the retired Next.js 15 baseline to the deployed Next.js 16.3 toolchain
- document the existing TypeScript command and permanent Playwright Chromium desktop/mobile journeys
- align the testing section with the current Quality gates without changing product, analytics, routes, or rendered production output

## Scope and evidence
`CLAUDE.md` still said Next.js 15 and that no automated E2E tests existed, while current main has Next.js 16.3 and the permanent Chromium user-journey gate introduced in #62. This is a repository-instruction repair only.

## Validation
Expected repository Quality checks must all succeed. After green CI, the complete one-file diff will be reviewed from the current daily operating contract before squash merge.

## Risk / rollback
Documentation-only developer guidance; no production deployment or public rendered output is affected. Roll back by reverting the squash commit if the guidance proves inaccurate.