### PR TITLE
feat: add Project Madurai discovery source

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -81,6 +81,12 @@ jobs:
           grep -Fq 'title: The Time Machine' out/sources/standard-ebooks-starter/search_index.yml
           grep -Fq 'license: CC0-1.0-standard-ebooks' out/sources/standard-ebooks-starter/search_index.yml
           grep -Fq 'https://standardebooks.org/ebooks/jane-austen/pride-and-prejudice' out/sources/standard-ebooks-starter/search_index.yml
+          test -f out/sources/project-madurai-starter/search_index.yml
+          test -f out/sources/project-madurai-starter/README.txt
+          grep -Fq 'title: திருக்குறள்' out/sources/project-madurai-starter/search_index.yml
+          grep -Fq 'title: சிலப்பதிகாரம் — புகார்க் காண்டம்' out/sources/project-madurai-starter/search_index.yml
+          grep -Fq 'license: Project-Madurai-origin-terms' out/sources/project-madurai-starter/search_index.yml
+          grep -Fq 'https://www.projectmadurai.org/pm_etexts/utf8/pmuni0001.html' out/sources/project-madurai-starter/search_index.yml
 
   browser-e2e:
     name: Chromium user journeys

--- a/public/sources/project-madurai-starter/README.txt
+++ b/public/sources/project-madurai-starter/README.txt
@@ -1,0 +1,57 @@
+Project Madurai Starter
+=======================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/project-madurai-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fproject-madurai-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small, link-based discovery catalog for selected
+Project Madurai Tamil classics. It gives readers stable origin pages while keeping
+WebNR's current source integration inside a narrow, reversible discovery boundary.
+
+Source and reuse boundary
+-------------------------
+Project Madurai describes itself as an open, voluntary effort that makes Tamil
+literature available on the Internet. Its FAQ says works in the collection are
+public-domain works or are included with due consent from the respective authors.
+The selected Unicode pages also state that the electronic-text file may be freely
+distributed when its header page is kept intact.
+
+Source: https://www.projectmadurai.org/
+Catalog: https://www.projectmadurai.org/pmworks.html
+FAQ: https://www.projectmadurai.org/faq.html
+
+This starter catalog does not redistribute those electronic texts. It stores only
+WebNR-authored descriptions, title/author metadata, and links to the official
+Project Madurai Unicode pages. Readers remain responsible for any jurisdiction-
+specific rights question that applies to their own access or reuse.
+
+Current WebNR behavior
+----------------------
+The entries are discovery links only. Project Madurai's catalog includes Unicode
+HTML and PDF, and its FAQ notes that older releases used legacy Tamil encodings
+before the project moved to Unicode/UTF-8. WebNR does not crawl, proxy, cache, or
+bulk-download Project Madurai content and does not depend on an origin API, login,
+cookie, CORS behavior, or undocumented rate limit.
+
+A future direct-reading adapter would need versioned fixtures for encoding,
+per-work provenance and rights status, bounded fetch behavior, and preservation of
+the Project Madurai header/distribution notice before WebNR could truthfully claim
+content import support.
+
+Included discovery pages
+------------------------
+- திருக்குறள் — திருவள்ளுவர்
+- ஆத்திசூடி மற்றும் ஔவையார் நீதிநூல்கள் — ஔவையார்
+- சிலப்பதிகாரம் — புகார்க் காண்டம் — இளங்கோ அடிகள்
+- திணைமாலை நூற்றைம்பது — கணிமேதாவியார்
+
+Last verified
+-------------
+2026-08-09

--- a/public/sources/project-madurai-starter/search_index.yml
+++ b/public/sources/project-madurai-starter/search_index.yml
@@ -1,0 +1,59 @@
+project-madurai/tirukkural.md:
+  title: திருக்குறள்
+  author: திருவள்ளுவர்
+  description: Project Madurai 的官方 Unicode/UTF-8 电子文本页。WebNR 当前仅提供来源发现链接，不复制正文或 PDF，并保留来源项目的权利与分发边界。
+  page_url: https://www.projectmadurai.org/pm_etexts/utf8/pmuni0001.html
+  source: Project Madurai
+  license: Project-Madurai-origin-terms
+  tags:
+    - Project Madurai
+    - தமிழ்
+    - Classical literature
+  categories:
+    - Free reading discovery
+  region: ta-IN
+
+project-madurai/auvaiyar-ethical-works.md:
+  title: ஆத்திசூடி மற்றும் ஔவையார் நீதிநூல்கள்
+  author: ஔவையார்
+  description: Project Madurai 的官方 Unicode/UTF-8 页面，收录 ஆத்திசூடி、கொன்றைவேந்தன்、மூதுரை 与 நல்வழி。WebNR 仅链接原始页面，不重新分发电子文本。
+  page_url: https://www.projectmadurai.org/pm_etexts/utf8/pmuni0002.html
+  source: Project Madurai
+  license: Project-Madurai-origin-terms
+  tags:
+    - Project Madurai
+    - தமிழ்
+    - Classical literature
+  categories:
+    - Free reading discovery
+  region: ta-IN
+
+project-madurai/cilappathikaram-pukar.md:
+  title: சிலப்பதிகாரம் — புகார்க் காண்டம்
+  author: இளங்கோ அடிகள்
+  description: Project Madurai 的官方 Unicode/UTF-8《சிலப்பதிகாரம்》 புகார்க் காண்டம் 页面。WebNR 只保留作品元数据和官方页面链接，不代理第三方文件。
+  page_url: https://www.projectmadurai.org/pm_etexts/utf8/pmuni0046.html
+  source: Project Madurai
+  license: Project-Madurai-origin-terms
+  tags:
+    - Project Madurai
+    - தமிழ்
+    - Epic
+  categories:
+    - Free reading discovery
+  region: ta-IN
+
+project-madurai/tinaimalai-nurraimpatu.md:
+  title: திணைமாலை நூற்றைம்பது
+  author: கணிமேதாவியார்
+  description: Project Madurai 的官方 Unicode/UTF-8 电子文本页。WebNR 当前把它作为泰米尔古典文学发现入口，不抓取、缓存或重新发布正文。
+  page_url: https://www.projectmadurai.org/pm_etexts/utf8/pmuni0056.html
+  source: Project Madurai
+  license: Project-Madurai-origin-terms
+  tags:
+    - Project Madurai
+    - தமிழ்
+    - Classical literature
+  categories:
+    - Free reading discovery
+  region: ta-IN


### PR DESCRIPTION
## Summary
- add a fourth WebNR-maintained source at `/sources/project-madurai-starter`
- expose four selected Tamil-classics origin pages as link-only discovery entries
- document the Project Madurai rights/format boundary and keep direct content import explicitly deferred
- extend Quality source-output assertions while preserving WebNR Originals, Aozora Bunko Starter, and Standard Ebooks Starter

## Source audit and rationale
Fresh checks on 2026-08-09 verified Project Madurai's official catalog, FAQ, and the four selected Unicode pages. The FAQ states that collection works are public-domain or included with due author consent; the selected pages identify Project Madurai as an open voluntary initiative and permit distribution when the page header is preserved. The catalog includes Unicode HTML/PDF and older encoding history. This PR intentionally copies no source text or PDF and performs no origin fetching at runtime: it stores only WebNR-authored descriptions, title/author metadata, and official page links.

The link-only boundary avoids an undocumented scraping contract, CORS/cookie dependency, encoding conversion, bulk redistribution, and per-work permission ambiguity. A future direct-reading adapter remains contingent on versioned fixtures, per-work provenance/rights status, bounded fetch behavior, and preservation of the origin distribution notice.

## Search-facing boundary
Affected: only the new `/sources/project-madurai-starter/*` public source files and the source-output CI gate. Representative unaffected sources: `/sources/aozora-starter/` and `/sources/standard-ebooks-starter/`. No canonical documentation route, reader UI, analytics implementation, or existing source record is replaced or removed.

## Validation
Expected Quality jobs: Web quality, Documentation quality, Production evidence, and Chromium user journeys. The Web build must emit both new source files and exact Tamil-title/origin-link assertions while all existing source and single-GA4/full-URL checks continue to pass.

## Deployment / acceptance
This changes reader application public output and should deploy through the existing application workflow after squash merge. Acceptance requires the exact squash commit in the production `app-pages` artifact, the new source files present there with all four origin entries, existing source files still present, and the reader production evidence/analytics gates green.

## Risk / rollback
Low-risk additive discovery catalog. It does not fetch or redistribute third-party content. Roll back by reverting the squash commit; no reader storage migration is introduced.