### PR TITLE
fix: remove analytics notice from reader UI

### DIFF
--- a/app/components/AddView.tsx
+++ b/app/components/AddView.tsx
@@ -65,10 +65,6 @@ export const AddView: React.FC<AddViewProps> = ({ onImportComplete }) => {
     return (
         <div className="h-full overflow-auto p-4">
             <div className="mx-auto max-w-xl space-y-6 py-4">
-                <p className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm leading-6 text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-100">
-                    {t('settings.privacyDescription')}
-                </p>
-
                 <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800" aria-labelledby="local-file-heading">
                     <h2 id="local-file-heading" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
                         {t('add.uploadTitle')}

--- a/app/components/library/LibraryView.tsx
+++ b/app/components/library/LibraryView.tsx
@@ -167,7 +167,7 @@ export const LibraryView: React.FC<LibraryViewProps> = ({ onNovelSelect, onAddNo
                             {t('settings.appDescription')}
                         </p>
 
-                        <ul className="mt-6 grid gap-3 text-sm text-gray-700 dark:text-gray-200 sm:grid-cols-3">
+                        <ul className="mt-6 grid gap-3 text-sm text-gray-700 dark:text-gray-200 sm:grid-cols-2">
                             <li className="rounded-lg bg-gray-50 p-3 dark:bg-gray-900/50">
                                 <strong className="block text-gray-950 dark:text-white">TXT</strong>
                                 {t('discover.localImport')}
@@ -175,10 +175,6 @@ export const LibraryView: React.FC<LibraryViewProps> = ({ onNovelSelect, onAddNo
                             <li className="rounded-lg bg-gray-50 p-3 dark:bg-gray-900/50">
                                 <strong className="block text-gray-950 dark:text-white">URL</strong>
                                 {t('add.urlTitle')}
-                            </li>
-                            <li className="rounded-lg bg-gray-50 p-3 dark:bg-gray-900/50">
-                                <strong className="block text-gray-950 dark:text-white">Privacy first</strong>
-                                {t('settings.privacyDescription')}
                             </li>
                         </ul>
 

--- a/tests/e2e/webnr-browser.spec.cjs
+++ b/tests/e2e/webnr-browser.spec.cjs
@@ -16,6 +16,8 @@ test('shows the Legado web-alternative note and registers the PWA shell', async 
 
   await expect(page.getByRole('button', { name: 'Import Novel' })).toBeVisible();
   await expect(page.getByText(/independent browser-based alternative/i)).toBeVisible();
+  await expect(page.locator('body')).not.toContainText('Google Analytics records page views');
+  await expect(page.locator('body')).not.toContainText('Privacy first');
 
   const manifestAvailable = await page.evaluate(async () => {
     const response = await fetch('/manifest.json');
@@ -27,6 +29,10 @@ test('shows the Legado web-alternative note and registers the PWA shell', async 
     () => page.evaluate(async () => Boolean(await navigator.serviceWorker.getRegistration())),
     { timeout: 12_000 }
   ).toBe(true);
+
+  await page.getByRole('button', { name: 'Import Novel' }).click();
+  await expect(page.getByRole('heading', { name: 'Upload File' })).toBeVisible();
+  await expect(page.locator('body')).not.toContainText('Google Analytics records page views');
 });
 
 test('imports a local TXT, persists it in IndexedDB, and reopens it with the keyboard', async ({ page }) => {


### PR DESCRIPTION
## Goal

Remove the visible Google Analytics notice from the WebNR reader UI without removing or weakening analytics itself.

## Changes

- remove the analytics/privacy banner from the Add/import view
- remove the `Privacy first` analytics card from the empty-library onboarding screen
- keep the TXT and URL onboarding cards and rebalance the layout to two columns
- extend permanent Chromium desktop/mobile E2E coverage so the empty library and import view must not display the Google Analytics notice

## Explicitly unchanged

- GA4 measurement and runtime script
- owner-selected full-URL reporting, including query strings and `?add=...`
- Google signals/ad-personalization settings
- repository and documentation disclosures about analytics
- canonical URLs, product positioning, sources, storage behavior, and Legado compatibility claims

## Expected validation

Wait for all current Quality checks, including dependency audit, lint, typecheck, production build, analytics-output assertions, source-output assertions, strict docs build, production evidence, and Chromium desktop/mobile user journeys. Then review the complete final diff and squash merge only if clean.