### PR TITLE
content: compare English serial-fiction platforms

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -87,6 +87,13 @@ jobs:
           grep -Fq 'title: சிலப்பதிகாரம் — புகார்க் காண்டம்' out/sources/project-madurai-starter/search_index.yml
           grep -Fq 'license: Project-Madurai-origin-terms' out/sources/project-madurai-starter/search_index.yml
           grep -Fq 'https://www.projectmadurai.org/pm_etexts/utf8/pmuni0001.html' out/sources/project-madurai-starter/search_index.yml
+          test -f out/sources/english-serial-platforms-starter/search_index.yml
+          test -f out/sources/english-serial-platforms-starter/README.txt
+          grep -Fq 'title: Royal Road — Complete & Rising Stars' out/sources/english-serial-platforms-starter/search_index.yml
+          grep -Fq 'title: Scribble Hub — Series Finder' out/sources/english-serial-platforms-starter/search_index.yml
+          grep -Fq 'title: Tapas — Novels' out/sources/english-serial-platforms-starter/search_index.yml
+          grep -Fq 'title: Honeyfeed — Novels' out/sources/english-serial-platforms-starter/search_index.yml
+          grep -Fq 'license: Link-only-WebNR-editorial' out/sources/english-serial-platforms-starter/search_index.yml
 
   browser-e2e:
     name: Chromium user journeys
@@ -169,6 +176,7 @@ jobs:
           test -f site/blog/2026/08/06/legado-source-guide/index.html
           test -f site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
           test -f site/blog/2026/08/09/webnr-legado-web-alternative/index.html
+          test -f site/blog/2026/08/10/english-serial-fiction-platforms/index.html
           grep -Fq 'AutoArchive/webNR' site/index.html
           grep -Fq 'https://www.webnovel.win/' site/index.html
           grep -Fq 'Legado 用户' site/index.html
@@ -184,10 +192,14 @@ jobs:
           grep -Fq 'https://www.webnovel.win/blog/2026/08/08/legal-free-novels-txt-collections/' site/blog/2026/08/08/legal-free-novels-txt-collections/index.html
           grep -Fq 'WebNR：给 Legado 用户的一个独立网页端替代选择' site/blog/2026/08/09/webnr-legado-web-alternative/index.html
           grep -Fq 'https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/' site/blog/2026/08/09/webnr-legado-web-alternative/index.html
+          grep -Fq '2026 英文连载小说平台怎么选' site/blog/2026/08/10/english-serial-fiction-platforms/index.html
+          grep -Fq 'English Serial Platforms Starter' site/blog/2026/08/10/english-serial-fiction-platforms/index.html
           grep -Fq 'https://www.webnovel.win/blog/2026/08/08/legal-free-novels-txt-collections/' site/sitemap.xml
           grep -Fq 'https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/' site/sitemap.xml
+          grep -Fq 'https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/' site/sitemap.xml
           grep -Fq 'https://www.webnovel.win/blog/2026/08/08/legal-free-novels-txt-collections/' site/feed_rss_created.xml
           grep -Fq 'https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/' site/feed_rss_created.xml
+          grep -Fq 'https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/' site/feed_rss_created.xml
           grep -R -Fq 'G-DGH8HNQKE4' site
           if grep -R -Fq 'G-NL0WV2XMJN' site; then
             echo 'Obsolete secondary GA4 destination found in documentation output' >&2

--- a/docs/blog/posts/2026-08-10-english-serial-fiction-platforms.md
+++ b/docs/blog/posts/2026-08-10-english-serial-fiction-platforms.md
@@ -1,0 +1,139 @@
+---
+title: 2026 英文连载小说平台怎么选？Royal Road、Scribble Hub、Wattpad、Tapas、Honeyfeed 对比
+date: 2026-08-10
+slug: english-serial-fiction-platforms
+description: 从读者视角比较 Royal Road、Scribble Hub、Wattpad、Tapas 与 Honeyfeed 的类型发现、完结信号、评论社区、阅读方式与免费/付费边界，并给出按阅读需求选择平台的建议。
+categories:
+  - Reader guides
+  - Ecosystem
+  - Recommendations
+---
+
+# 2026 英文连载小说平台怎么选？Royal Road、Scribble Hub、Wattpad、Tapas、Honeyfeed 对比
+
+**直接答案：** 如果你想追 LitRPG、Progression Fantasy、Isekai 一类持续更新的英文网文，并且很在意“这本到底还更不更新、有没有完结”，先看 **Royal Road**；如果你希望筛选条件更细、类型跨度更大，也愿意主动处理成人内容标签，**Scribble Hub** 更像一个可以自己调参数的小说目录；如果你最看重庞大的社交阅读社区、段落/故事评论、阅读列表和手机离线阅读，**Wattpad** 仍然更接近大众社交阅读产品；如果你想把原创社区小说与编辑签约、Premium、Free Access 放在一个平台里看，**Tapas** 的边界最清楚；如果你偏爱轻小说、动漫文化和写作活动氛围，**Honeyfeed** 值得单独看。
+
+这不是“哪个平台最好”的总榜。五个平台解决的是不同问题。本文在 **2026 年 8 月 10 日**重新核验它们的公开发现页、官方帮助/条款与当前读者功能，并把比较拆成五件读者真的会遇到的事：**怎么找书、怎么看连载状态、评论在哪里、免费与付费怎么区分、能不能把平台当成开放书源。**
+
+今天同时上线一个只做跳转发现的 **English Serial Platforms Starter**。它不会抓取、缓存或重新发布这些平台上的小说，只把经过核验的官方发现入口放进 WebNR：
+
+[添加 English Serial Platforms Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fenglish-serial-platforms-starter){ .md-button .md-button--primary }
+
+## 一张表先决定从哪里开始
+
+| 读者需求 | 更适合先看 | 为什么 | 需要注意 |
+| --- | --- | --- | --- |
+| LitRPG、Progression、Isekai、长篇持续连载 | Royal Road | Rising Stars、Latest Updates、Ongoing、Complete 等发现入口很明确，作品状态粒度高 | Stub 可能意味着完整内容已转移到站外或付费渠道 |
+| 想按题材、字数、章节数、更新频率、读者数、评论数细筛 | Scribble Hub | Series Finder 暴露大量筛选维度，类型标签范围很宽 | Adult、Smut、Mature 等内容与普通类型并列，需要主动筛选 |
+| 想要社交阅读、评论、阅读列表、手机离线 | Wattpad | 官方应用强调评论、Library/Reading Lists 与离线阅读 | 广告、应用内购买和平台推荐逻辑会影响阅读流；完结筛选不如前两者直观 |
+| 想在社区原创、编辑内容和 Premium 之间切换 | Tapas | Community、Free Access、Premium 的产品分区相对明确 | Free Access 标题会变化；Mature 区需要网页登录与年龄验证 |
+| 偏轻小说、动漫文化、写作比赛与作者互动 | Honeyfeed | Ongoing/Finished、题材筛选、活动入口和评论互动都很显眼 | 官方条款对自动抓取和内容再利用限制明确，不适合做正文抓取源 |
+
+这里有一个容易被“平台推荐榜”掩盖的差异：**连载平台不是只有内容库，发现机制本身就是阅读体验。** 同一本处于连载中的作品，在“按最近更新排序”“按上升趋势排序”“按读者评价排序”和“算法首页推荐”里，会呈现出完全不同的可见性。读者如果经常遇到追到一半才发现作者停更，状态字段和更新时间筛选往往比首页推荐更有用。
+
+## Royal Road：最适合把“连载状态”当第一筛选条件
+
+Royal Road 的公开帮助把作品状态分成 **Ongoing、Completed、Hiatus、Stub、Dropped** 五种。Ongoing 会和最近更新联动；Completed 由作者标记；Dropped 明确表示不再继续；而 Stub 特别值得注意——它表示完整内容已经不再全部留在 Royal Road，读者可能需要前往其他渠道，甚至付费，才能继续读完。
+
+这套状态系统对追长篇很实用，因为“最后更新时间很久以前”和“作者明确弃坑”不是同一件事。Royal Road 的 [Fiction Status 说明](https://www.royalroad.com/support/knowledgebase/88) 和 [Advanced Search](https://www.royalroad.com/support/knowledgebase/79) 都把状态当成正式筛选维度。
+
+发现层也很细。官方 [Discovery & Ranking](https://www.royalroad.com/support/knowledgebase/78) 列出 Best Rated、Trending、Ongoing Fictions、Complete、Popular this Week、New Releases、Latest Updates、Rising Stars 等入口。当前 [Rising Stars](https://www.royalroad.com/fictions/rising-stars) 页面可以直接看到 LitRPG、Progression、Portal Fantasy / Isekai、GameLit 等高频标签；如果你不想承担连载风险，则可以直接从 [Complete](https://www.royalroad.com/fictions/complete) 开始。
+
+评论与评价也不是一个简单五星总分。Royal Road 的评价规则区分 rating、basic review 与 advanced review，后者进一步给 Style、Story、Grammar、Characters 等维度；章节评论则构成持续反馈流。对于愿意在开读前花五分钟判断作品的人，这是五个平台里信息结构最清楚的一类。
+
+**适合谁：** 喜欢长篇幻想、升级流、LitRPG、冒险，愿意追更，同时非常介意弃坑风险的读者。
+
+**不适合谁：** 只想打开一个极简首页、被动接受推荐，不想理解状态、榜单和标签体系的人。
+
+### 为什么 WebNR 今天只链接，不抓 Royal Road
+
+Royal Road 的 `robots.txt` 对普通抓取路径有具体规则，同时单独禁止多种 AI crawler；更重要的是，当前 [Terms of Service](https://www.royalroad.com/tos) 明确限制未经许可的 scrape、crawl、cache 和 bot 访问。也就是说，“网页公开可读”并不自动等于“可以把它做成第三方自动抓取正文源”。
+
+因此 WebNR 的 Starter 只给出官方发现页链接，不复制作品简介，不抓章节，不把网页结构变成运行时 adapter。以后只有存在明确授权、官方机器接口或其他可解释的访问契约时，才会升级能力。
+
+## Scribble Hub：像一个“自己调参数”的小说发现器
+
+Scribble Hub 最突出的读者能力不是首页，而是 [Series Finder](https://www.scribblehub.com/series-finder/)。当前公开页面可以按标题、章节数、每周章节、收藏、评分数量、读者数、评论数、最后更新、页数、浏览量、总字数等条件筛选，还能同时包含或排除题材、标签和内容警告。
+
+它的题材表也比很多大众阅读平台更直接：Fantasy、LitRPG、Isekai、Gender Bender、Girls Love、Boys Love、Fanfiction、Adult、Mature、Smut 等都作为显式分类存在。各 [Genre 页面](https://www.scribblehub.com/genre/) 还能按章节数、更新频率、最后更新、Popularity、Ratings、Readers、Reviews、Word Count 排序，并筛选 Completed、Ongoing、Hiatus。
+
+这意味着 Scribble Hub 特别适合“我已经知道自己要什么”的读者。例如你可以把需求写成：Fantasy + Girls Love、至少几十章、最近仍更新、排除某些内容警告，然后自己缩小范围，而不是把全部决定交给首页算法。
+
+它的代价也是同一件事：标签非常开放，成人内容与一般题材共享同一套发现系统。对不想看到这类作品的读者，Series Finder 的排除条件和内容警告不是高级功能，而是正常使用流程的一部分。
+
+Scribble Hub 在 2026 年 6 月更新的 [Terms of Service](https://www.scribblehub.com/terms-of-service/) 与 [Privacy Policy](https://www.scribblehub.com/privacy-policy/) 也明确区分平台内容与用户投稿权利。WebNR 因此同样不把公开页面当成可自由复制的小说数据库。今天只收录官方 Series Finder 入口。
+
+**适合谁：** 喜欢精细筛选、题材口味明确、希望根据字数/更新/评论等信号自己做判断的人。
+
+## Wattpad：真正的优势仍然是“社交阅读产品”
+
+Wattpad 的当前官方 Google Play 应用说明把核心体验写得很清楚：读者可以直接在故事上评论、建立 Library 与 Reading Lists、与其他读者和作者互动，并把作品下载到应用里离线阅读。2026 年 7 月的官方应用页面仍然把这些能力作为主要卖点。
+
+这也是它与 Royal Road / Scribble Hub 最大的差别。前两者更像“高密度连载目录 + 社区”；Wattpad 更像“故事社交网络 + 阅读器”。如果你经常从朋友的阅读列表、评论区、作者更新和平台推荐里决定下一本，而不是先设十个过滤器，Wattpad 的使用方式更自然。
+
+它也更明显地是一个商业移动产品。当前 [Google Play 官方页面](https://play.google.com/store/apps/details?id=wp.wattpad) 标有广告与应用内购买，并宣传移动端离线下载。因此本文不会把“免费平台”理解成“完全没有商业化或付费体验”。
+
+另一个实际差异是**完结风险的可见性**。Royal Road 和 Scribble Hub 把作品状态直接放进发现筛选；Wattpad 的官方应用说明更强调社交、收藏、推荐和离线。对“只读已经完结的长篇”这类需求，我会优先使用状态筛选更直接的平台，再把 Wattpad 用作作品和社区发现。
+
+**适合谁：** 看重读者社区、评论、阅读列表和移动端体验，尤其是 romance、fanfiction、YA 等社交传播很强的类型读者。
+
+## Tapas：先判断你在看 Community、Free Access 还是 Premium
+
+Tapas 最值得先理解的不是类型，而是内容分区。官方 [Tapas Community](https://help.tapas.io/hc/en-us/articles/4409607638171-What-is-Tapas-Community) 说明 Community 是免费阅读的用户创作 webcomics 与 webnovels 空间；[Free Access](https://help.tapas.io/hc/en-us/articles/25196732571419-What-is-Free-Access) 则是把 Premium 系列从头到尾临时或持续免费开放的专区，而且标题列表会变化。平台还有单独的 Premium 与付费阅读机制。
+
+这使 Tapas 特别适合“我愿意在编辑内容和社区原创之间切换”的读者，也意味着“Tapas 上免费”需要再问一句：这是 Community 原创、本期 Free Access，还是某种付费解锁机制下的免费章节？
+
+它的 Mature 内容边界也比很多平台明确。官方帮助说明 Mature 是 **18+、仅 Web、需要登录和年龄验证** 的区域。对于目录或第三方阅读器，这类状态必须保留，不能把“网页能打开”简化成通用公开内容。
+
+小说发现可以从 [Novels collection](https://tapas.io/collection/novels) 与 Community 入口开始。WebNR 今天仍只做链接跳转：不复制 Premium 内容，不尝试绕过登录、年龄验证、付费或应用限制。
+
+**适合谁：** 同时读网漫和网文，喜欢编辑推荐，也愿意浏览社区原创，并能接受平台内免费/付费层级的人。
+
+## Honeyfeed：轻小说与动漫文化取向很鲜明，但自动化边界也最值得认真读
+
+Honeyfeed 自己把产品称为 Web Novel Community。它的 [About](https://www.honeyfeed.fm/about/) 强调作者反馈、动漫读者社区、订阅新章节邮件以及作者与读者互动；当前 [Novels](https://www.honeyfeed.fm/novels) 页面提供 Action、Fantasy、Isekai、LitRPG、Girls Love、Mecha、Sci-Fi 等题材，也能按 **Ongoing / Finished** 和章节数筛选，并把写作活动放在发现入口中。
+
+如果你喜欢“轻小说/动漫社区 + 原创连载 + 写作比赛”的组合，它和 Royal Road 的气质差异很明显。Royal Road 的榜单更强调连载表现与排名结构；Honeyfeed 则把活动、社区和作者曝光放得更靠前。
+
+但从 WebNR 书源角度，Honeyfeed 是今天最明确的“不要误判公开网页”的例子。它的 [Terms of Service](https://www.honeyfeed.fm/terms) 明确限制自动系统的访问频率，规定用户投稿主要通过网站正常功能访问，并限制未经许可的复制、分发与商业使用。因此一个负责任的 WebNR 集成不能因为页面结构好解析，就自动把章节抓走。
+
+今天的 Starter 只链接 Honeyfeed 的官方小说目录，不复制小说正文、简介或作者内容，也不发起后台同步。
+
+**适合谁：** 喜欢轻小说、动漫文化、Isekai 等题材，也喜欢关注写作活动和作者互动的人。
+
+## 五个平台真正不同的是“你怎样判断下一本书”
+
+把功能表放到一边，选择可以进一步简化成五种阅读决策方式：
+
+1. **我先问“它会不会完结？”** —— Royal Road。状态体系最值得先用，Complete 也是独立发现入口。
+2. **我先问“有没有精准符合这些标签和长度的？”** —— Scribble Hub。Series Finder 最像数据库查询器。
+3. **我先问“大家正在读什么、评论什么？”** —— Wattpad。社交阅读与移动端产品能力是核心。
+4. **我先问“这是社区原创还是编辑/Premium 内容？”** —— Tapas。先看内容层级，再看题材。
+5. **我先问“有没有我喜欢的轻小说/动漫风格和活动？”** —— Honeyfeed。社区文化与事件入口更突出。
+
+对读者来说，这比一个总分更有用。你完全可以同时使用两三个平台：例如用 Royal Road 的 Complete 找完结幻想，用 Scribble Hub 的 Finder 找小众标签，再用 Wattpad 追朋友和评论区推荐。
+
+## “可以在浏览器里读”不等于“可以做成自动书源”
+
+今天五个平台的核验也再次说明，**公开发现、人工点击阅读、机器索引、自动抓取、复制正文、缓存、再分发，是不同权限层级。**
+
+WebNR 的来源接入采用分级策略：
+
+- 有官方机器接口、开放许可或明确授权时，可以研究真正的 adapter；
+- 只有公开作品/目录页面、但自动化或内容权利边界不明确时，先做 link-only discovery；
+- 遇到登录、付费、年龄验证、DRM、反自动化条款或其他访问控制时，不绕过；
+- 任何平台上的作者投稿，都不能因为“用户可免费阅读”就推定为可重新分发。
+
+这也是今天新增的 English Serial Platforms Starter 为什么只有五个官方入口。它的价值不是把五个平台“搬进 WebNR”，而是让 WebNR 搜索和来源系统能够告诉你：**去哪里找，那里最擅长什么，以及下一步仍然应该在原平台完成什么。**
+
+## 如果只想现在选一个
+
+如果你完全没有偏好，我会按下面的最短路径开始：
+
+- 想追英文幻想连载：先开 [Royal Road Rising Stars](https://www.royalroad.com/fictions/rising-stars)，再切 Complete 看完结作品。
+- 已经知道想看的标签：打开 [Scribble Hub Series Finder](https://www.scribblehub.com/series-finder/) 直接筛。
+- 更重视社交和手机阅读：从 [Wattpad](https://www.wattpad.com/) 的官方应用/网站开始。
+- 想看社区原创与编辑内容混合生态：打开 [Tapas Novels](https://tapas.io/collection/novels)，先分清 Community、Free Access 和 Premium。
+- 偏轻小说、动漫文化和活动：从 [Honeyfeed Novels](https://www.honeyfeed.fm/novels) 开始。
+
+如果你已经在使用 WebNR，可以直接添加本文开头的 Starter。它不会替你跨站抓正文，但能把这五个不同的英文连载生态留在同一个发现入口里。对于真正允许直接导入的 TXT、公版或授权来源，继续参考 [2026 年哪里能合法免费看小说？](./2026-08-08-legal-free-novels-txt-collections.md)；如果你来自 Legado，则可以再看 [WebNR：给 Legado 用户的一个独立网页端替代选择](./2026-08-09-webnr-legado-web-alternative.md) 了解当前兼容边界。

--- a/public/sources/english-serial-platforms-starter/README.txt
+++ b/public/sources/english-serial-platforms-starter/README.txt
@@ -1,0 +1,56 @@
+English Serial Platforms Starter
+================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/english-serial-platforms-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fenglish-serial-platforms-starter
+
+Purpose
+-------
+This WebNR-maintained source is a link-only discovery directory for major English
+serial-fiction platforms reviewed on 2026-08-10. It is designed to help readers
+choose an origin platform by discovery model and reading workflow, not to mirror
+or aggregate third-party fiction.
+
+Included discovery routes
+-------------------------
+- Royal Road: Complete / status-oriented discovery
+- Scribble Hub: Series Finder
+- Wattpad: official reader/platform entry point
+- Tapas: Novels collection
+- Honeyfeed: Novels directory
+
+Content and rights boundary
+---------------------------
+The index contains WebNR-authored descriptions plus official destination URLs. It
+does not copy story text, chapter feeds, user reviews, cover art, comments, or
+platform-owned discovery data. A public web page is not treated as permission to
+scrape, cache, proxy, or redistribute its contents.
+
+Royal Road's current Terms of Service restrict unauthorized scraping/crawling.
+Honeyfeed's current Terms of Service limit automated access and reuse of site and
+user content. Scribble Hub's current Terms and privacy/copyright statements keep
+user submissions with their authors and do not provide a blanket reuse license.
+Tapas and Wattpad include account, commercial, moderation, and platform-specific
+reading boundaries. WebNR therefore keeps this starter in the link-only tier.
+
+Current WebNR behavior
+----------------------
+Selecting an item sends the reader to the official platform page. WebNR does not
+perform background synchronization, content extraction, login automation, age
+verification, payment bypass, DRM bypass, or chapter caching for this source.
+
+Future upgrade rule
+-------------------
+A platform may gain a richer adapter only after WebNR can identify an explicit
+machine-readable interface or permission boundary, define request/rate behavior,
+preserve rights and maturity metadata, build fixtures, and test the behavior
+without bypassing origin controls.
+
+Last verified
+-------------
+2026-08-10

--- a/public/sources/english-serial-platforms-starter/search_index.yml
+++ b/public/sources/english-serial-platforms-starter/search_index.yml
@@ -1,0 +1,75 @@
+english-serial-platforms/royal-road.md:
+  title: Royal Road — Complete & Rising Stars
+  author: Royal Road
+  description: WebNR 核验的 Royal Road 官方发现入口，适合按连载状态、Rising Stars、Complete 等信号寻找英文连载小说。此条目仅跳转原站，不抓取、缓存或重新发布小说正文。
+  page_url: https://www.royalroad.com/fictions/complete
+  source: WebNR English Serial Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Royal Road
+    - English serial fiction
+    - LitRPG
+    - Progression fantasy
+  categories:
+    - Platform discovery
+  region: en
+
+english-serial-platforms/scribble-hub.md:
+  title: Scribble Hub — Series Finder
+  author: Scribble Hub
+  description: WebNR 核验的 Scribble Hub Series Finder 官方入口，可按题材、章节、字数、更新、读者、评论和状态等条件筛选。此条目仅提供官方页面链接。
+  page_url: https://www.scribblehub.com/series-finder/
+  source: WebNR English Serial Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Scribble Hub
+    - English serial fiction
+    - Series finder
+  categories:
+    - Platform discovery
+  region: en
+
+english-serial-platforms/wattpad.md:
+  title: Wattpad — Stories
+  author: Wattpad
+  description: Wattpad 官方阅读入口，面向重视社交阅读、评论、阅读列表和移动端体验的读者。WebNR 不复制 Wattpad 用户投稿，也不尝试绕过账号、广告、付费或平台访问限制。
+  page_url: https://www.wattpad.com/
+  source: WebNR English Serial Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Wattpad
+    - English serial fiction
+    - Social reading
+  categories:
+    - Platform discovery
+  region: en
+
+english-serial-platforms/tapas.md:
+  title: Tapas — Novels
+  author: Tapas
+  description: Tapas 官方 Novels 发现入口，包含 Community、Free Access 与 Premium 等不同内容层级。WebNR 仅做跳转发现，不复制内容或绕过登录、年龄验证和付费边界。
+  page_url: https://tapas.io/collection/novels
+  source: WebNR English Serial Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Tapas
+    - English serial fiction
+    - Community novels
+  categories:
+    - Platform discovery
+  region: en
+
+english-serial-platforms/honeyfeed.md:
+  title: Honeyfeed — Novels
+  author: Honeyfeed
+  description: Honeyfeed 官方小说目录，提供 Ongoing/Finished、章节数、题材与活动等发现维度。根据官方条款，WebNR 仅保留人工核验的跳转链接，不运行正文抓取或后台同步。
+  page_url: https://www.honeyfeed.fm/novels
+  source: WebNR English Serial Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Honeyfeed
+    - English serial fiction
+    - Light novel
+  categories:
+    - Platform discovery
+  region: en


### PR DESCRIPTION
## Outcome
Publish the 2026-08-10 reader-facing comparison of Royal Road, Scribble Hub, Wattpad, Tapas, and Honeyfeed, add one installable WebNR-maintained link-only discovery source for their official platform entry points, and advance the pinned SEO-skill submodule after reviewing the upstream one-commit automation-first update.

## Evidence and scope
- Follows the 2026-08-10 editorial slot in `.github/seo-data/editorial-calendar.md`.
- Audited five new platform/source candidates; the integration deliberately remains link-only because origin terms and access boundaries do not authorize a generic chapter scraper.
- Royal Road exposes strong status/ranking discovery but its current Terms restrict unauthorized scraping/crawling.
- Scribble Hub exposes a detailed public Series Finder; current Terms/copyright statements do not grant blanket third-party content reuse.
- Honeyfeed explicitly limits automated access and content reuse in its Terms.
- Tapas distinguishes Community, Free Access, Premium, and age-gated Mature content.
- Wattpad's current official app listing emphasizes comments, reading lists, and offline mobile reading.
- Reviewed `AutoArchive/seo-skill` `d1194eeb... -> 9f0bd4f...`; the new contract adds deterministic autoaction guidance without weakening this repository's existing PR/CI/content/source-admission boundaries. WebNR has no site-owned `autoaction.md`, so no direct-main mutation lane is created by this PR.

## Changes
- Add the comparison article with primary-source links and explicit fact/editorial boundaries.
- Add `english-serial-platforms-starter` containing only WebNR-authored descriptions and official destination links; no story text, comments, cover art, chapter feeds, or background crawling.
- Extend Quality CI to assert the new source, article, canonical route, sitemap entry, and RSS entry.
- Advance `.github/seo-skills` to `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`.

## Preserved behavior
Existing reader import, existing four WebNR sources, analytics destination `G-DGH8HNQKE4`, full-URL reporting policy, routes, canonicals, and previous articles are unchanged. The submodule update does not authorize any direct default-branch writes because WebNR does not define an autoaction contract.

## Validation
Expected PR gates: Web quality, Chromium user journeys, Documentation quality, and Production evidence. Documentation CI must build the new canonical article route and find it in sitemap/RSS; Web CI must build the new source output and recursively checkout the new pinned skills.

## Risk / rollback
Risk is limited to editorial/source metadata, CI assertions, and a reviewed shared-skill pointer. The new source cannot fetch third-party content. Rollback is a squash revert removing the article/source/assertions and restoring the previous submodule pointer.

## Production acceptance
After squash merge, verify the canonical article at `https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/`, the source at `https://app.webnovel.win/sources/english-serial-platforms-starter/search_index.yml`, the existing app path, GA4 runtime contract, and representative prior documentation routes. Then record exact deployment/public evidence through the repository closeout PR lifecycle.