### PR TITLE
ops: close out 2026-08-09 full scheduled cycle

### DIFF
--- a/.github/seo-data/daily/2026-08-09.md
+++ b/.github/seo-data/daily/2026-08-09.md
@@ -122,3 +122,82 @@ Pull request #29 squash-merged as `7d319f26e2c3398215c1d2cedca6f99820f1de50`. Po
 - the rendered reader still contains the single historical GA4 destination.
 
 The GitHub Pages documentation build mirror remains at exact product commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`. That is expected because the dependency-only paths do not trigger the mirror workflow; it remains a valid attributable noncanonical build mirror rather than being mislabeled as missing or zero.
+
+## Full scheduled source-growth and data-analysis cycle
+
+The scheduled operating cycle then resumed from current `main`, with no pre-existing open WebNR automation pull request or issue to continue. The pinned `.github/seo-skills` submodule remained at `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`, which matched the current upstream skill repository head, so no pointer movement was necessary.
+
+### Data acquisition and quality
+
+- The configured Google Drive folder `webNR SEO Weekly CSV` was reachable, but its direct child listing contained no matching GA4 or Search Console export files. GA4/GSC performance is therefore **unavailable for this cycle**, not zero.
+- The authenticated Cloudflare zone connector did not return an exact `webnovel.win` zone from the available accounts. Cloudflare request analytics are therefore **unavailable for this cycle**, not zero.
+- GitHub, repository, CI, artifact and production-evidence paths remained available. Before source integration, the reader artifact branch exposed exact build `23a660fa0e68b74ef73716ac0383dafd01786fab`; after source delivery it advanced to exact build `65fbda14e8062d7b055db5987646598b04ffcddc`.
+- The application source still sends the single required GA4 destination `G-DGH8HNQKE4`, reports `window.location.href` plus pathname and query string, and keeps Google signals and ad-personalization signals disabled.
+
+### Six operating decisions
+
+- **Technical:** repair stale developer guidance immediately rather than allowing future automation to act on a Next.js 15 / no-E2E description that no longer matched the repository.
+- **Content:** publish no additional 2026-08-09 article. The substantial Legado web-alternative article already satisfies the rolling 48-hour reader-content cadence; keep the English serial-fiction platform comparison as the next scheduled reader topic for 2026-08-10.
+- **Source:** integrate Project Madurai only as a narrow link-based discovery catalog. Defer source-body import until encoding fixtures, per-work provenance/rights handling and bounded fetch behavior exist.
+- **Search:** make no speculative canonical, route or metadata experiment. The additive source catalog expands reader discovery without replacing existing indexed content or navigation.
+- **Community:** perform no external posting or account creation. Public community evidence remains research input for reader-facing ecosystem work rather than an authorization to automate promotion.
+- **Measurement:** preserve the single-GA4/full-URL analytics contract and explicitly carry the Drive/Cloudflare evidence gaps forward as unavailable.
+
+### New source discovery
+
+Five candidates not present in the 2026-08-08 discovery set were added to the research queue:
+
+1. **Project Gutenberg Australia** — more than 5,000 Australian-public-domain titles; site remains online after stopping new ebook additions from 2025-01-01; held works can expose TXT, HTML, EPUB, MOBI and PDF.
+2. **Faded Page** — volunteer-built archive of free ebooks in the Canadian public domain, with item pages commonly exposing UTF-8 text, HTML and EPUB.
+3. **The Online Books Page** — University of Pennsylvania-maintained discovery index listing more than three million free books on the Web.
+4. **Project Gutenberg Canada** — no-charge Canadian-public-domain catalog with jurisdiction warnings for readers outside Canada.
+5. **Europeana** — broad cultural-heritage discovery and metadata APIs; Search/Record/IIIF access requires a free Europeana account/API key, so it is not a zero-setup runtime source candidate.
+
+### Full source audits and decisions
+
+**Project Madurai — accepted and integrated at discovery-only compatibility level.** The official catalog and FAQ remained live. The four selected Unicode pages were independently checked: `திருக்குறள்`, Auvaiyar's `ஆத்திச்சூடி / கொன்றைவேந்தன் / மூதுரை / நல்வழி`, `சிலப்பதிகாரம் — புகார்க் காண்டம்`, and `திணைமாலை நூற்றைம்பது`. Their headers identify Project Madurai as an open volunteer initiative and allow distribution when the header remains intact. WebNR nevertheless copies no electronic-text body or PDF: it stores only WebNR-authored descriptions, title/author metadata and official page links. This avoids introducing runtime CORS, cookies, login, undocumented rate-limit, bulk-download or encoding-conversion dependencies.
+
+**Faded Page — audited and deferred.** The project is a free volunteer ebook archive operating under Canadian public-domain rules, with an explicit outside-Canada copyright warning. Sample item pages expose UTF-8 text, HTML and EPUB. This is technically attractive for future TXT-oriented compatibility, but direct global import should wait for a per-item jurisdiction/rights policy and stable fixtures rather than treating Canadian public-domain status as universally portable.
+
+**Project Gutenberg Australia — audited and deferred.** Official help documents TXT/HTML/EPUB/MOBI/PDF availability for hosted books. Its licence states that most works are public domain in Australia, while some are redistributed by permission with additional conditions, and warns users outside Australia to check local law. A future adapter therefore needs per-item header parsing and a region-aware rights boundary; today's cycle does not turn the whole catalog into a globally safe direct-download source.
+
+Europeana and Project Gutenberg Canada remain useful follow-up candidates, but neither displaced the safer Project Madurai discovery-only integration in this cycle.
+
+### Existing-source rotation
+
+- **WebNR Originals:** maintained source/output fixture remained present and passed the repository Quality source assertions.
+- **Aozora Bunko Starter:** the rotating official card sample for `吾輩は猫である` remained reachable during the cycle.
+- **Standard Ebooks Starter:** the official `Pride and Prejudice` origin page remained reachable, and the deployed source catalog remained present after the new integration.
+- **Project Madurai Starter:** all four selected official Unicode origin pages were checked before integration.
+
+No existing source was removed, downgraded or replaced.
+
+### Technical repair delivery
+
+`CLAUDE.md` still described a Next.js 15 application and said that no automated E2E tests existed. Pull request #67 corrected the guidance to Next.js 16.3, documented the existing `npm run typecheck` command and the permanent desktop/Pixel-7 Chromium journeys, and aligned the Quality description with current CI.
+
+- PR: #67 `docs: refresh current development guidance`
+- Final head: `60d45add300885187b9abea9f793cf481c1f24c6`
+- Quality run: `31323828174`
+- Result: Web quality, Documentation quality, Production evidence and Chromium user journeys all passed.
+- Squash merge: `23a660fa0e68b74ef73716ac0383dafd01786fab`
+- Deployment: not applicable; this was repository developer guidance only and changed no rendered public output.
+
+### Source integration delivery
+
+Pull request #68 added `public/sources/project-madurai-starter/` with four official-origin discovery entries and a README documenting the rights, format and future-adapter boundary. It also extended Quality so production output must contain the new source while preserving all previous source checks.
+
+- PR: #68 `feat: add Project Madurai discovery source`
+- Final head: `6193f00e8d2914241c391eb805f82c0b1488df81`
+- Quality run: `31324032188`
+- Result: Web quality, Documentation quality, Production evidence and Chromium user journeys all passed before merge.
+- From-scratch post-CI review found only the intended three-file additive change and no review comments or scope drift.
+- Squash merge: `65fbda14e8062d7b055db5987646598b04ffcddc`
+- Application artifact: `app-pages/build.json` advanced to exact commit `65fbda14e8062d7b055db5987646598b04ffcddc`, source `github-actions`, built at `2026-08-09T16:35:29.209Z`.
+- Deployed artifact contents: the Project Madurai source contains all four selected entries; the previously integrated Standard Ebooks source remains present unchanged.
+
+The metadata closeout records the same exact application deployment in `status.md`. Its Production evidence job is required to perform cache-busted checks against public `https://app.webnovel.win/build.json`; the closeout cannot merge unless that public reader target exposes the recorded exact source squash commit. The noncanonical GitHub Pages documentation mirror remains at `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`, which is expected and independently attributable.
+
+### Scheduled-cycle completion condition
+
+The source/data cycle has satisfied the required five-candidate discovery, three full audits and one passing integration attempt. No reader article was additionally due on 2026-08-09. GA4/GSC and Cloudflare traffic analytics remain unavailable rather than zero, and no human-only permission, legal or billing blocker was identified. Final completion still depends on the metadata closeout PR passing all Quality jobs, including its exact public reader production-evidence check, followed by the required from-scratch review and squash merge.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,18 +2,19 @@
 
 ## Current state
 
-- Last merged product and reader-content change: pull request #62, squash merge `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
-- Last successful attributable application deployment: `7d319f26e2c3398215c1d2cedca6f99820f1de50`
+- Last merged product and reader-content change: pull request #68, squash merge `65fbda14e8062d7b055db5987646598b04ffcddc`
+- Last successful attributable application deployment: `65fbda14e8062d7b055db5987646598b04ffcddc`
 - Last successful attributable documentation deployment: `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
 - Last successful canonical Cloudflare documentation deployment: `7d319f26e2c3398215c1d2cedca6f99820f1de50`
-- Latest application deployment artifact branch commit: `7d319f26e2c3398215c1d2cedca6f99820f1de50`
+- Latest application deployment artifact branch commit: `65fbda14e8062d7b055db5987646598b04ffcddc`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
-- Canonical public-site state: healthy and attributable on the independent `webnr-docs` Cloudflare Pages project; `https://www.webnovel.win/build.json` exposes exact main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`
-- Reader public-site state: healthy and attributable on the separate `webnr` Cloudflare Pages project; `https://app.webnovel.win/build.json` exposes exact pull request #29 squash commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`
+- Canonical public-site state: healthy and attributable on the independent `webnr-docs` Cloudflare Pages project; the last independently recorded exact canonical build is main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`
+- Reader public-site state: healthy and attributable on the separate `webnr` Cloudflare Pages project; production verification requires `https://app.webnovel.win/build.json` to expose exact pull request #68 squash commit `65fbda14e8062d7b055db5987646598b04ffcddc`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
-- Current analytics export state: the configured Google Drive folder is accessible, but the latest direct folder-content check exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
+- Current analytics export state: the configured Google Drive folder is accessible, but the 2026-08-09 direct folder-content check exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
+- Current Cloudflare traffic-analytics state: the authenticated zone connector did not expose an exact `webnovel.win` zone during the 2026-08-09 scheduled cycle, so Cloudflare request analytics are unavailable for that cycle rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
 
 ## Current signals
@@ -23,7 +24,7 @@
 - `https://www.webnovel.win/` is the sole canonical public identity for documentation, reader-facing articles, search indexing, canonical tags, sitemap, and RSS. A temporary delivery failure must never cause automation to promote another hostname as the canonical documentation address.
 - `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
 - `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. It emits `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
-- The `app-pages` artifact branch and the Cloudflare-served `app.webnovel.win` public runtime both expose exact squash commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`. Public acceptance also found the auxiliary Legado statement and the single historical GA4 destination in the rendered reader.
+- The `app-pages` application artifact exposes exact squash commit `65fbda14e8062d7b055db5987646598b04ffcddc`, source `github-actions`, and includes the Project Madurai Starter plus the previously integrated source catalogs. The production-evidence gate independently checks the Cloudflare-served `app.webnovel.win` build marker against the same recorded commit before closeout can merge.
 - The public GitHub Pages documentation build mirror exposes exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and labels itself `github-pages-build-mirror`.
 - The documentation mirror contains the generated article `WebNR：给 Legado 用户的一个独立网页端替代选择` at mirror path `/blog/2026/08/09/webnr-legado-web-alternative/`, with intended canonical `https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/`.
 - Pull request #62 final Quality run `31303061815` passed Web quality, Documentation quality, Production evidence against the pre-merge production baseline, and Chromium user journeys.
@@ -35,8 +36,10 @@
 - The 2026-08-08 routing diagnostic proved that `www.webnovel.win` and the documentation mirror are different delivery paths: the mirror exposed an exact reviewed build while `www/build.json` returned 404 and the `www` root served an older site shell.
 - `https://webnr.pages.dev/` is a reader-application mirror/project and must not be used as the documentation origin for `www`.
 - Pull request #57 established the durable canonical contract; pull request #58 added the repository-owned documentation build entrypoint; pull request #61 repaired shallow-checkout history for that build; pull request #59 merged the rendered canonical-origin source repair as `a6e9256369b0b2c29f3c80e428708e0b2da4894c`.
-- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The canonical site exposes exact main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`, the three current reader guides, `www` canonicals, sitemap, RSS, and the single historical GA4 destination.
+- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The last independently recorded canonical site build is exact main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`, with the three current reader guides at that deployment point, `www` canonicals, sitemap, RSS, and the single historical GA4 destination.
 - Pull request #29 upgraded Next.js to 16.3.0 and the matching native flat ESLint configuration, upgraded the affected Sharp dependency, preserved the prior behavioral lint baseline for separately scoped React refactors, passed all four Quality jobs, and produced an audit result with no known vulnerabilities.
+- Pull request #67 repaired stale repository guidance after that migration. Quality run `31323828174` passed Web quality, Documentation quality, Production evidence, and Chromium user journeys before squash merge `23a660fa0e68b74ef73716ac0383dafd01786fab`; the change was developer-guidance-only and required no rendered-site deployment.
+- Pull request #68 added `Project Madurai Starter` as a link-only Tamil-literature discovery catalog with four audited origin pages, preserved the existing source catalogs, and extended source-output validation. Quality run `31324032188` passed Web quality, Documentation quality, Production evidence, and Chromium user journeys before squash merge `65fbda14e8062d7b055db5987646598b04ffcddc`.
 - Runtime analytics is mandatory on the canonical public site and reader application.
 - Both public surfaces use the single GA4 destination `G-DGH8HNQKE4`.
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
@@ -47,7 +50,8 @@
 - The documentation project excludes pure `.github/seo-data/*` changes from build triggers. Any commit containing other changed paths still builds normally, while status-only closeouts no longer create a new documentation commit that immediately invalidates their own recorded production evidence.
 - Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict attributable documentation build, single-GA4 output assertions, integrated-source output, generated canonical/discovery output, recorded public build evidence, and real Chromium desktop/mobile journeys.
 - The reader guides from 2026-08-06 and 2026-08-08 remain in the exact documentation build mirror with `www.webnovel.win` canonical output.
-- `WebNR Originals`, `Aozora Bunko Starter`, and `Standard Ebooks Starter` remain the three passing integrated sources from prior source-growth cycles.
+- `WebNR Originals`, `Aozora Bunko Starter`, `Standard Ebooks Starter`, and `Project Madurai Starter` are the four passing integrated sources after the 2026-08-09 scheduled source-growth cycle.
+- `Project Madurai Starter` is deliberately discovery-only: WebNR stores its own descriptions plus title/author metadata and official Project Madurai Unicode-page links. It does not crawl, proxy, cache, bulk-download, or redistribute the linked electronic texts.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available on the current verified public reader build. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
 - Reader-content publishing targets one substantial production asset per rolling 48-hour window. Canonical production completion requires exact public build evidence rather than an artifact branch alone.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -9,7 +9,7 @@
 - Latest application deployment artifact branch commit: `65fbda14e8062d7b055db5987646598b04ffcddc`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
 - Canonical public-site state: healthy and attributable on the independent `webnr-docs` Cloudflare Pages project; the last independently recorded exact canonical build is main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`
-- Reader public-site state: healthy and attributable on the separate `webnr` Cloudflare Pages project; production verification requires `https://app.webnovel.win/build.json` to expose exact pull request #68 squash commit `65fbda14e8062d7b055db5987646598b04ffcddc`
+- Reader public-site state: healthy and attributable on the separate `webnr` Cloudflare Pages project; cache-busted production verification on 2026-08-09 confirmed `https://app.webnovel.win/build.json` exposes exact pull request #68 squash commit `65fbda14e8062d7b055db5987646598b04ffcddc`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
@@ -24,7 +24,7 @@
 - `https://www.webnovel.win/` is the sole canonical public identity for documentation, reader-facing articles, search indexing, canonical tags, sitemap, and RSS. A temporary delivery failure must never cause automation to promote another hostname as the canonical documentation address.
 - `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
 - `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. It emits `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
-- The `app-pages` application artifact exposes exact squash commit `65fbda14e8062d7b055db5987646598b04ffcddc`, source `github-actions`, and includes the Project Madurai Starter plus the previously integrated source catalogs. The production-evidence gate independently checks the Cloudflare-served `app.webnovel.win` build marker against the same recorded commit before closeout can merge.
+- The `app-pages` application artifact exposes exact squash commit `65fbda14e8062d7b055db5987646598b04ffcddc`, source `github-actions`, and includes the Project Madurai Starter plus the previously integrated source catalogs. Closeout Production evidence job `93272242519` then resolved the Cloudflare-served `app.webnovel.win` target and independently observed the same exact commit with a Cloudflare response before this record was finalized.
 - The public GitHub Pages documentation build mirror exposes exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and labels itself `github-pages-build-mirror`.
 - The documentation mirror contains the generated article `WebNR：给 Legado 用户的一个独立网页端替代选择` at mirror path `/blog/2026/08/09/webnr-legado-web-alternative/`, with intended canonical `https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/`.
 - Pull request #62 final Quality run `31303061815` passed Web quality, Documentation quality, Production evidence against the pre-merge production baseline, and Chromium user journeys.


### PR DESCRIPTION
## Summary
- record the complete 2026-08-09 scheduled data-analysis and source-growth cycle without rewriting the earlier focused-cycle history
- advance the recorded reader application deployment to Project Madurai source squash `65fbda14e8062d7b055db5987646598b04ffcddc`
- record the five-candidate discovery set, three full audits, rotating source checks, six operating decisions, analytics availability gaps, PR #67 repair, and PR #68 delivery
- keep the noncanonical GitHub Pages documentation mirror at its independently attributable commit and keep the last independently recorded canonical documentation build unchanged

## Evidence boundary
This is metadata-only closeout under `.github/seo-data/*`. It does not change reader code, public source files, routes, canonical metadata, analytics implementation, or rendered documentation. The application artifact branch already exposes exact source squash `65fbda14e8062d7b055db5987646598b04ffcddc` and the deployed artifact contains the new Project Madurai catalog plus prior Standard Ebooks output.

## Required production acceptance
The updated machine-readable application deployment line intentionally makes the existing `Production evidence` Quality job perform cache-busted public verification of `https://app.webnovel.win/build.json` against exact source squash `65fbda14e8062d7b055db5987646598b04ffcddc`. This PR must not merge unless that job and all other expected Quality jobs succeed.

The documentation-build-mirror deployment line remains `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`; the mirror did not move and remains a valid attributable noncanonical build. The canonical Cloudflare documentation deployment line is not guessed forward without an independent exact check.

## Validation and review
Expected checks: Web quality, Documentation quality, Production evidence, and Chromium user journeys. After all are green, review the complete two-file closeout diff from scratch, confirm the stable deployment-label interfaces are intact, confirm no historical section was rewritten beyond the new appended full-cycle record, and squash merge with the exact reviewed head.

## Risk / rollback
Metadata-only. If any recorded production commit is wrong, the Production evidence job will fail rather than allowing closeout. Roll back by reverting the closeout squash; it does not alter the already deployed Project Madurai source.