### PR TITLE
ops: close out 2026-08-10 scheduled cycle

### DIFF
--- a/.github/seo-data/daily/2026-08-10.md
+++ b/.github/seo-data/daily/2026-08-10.md
@@ -1,0 +1,82 @@
+# WebNR operations — 2026-08-10
+
+## Scope
+
+The scheduled cycle resumed from current `main` after pull request #72 had already completed the day's reader-content and source-admission change. No WebNR pull request was open to continue when this closeout work began. The repository's pinned SEO skills had advanced in #72 from `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003` to the reviewed upstream commit `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`; WebNR still has no site-owned `autoaction.md`, so no direct-default-branch automation lane is authorized.
+
+This cycle completed the required evidence pass, rechecked source health, identified a production-evidence defect, and placed that defect on the same-cycle repair path. No external promotional post or account action was performed.
+
+## Data quality and windows
+
+WebNR uses `America/Los_Angeles`, a 28-day decision lookback, and a three-day finalization lag. For this cycle, the latest fully eligible provider date would be 2026-08-07. The operational window covers the prior 24 hours and all repository/deployment activity since the last completed cycle.
+
+- **GA4:** the configured Google Drive folder `webNR SEO Weekly CSV` was reachable on 2026-08-10, but its direct non-trashed child listing contained no matching GA4 export. GA4 acquisition and landing-page performance are **unavailable**, not zero. No provider row or private identifier is stored here.
+- **Google Search Console:** the same direct folder check contained no matching Search Console export. Query/page, indexing, country, device, search-appearance, and sitemap performance are **unavailable**, not zero.
+- **Cloudflare traffic analytics:** the authenticated zone connector was checked against every currently exposed account and returned no exact active `webnovel.win` zone. Request/visit/byte aggregates are therefore **unavailable**, not zero.
+- **GitHub, CI, generated artifacts, and repository evidence:** available. Pull request #72's final head `707269a4cc44b3b563d026473c8fb6fec898de11` completed Quality run `31409672801` successfully before squash merge `e5de80559e3d9bc4f467c74d81e6eac423eecf47`.
+- **Generated application artifact:** `app-pages/build.json` identifies exact commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`, source `github-actions`, built on 2026-08-10.
+- **Generated documentation mirror artifact:** `gh-pages/build.json` identifies exact commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`, source `github-pages-build-mirror`. The generated 2026-08-10 article has the intended `www.webnovel.win` canonical and the configured GA4 destination.
+
+Because GA4 and Search Console exports are absent, there is no valid finalized 7-day-versus-previous-7-day or 28-day-versus-prior-period traffic/search comparison for this cycle. No traffic, demand, CTR, position, or engagement conclusion is inferred from the missing files.
+
+## Analytics and measurement audit
+
+Source and generated-output inspection preserves the single runtime measurement destination `G-DGH8HNQKE4`. The reader still configures `page_location` from `window.location.href` and `page_path` from `window.location.pathname + window.location.search`, so imported URLs carried in query parameters remain part of the owner-selected full-URL reporting policy. Google signals and ad-personalization signals remain disabled. The documentation build also retains the single configured destination.
+
+The evidence pass found one concrete measurement/production defect: `scripts/verify-production-builds.mjs`, which backs the required Quality `Production evidence` job, verified the public reader and the noncanonical GitHub Pages documentation mirror but did not independently verify the canonical `https://www.webnovel.win/` build identity. That left the canonical publication path outside the repository's normal exact-production gate even though `daily-task.md` and `site.md` require it.
+
+The same-cycle repair extends the verifier to require exact public build identity for the canonical documentation site and to check representative canonical content, today's scheduled article, sitemap/RSS discovery, the reader's full-URL GA4 configuration, and today's source output. The repair is deliberately read-only and does not change Cloudflare, DNS, analytics, source admission, or application behavior.
+
+## Reader-content and search review
+
+The rolling 48-hour content requirement is satisfied by pull request #72's scheduled 2026-08-10 article, `2026 英文连载小说平台怎么选？Royal Road、Scribble Hub、Wattpad、Tapas、Honeyfeed 对比`, at the stable intended canonical route `/blog/2026/08/10/english-serial-fiction-platforms/`.
+
+The article answers the named reader question near the top, states its 2026-08-10 verification date, compares discovery and reading workflows rather than manufacturing a universal ranking, and keeps platform facts separate from WebNR's editorial choice to remain link-only. Documentation Quality on the final #72 head asserted the static article, canonical URL, sitemap entry, RSS entry, and `English Serial Platforms Starter` callout. The generated documentation mirror independently contains the same route with the intended `www.webnovel.win` canonical.
+
+No speculative canonical, redirect, route, metadata, or keyword-variant experiment is justified by current Search Console evidence because that evidence is unavailable. The next scheduled reader-facing topic remains the 2026-08-12 map of public web-novel reader communities and recommendation channels.
+
+## Source discovery, audits, integration, and health
+
+Pull request #72 supplied the required five new candidates for the 2026-08-10 source program and audited them as platform discovery routes:
+
+1. **Royal Road** — official Complete / status-oriented discovery route; current public Complete discovery was reachable during this cycle.
+2. **Scribble Hub** — official Series Finder; retained as link-only because no blanket reuse right is inferred from public availability.
+3. **Wattpad** — official reader/platform entry point; retained as link-only and outside any account, advertising, payment, or content-copying workflow.
+4. **Tapas** — official Novels collection; current public Novels route was reachable during this cycle; Community, Free Access, Premium, login, maturity, and payment boundaries remain origin-owned.
+5. **Honeyfeed** — official Novels directory; current public directory was reachable during this cycle and the origin's automated-access/reuse boundary remains respected.
+
+The passing integration is `English Serial Platforms Starter`, a WebNR-maintained link-only source containing WebNR-authored descriptions and official destination links. It copies no story text, chapter feed, comments, reviews, cover art, or platform-owned catalog data, and performs no background crawling, login automation, age-verification bypass, payment bypass, DRM bypass, or chapter caching. A richer adapter remains contingent on an explicit machine-readable interface or permission boundary plus fixtures and bounded request behavior.
+
+Existing-source rotation also found the Project Madurai `திருக்குறள்` origin page and the Aozora Bunko `吾輩は猫である` card reachable during this cycle. Quality continues to assert output for WebNR Originals, Aozora Bunko Starter, Standard Ebooks Starter, Project Madurai Starter, and the new English Serial Platforms Starter. No maintained source was removed or downgraded.
+
+## Public community evidence
+
+Today's scheduled comparison relies primarily on platform-owned discovery/help/terms evidence rather than a claim about reader-community consensus. No small social sample is promoted into a popularity statement. No automated Reddit, Discord, forum, or social posting is authorized or needed for this cycle. Public-community sampling is intentionally reserved for the 2026-08-12 community-map assignment, where the sampling scope and date window can be defined before claims are made.
+
+## Decisions
+
+- **Technical:** repair the canonical-production verification blind spot in the current cycle; do not defer a reproducible measurement defect.
+- **Content:** keep the 2026-08-10 English serial-fiction platform comparison as today's qualifying reader asset; proceed next to the 2026-08-12 community-map slot rather than creating another same-day page.
+- **Source:** accept the five-platform directory only at the link-only compatibility tier; require explicit machine-interface/permission evidence before any richer adapter.
+- **Search:** make no speculative search-facing experiment while Search Console evidence is unavailable; preserve stable URL/canonical behavior and strengthen exact production proof instead.
+- **Community:** do not post externally or infer consensus today; define a reproducible public sample for the next community-focused assignment.
+- **Measurement:** preserve the single GA4/full-URL owner policy, label GA4/GSC/Cloudflare traffic evidence unavailable, and extend the repository production gate to the canonical documentation origin.
+
+## Delivery state
+
+### Reader content and source delivery
+
+- Pull request: #72 `content: compare English serial-fiction platforms`
+- Final reviewed head: `707269a4cc44b3b563d026473c8fb6fec898de11`
+- Final Quality run: `31409672801` — success
+- Squash merge: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Generated application artifact: exact `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Generated documentation mirror artifact: exact `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+
+### Same-cycle production-evidence repair and closeout
+
+A fresh `seo/2026-08-10-production-closeout` branch was created from exact squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`. It contains the canonical-production verifier repair plus this public-safe daily record. The real non-draft pull request, complete Quality result, post-CI from-scratch review, squash merge, and exact public acceptance evidence are recorded here and in `status.md` as those facts become available.
+
+## Uncertainty and blockers
+
+The absent GA4/Search Console exports and unavailable Cloudflare zone analytics reduce performance evidence but do not constitute a human-only blocker and are not represented as zero. No human-only permission, legal, billing, credential, or external-account action is currently required for the repository/CI/public-verification path. The cycle remains incomplete until the production-evidence repair and metadata closeout complete the repository's required PR, CI, final-review, squash-merge, and exact public verification lifecycle.

--- a/.github/seo-data/daily/2026-08-10.md
+++ b/.github/seo-data/daily/2026-08-10.md
@@ -75,8 +75,16 @@ Today's scheduled comparison relies primarily on platform-owned discovery/help/t
 
 ### Same-cycle production-evidence repair and closeout
 
-A fresh `seo/2026-08-10-production-closeout` branch was created from exact squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`. It contains the canonical-production verifier repair plus this public-safe daily record. The real non-draft pull request, complete Quality result, post-CI from-scratch review, squash merge, and exact public acceptance evidence are recorded here and in `status.md` as those facts become available.
+A fresh `seo/2026-08-10-production-closeout` branch was created from exact squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`. Pull request #73 `ops: close out 2026-08-10 scheduled cycle` is the real non-draft delivery for the canonical-production verifier repair and the public-safe operating record.
+
+Its first complete Quality run, `31412094151`, passed all four expected jobs: Web quality, Documentation quality, Production evidence, and Chromium user journeys. Production evidence job `93532348626` independently observed exact commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47` on all three delivery surfaces:
+
+- public reader `app.webnovel.win`, including the single GA4 destination, full-URL configuration strings, and the public `English Serial Platforms Starter` output;
+- noncanonical GitHub Pages documentation mirror, including the troubleshooting route with the intended `www.webnovel.win` canonical;
+- canonical `www.webnovel.win` documentation site, including the exact build identity, the 2026-08-10 platform-comparison article with its canonical, the sitemap entry, and the RSS entry.
+
+That independent proof authorizes the closeout branch to advance the three last-successful deployment records to `e5de80559e3d9bc4f467c74d81e6eac423eecf47` and remove the temporary verification targets. The resulting final head must rerun complete Quality and undergo the required from-scratch review before squash merge.
 
 ## Uncertainty and blockers
 
-The absent GA4/Search Console exports and unavailable Cloudflare zone analytics reduce performance evidence but do not constitute a human-only blocker and are not represented as zero. No human-only permission, legal, billing, credential, or external-account action is currently required for the repository/CI/public-verification path. The cycle remains incomplete until the production-evidence repair and metadata closeout complete the repository's required PR, CI, final-review, squash-merge, and exact public verification lifecycle.
+The absent GA4/Search Console exports and unavailable Cloudflare zone analytics reduce performance evidence but do not constitute a human-only blocker and are not represented as zero. No human-only permission, legal, billing, credential, or external-account action is currently required for the repository/CI/public-verification path. The cycle remains incomplete until the final #73 head completes the repository's required CI, final-review, squash-merge, and post-merge exact public verification lifecycle.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,24 +3,19 @@
 ## Current state
 
 - Last merged product and reader-content change: pull request #72, squash merge `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
-- Last successful attributable application deployment: `2df9e0f50cc93d79418a435069f46150d76d46f6`
-- Last successful attributable documentation deployment: `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
-- Last successful canonical Cloudflare documentation deployment: `7d319f26e2c3398215c1d2cedca6f99820f1de50`
-- Current application verification target: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
-- Current documentation mirror verification target: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
-- Current canonical documentation verification target: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Last successful attributable application deployment: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Last successful attributable documentation deployment: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Last successful canonical Cloudflare documentation deployment: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
 - Latest application deployment artifact branch commit: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
-- Canonical public-site state: the independent `webnr-docs` Cloudflare Pages project remains the required canonical route; the 2026-08-10 closeout must independently prove exact commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47` before advancing the last-successful record
-- Reader public-site state: the generated `app-pages` artifact exposes exact pull request #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`; the 2026-08-10 closeout must independently prove the same exact commit on `https://app.webnovel.win/build.json` before advancing the last-successful record
+- Canonical public-site state: healthy and attributable on the independent `webnr-docs` Cloudflare Pages project; pull request #73 initial Quality run `31412094151`, Production evidence job `93532348626`, independently observed exact commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`, the 2026-08-10 article canonical, sitemap entry, RSS entry, and representative troubleshooting content on `www.webnovel.win`
+- Reader public-site state: healthy and attributable; pull request #73 initial Quality run `31412094151`, Production evidence job `93532348626`, independently observed exact pull request #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`, the single GA4/full-URL runtime configuration, and the public English serial-platform source on `app.webnovel.win`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
 - Current skill submodule: `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`
 - Current analytics export state: the configured Google Drive folder is accessible, but the 2026-08-10 direct folder-content check exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
 - Current Cloudflare traffic-analytics state: the authenticated zone connector did not expose an exact active `webnovel.win` zone in any currently exposed account during the 2026-08-10 scheduled cycle, so Cloudflare request analytics are unavailable for this cycle rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
-
-The three `Current ... verification target` lines are temporary closeout targets. They do not replace the last-successful records. `scripts/verify-production-builds.mjs` must prove each target on its actual public route before the closeout advances the corresponding last-successful line and removes the temporary target.
 
 ## Current signals
 
@@ -30,22 +25,22 @@ The three `Current ... verification target` lines are temporary closeout targets
 - `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
 - `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. It emits `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
 - Pull request #72 published the scheduled 2026-08-10 reader comparison of Royal Road, Scribble Hub, Wattpad, Tapas, and Honeyfeed and added `English Serial Platforms Starter` as a WebNR-maintained link-only discovery source. Its final head `707269a4cc44b3b563d026473c8fb6fec898de11` passed Quality run `31409672801` before squash merge `e5de80559e3d9bc4f467c74d81e6eac423eecf47`.
-- The `app-pages` application artifact and `gh-pages` documentation mirror artifact both expose exact pull request #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`. The generated documentation article emits canonical `https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/` and the configured GA4 destination.
-- The 2026-08-10 evidence pass found that the repository's Production evidence verifier covered the reader and noncanonical documentation mirror but did not independently require the canonical `www.webnovel.win` build. The current closeout repairs that blind spot and adds exact canonical article, sitemap/RSS, application analytics, and source-output acceptance checks.
+- The `app-pages` application artifact and `gh-pages` documentation mirror artifact both expose exact pull request #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`. Pull request #73 Production evidence job `93532348626` independently observed that same exact commit on the public reader, public documentation mirror, and canonical documentation site.
+- The generated and canonical 2026-08-10 article emits canonical `https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/`; the public sitemap and RSS both include the route.
+- The 2026-08-10 evidence pass found that the repository's Production evidence verifier covered the reader and noncanonical documentation mirror but did not independently require the canonical `www.webnovel.win` build. Pull request #73 repairs that blind spot and adds exact canonical article, sitemap/RSS, application analytics, and source-output acceptance checks.
 - Pull request #70 removed the visible Google Analytics notice from the reader's empty-library onboarding and Add/import view while preserving the runtime GA4 destination, full-URL reporting, Google-signal settings and documentation disclosure. Its final Quality run `31339726456` passed Web quality, Documentation quality, Production evidence against the prior public baseline, and Chromium user journeys; the Chromium suite passed all eight desktop/mobile tests and now asserts that the analytics notice is absent from both first-use and import UI.
 - The `app-pages` application artifact exposed exact pull request #70 squash commit `2df9e0f50cc93d79418a435069f46150d76d46f6`, source `github-actions`. Closeout Quality run `31340025388`, Production evidence job `93312160963`, independently resolved the Cloudflare-served `app.webnovel.win` hostname and observed the same exact commit, so the reader UI cleanup was production-verified before the newer #72 delivery.
-- The GitHub Pages documentation build mirror previously exposed exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and labels itself `github-pages-build-mirror`; the generated artifact has now advanced to the #72 target `e5de80559e3d9bc4f467c74d81e6eac423eecf47` and awaits independent public closeout proof.
 - The documentation mirror contains the generated article `WebNR：给 Legado 用户的一个独立网页端替代选择` at mirror path `/blog/2026/08/09/webnr-legado-web-alternative/`, with intended canonical `https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/`, as well as the generated 2026-08-10 platform-comparison route.
 - Pull request #62 final Quality run `31303061815` passed Web quality, Documentation quality, Production evidence against the pre-merge production baseline, and Chromium user journeys.
 - Chromium job `93218999672` ran eight tests across desktop Chromium and Pixel 7 emulation; all eight passed. The suite covers first use, manifest and Service Worker registration, local TXT import, rendered reading content, IndexedDB persistence, keyboard reopen, CORS-allowed URL import and recoverable invalid-input errors.
 - The Chromium gate found and repaired a real PWA bug: an `afterInteractive` registration script could attach its `window.load` listener after the load event had already fired. Registration now runs immediately when the document is already complete.
 - The same cycle repaired mouse-only library activation. Novel rows now expose button semantics, keyboard focus, Enter/Space activation and visible focus treatment.
 - Closeout Quality run `31303434565` independently verified the exact documentation mirror at `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and correctly exposed the then-stale application route. The Cloudflare production deployment subsequently advanced `app.webnovel.win` to the same exact commit, resolving that incident without rewriting the historical failed run.
-- Production-evidence logic follows the current topology: `app.webnovel.win` is the public reader target; GitHub Pages is the attributable documentation build mirror and must emit `www.webnovel.win` canonical output; the canonical `www.webnovel.win` route is now also an explicit exact-build verification target.
+- Production-evidence logic follows the current topology: `app.webnovel.win` is the public reader target; GitHub Pages is the attributable documentation build mirror and must emit `www.webnovel.win` canonical output; the canonical `www.webnovel.win` route is an explicit exact-build verification target.
 - The 2026-08-08 routing diagnostic proved that `www.webnovel.win` and the documentation mirror are different delivery paths: the mirror exposed an exact reviewed build while `www/build.json` returned 404 and the `www` root served an older site shell.
 - `https://webnr.pages.dev/` is a reader-application mirror/project and must not be used as the documentation origin for `www`.
 - Pull request #57 established the durable canonical contract; pull request #58 added the repository-owned documentation build entrypoint; pull request #61 repaired shallow-checkout history for that build; pull request #59 merged the rendered canonical-origin source repair as `a6e9256369b0b2c29f3c80e428708e0b2da4894c`.
-- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The last independently recorded canonical site build remains `7d319f26e2c3398215c1d2cedca6f99820f1de50` until the current closeout proves and advances the 2026-08-10 target.
+- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The current independently verified canonical site build is exact product/content commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`.
 - Pull request #29 upgraded Next.js to 16.3.0 and the matching native flat ESLint configuration, upgraded the affected Sharp dependency, preserved the prior behavioral lint baseline for separately scoped React refactors, passed all four Quality jobs, and produced an audit result with no known vulnerabilities.
 - Pull request #67 repaired stale repository guidance after that migration. Quality run `31323828174` passed Web quality, Documentation quality, Production evidence, and Chromium user journeys before squash merge `23a660fa0e68b74ef73716ac0383dafd01786fab`; the change was developer-guidance-only and required no rendered-site deployment.
 - Pull request #68 added `Project Madurai Starter` as a link-only Tamil-literature discovery catalog with four audited origin pages, preserved the existing source catalogs, and extended source-output validation. Quality run `31324032188` passed Web quality, Documentation quality, Production evidence, and Chromium user journeys before squash merge `65fbda14e8062d7b055db5987646598b04ffcddc`.
@@ -70,7 +65,7 @@ The three `Current ... verification target` lines are temporary closeout targets
 
 ## Active focus
 
-1. Complete the 2026-08-10 exact production closeout, then keep `https://www.webnovel.win/` as the sole canonical documentation/editorial identity and `https://app.webnovel.win/` as the reader runtime with exact public build evidence after rendered changes.
+1. Complete pull request #73's final CI/review/merge lifecycle, then keep `https://www.webnovel.win/` as the sole canonical documentation/editorial identity and `https://app.webnovel.win/` as the reader runtime with exact public build evidence after rendered changes.
 2. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status.
 3. Keep the Chromium desktop/mobile journeys as a permanent gate and expand them alongside backup/restore, storage migration, offline behavior and accessibility improvements.
 4. Continue the reader-facing editorial schedule; the English serial-fiction platform comparison is the 2026-08-10 asset, and the next scheduled reader topic is the 2026-08-12 map of public reader communities and recommendation channels.

--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -2,20 +2,25 @@
 
 ## Current state
 
-- Last merged product and reader-content change: pull request #70, squash merge `2df9e0f50cc93d79418a435069f46150d76d46f6`
+- Last merged product and reader-content change: pull request #72, squash merge `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
 - Last successful attributable application deployment: `2df9e0f50cc93d79418a435069f46150d76d46f6`
 - Last successful attributable documentation deployment: `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd`
 - Last successful canonical Cloudflare documentation deployment: `7d319f26e2c3398215c1d2cedca6f99820f1de50`
-- Latest application deployment artifact branch commit: `2df9e0f50cc93d79418a435069f46150d76d46f6`
+- Current application verification target: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Current documentation mirror verification target: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Current canonical documentation verification target: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
+- Latest application deployment artifact branch commit: `e5de80559e3d9bc4f467c74d81e6eac423eecf47`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
-- Canonical public-site state: healthy and attributable on the independent `webnr-docs` Cloudflare Pages project; the last independently recorded exact canonical build is main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`
-- Reader public-site state: healthy and attributable; closeout Quality run `31340025388`, Production evidence job `93312160963`, independently observed exact pull request #70 squash commit `2df9e0f50cc93d79418a435069f46150d76d46f6` on `https://app.webnovel.win/build.json`
+- Canonical public-site state: the independent `webnr-docs` Cloudflare Pages project remains the required canonical route; the 2026-08-10 closeout must independently prove exact commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47` before advancing the last-successful record
+- Reader public-site state: the generated `app-pages` artifact exposes exact pull request #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`; the 2026-08-10 closeout must independently prove the same exact commit on `https://app.webnovel.win/build.json` before advancing the last-successful record
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
-- Current skill submodule: `d1194eeb23a6dd5cf04956f5efcfe8e3f0105003`
-- Current analytics export state: the configured Google Drive folder is accessible, but the 2026-08-09 direct folder-content check exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
-- Current Cloudflare traffic-analytics state: the authenticated zone connector did not expose an exact `webnovel.win` zone during the 2026-08-09 scheduled cycle, so Cloudflare request analytics are unavailable for that cycle rather than zero
+- Current skill submodule: `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`
+- Current analytics export state: the configured Google Drive folder is accessible, but the 2026-08-10 direct folder-content check exposed no matching GA4 or Search Console files; missing exports are treated as unavailable rather than zero
+- Current Cloudflare traffic-analytics state: the authenticated zone connector did not expose an exact active `webnovel.win` zone in any currently exposed account during the 2026-08-10 scheduled cycle, so Cloudflare request analytics are unavailable for this cycle rather than zero
 - Current long-term operating direction: reader discovery, recommendations, community and ecosystem analysis, daily source growth, broad clean-room Legado compatibility, and supporting product maintenance
+
+The three `Current ... verification target` lines are temporary closeout targets. They do not replace the last-successful records. `scripts/verify-production-builds.mjs` must prove each target on its actual public route before the closeout advances the corresponding last-successful line and removes the temporary target.
 
 ## Current signals
 
@@ -24,20 +29,23 @@
 - `https://www.webnovel.win/` is the sole canonical public identity for documentation, reader-facing articles, search indexing, canonical tags, sitemap, and RSS. A temporary delivery failure must never cause automation to promote another hostname as the canonical documentation address.
 - `https://app.webnovel.win/` is the reader application runtime, not an alternate documentation origin.
 - `https://autoarchive.github.io/webNR/` is an attributable documentation build mirror only. It emits `www.webnovel.win` canonical/discovery metadata and must not claim the custom domain.
+- Pull request #72 published the scheduled 2026-08-10 reader comparison of Royal Road, Scribble Hub, Wattpad, Tapas, and Honeyfeed and added `English Serial Platforms Starter` as a WebNR-maintained link-only discovery source. Its final head `707269a4cc44b3b563d026473c8fb6fec898de11` passed Quality run `31409672801` before squash merge `e5de80559e3d9bc4f467c74d81e6eac423eecf47`.
+- The `app-pages` application artifact and `gh-pages` documentation mirror artifact both expose exact pull request #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`. The generated documentation article emits canonical `https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/` and the configured GA4 destination.
+- The 2026-08-10 evidence pass found that the repository's Production evidence verifier covered the reader and noncanonical documentation mirror but did not independently require the canonical `www.webnovel.win` build. The current closeout repairs that blind spot and adds exact canonical article, sitemap/RSS, application analytics, and source-output acceptance checks.
 - Pull request #70 removed the visible Google Analytics notice from the reader's empty-library onboarding and Add/import view while preserving the runtime GA4 destination, full-URL reporting, Google-signal settings and documentation disclosure. Its final Quality run `31339726456` passed Web quality, Documentation quality, Production evidence against the prior public baseline, and Chromium user journeys; the Chromium suite passed all eight desktop/mobile tests and now asserts that the analytics notice is absent from both first-use and import UI.
-- The `app-pages` application artifact exposes exact pull request #70 squash commit `2df9e0f50cc93d79418a435069f46150d76d46f6`, source `github-actions`. Closeout Quality run `31340025388`, Production evidence job `93312160963`, independently resolved the Cloudflare-served `app.webnovel.win` hostname and observed the same exact commit, so the reader UI cleanup is production-verified.
-- The public GitHub Pages documentation build mirror exposes exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and labels itself `github-pages-build-mirror`.
-- The documentation mirror contains the generated article `WebNR：给 Legado 用户的一个独立网页端替代选择` at mirror path `/blog/2026/08/09/webnr-legado-web-alternative/`, with intended canonical `https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/`.
+- The `app-pages` application artifact exposed exact pull request #70 squash commit `2df9e0f50cc93d79418a435069f46150d76d46f6`, source `github-actions`. Closeout Quality run `31340025388`, Production evidence job `93312160963`, independently resolved the Cloudflare-served `app.webnovel.win` hostname and observed the same exact commit, so the reader UI cleanup was production-verified before the newer #72 delivery.
+- The GitHub Pages documentation build mirror previously exposed exact squash commit `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and labels itself `github-pages-build-mirror`; the generated artifact has now advanced to the #72 target `e5de80559e3d9bc4f467c74d81e6eac423eecf47` and awaits independent public closeout proof.
+- The documentation mirror contains the generated article `WebNR：给 Legado 用户的一个独立网页端替代选择` at mirror path `/blog/2026/08/09/webnr-legado-web-alternative/`, with intended canonical `https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/`, as well as the generated 2026-08-10 platform-comparison route.
 - Pull request #62 final Quality run `31303061815` passed Web quality, Documentation quality, Production evidence against the pre-merge production baseline, and Chromium user journeys.
 - Chromium job `93218999672` ran eight tests across desktop Chromium and Pixel 7 emulation; all eight passed. The suite covers first use, manifest and Service Worker registration, local TXT import, rendered reading content, IndexedDB persistence, keyboard reopen, CORS-allowed URL import and recoverable invalid-input errors.
 - The Chromium gate found and repaired a real PWA bug: an `afterInteractive` registration script could attach its `window.load` listener after the load event had already fired. Registration now runs immediately when the document is already complete.
 - The same cycle repaired mouse-only library activation. Novel rows now expose button semantics, keyboard focus, Enter/Space activation and visible focus treatment.
 - Closeout Quality run `31303434565` independently verified the exact documentation mirror at `7140fd24277ab357ed8029db8aa8f6c1ecdfe6bd` and correctly exposed the then-stale application route. The Cloudflare production deployment subsequently advanced `app.webnovel.win` to the same exact commit, resolving that incident without rewriting the historical failed run.
-- Production-evidence logic follows the current topology: `app.webnovel.win` is the public reader target; GitHub Pages is the attributable documentation build mirror and must emit `www.webnovel.win` canonical output.
+- Production-evidence logic follows the current topology: `app.webnovel.win` is the public reader target; GitHub Pages is the attributable documentation build mirror and must emit `www.webnovel.win` canonical output; the canonical `www.webnovel.win` route is now also an explicit exact-build verification target.
 - The 2026-08-08 routing diagnostic proved that `www.webnovel.win` and the documentation mirror are different delivery paths: the mirror exposed an exact reviewed build while `www/build.json` returned 404 and the `www` root served an older site shell.
 - `https://webnr.pages.dev/` is a reader-application mirror/project and must not be used as the documentation origin for `www`.
 - Pull request #57 established the durable canonical contract; pull request #58 added the repository-owned documentation build entrypoint; pull request #61 repaired shallow-checkout history for that build; pull request #59 merged the rendered canonical-origin source repair as `a6e9256369b0b2c29f3c80e428708e0b2da4894c`.
-- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The last independently recorded canonical site build is exact main commit `7d319f26e2c3398215c1d2cedca6f99820f1de50`, with the three current reader guides at that deployment point, `www` canonicals, sitemap, RSS, and the single historical GA4 destination.
+- Repository-side documentation canonical generation and the `www` Cloudflare serving route are complete. The last independently recorded canonical site build remains `7d319f26e2c3398215c1d2cedca6f99820f1de50` until the current closeout proves and advances the 2026-08-10 target.
 - Pull request #29 upgraded Next.js to 16.3.0 and the matching native flat ESLint configuration, upgraded the affected Sharp dependency, preserved the prior behavioral lint baseline for separately scoped React refactors, passed all four Quality jobs, and produced an audit result with no known vulnerabilities.
 - Pull request #67 repaired stale repository guidance after that migration. Quality run `31323828174` passed Web quality, Documentation quality, Production evidence, and Chromium user journeys before squash merge `23a660fa0e68b74ef73716ac0383dafd01786fab`; the change was developer-guidance-only and required no rendered-site deployment.
 - Pull request #68 added `Project Madurai Starter` as a link-only Tamil-literature discovery catalog with four audited origin pages, preserved the existing source catalogs, and extended source-output validation. Quality run `31324032188` passed Web quality, Documentation quality, Production evidence, and Chromium user journeys before squash merge `65fbda14e8062d7b055db5987646598b04ffcddc`.
@@ -46,12 +54,12 @@
 - WebNR owner policy is full-URL reporting. Reader page views use `window.location.href` and pathname plus query string, including imported URLs carried in `?add=...`.
 - Google signals and ad-personalization signals remain disabled.
 - Imported book text and reading progress remain in browser storage. No additional custom analytics event containing local content or progress is authorized.
-- The authenticated Cloudflare environment now exposes and controls both WebNR Pages projects. `webnr-docs` owns only `www.webnovel.win`; `webnr` owns only `app.webnovel.win` and its Pages mirror.
+- The authenticated Cloudflare operating environment has historically exposed and controlled both WebNR Pages projects. `webnr-docs` owns only `www.webnovel.win`; `webnr` owns only `app.webnovel.win` and its Pages mirror. The traffic-analytics zone connector available in this cycle is a separate evidence route and does not expose an exact `webnovel.win` zone.
 - Automatic preview-branch deployments are disabled on both Pages projects because repository Quality and Chromium jobs provide the review gates and the old previews created an account-wide production queue. Production branch deployments remain enabled.
 - The documentation project excludes pure `.github/seo-data/*` changes from build triggers. Any commit containing other changed paths still builds normally, while status-only closeouts no longer create a new documentation commit that immediately invalidates their own recorded production evidence.
 - Application and documentation CI cover dependency audit, lint, typecheck, production application build, strict attributable documentation build, single-GA4 output assertions, integrated-source output, generated canonical/discovery output, recorded public build evidence, and real Chromium desktop/mobile journeys.
-- The reader guides from 2026-08-06 and 2026-08-08 remain in the exact documentation build mirror with `www.webnovel.win` canonical output.
-- `WebNR Originals`, `Aozora Bunko Starter`, `Standard Ebooks Starter`, and `Project Madurai Starter` are the four passing integrated sources after the 2026-08-09 scheduled source-growth cycle.
+- The reader guides from 2026-08-06, 2026-08-08, 2026-08-09, and the 2026-08-10 comparison are present in current generated documentation output with `www.webnovel.win` canonical metadata.
+- `WebNR Originals`, `Aozora Bunko Starter`, `Standard Ebooks Starter`, `Project Madurai Starter`, and `English Serial Platforms Starter` are the five passing maintained sources after the 2026-08-10 source-growth delivery. The new English platform source is deliberately link-only and performs no third-party story crawling or redistribution.
 - `Project Madurai Starter` is deliberately discovery-only: WebNR stores its own descriptions plus title/author metadata and official Project Madurai Unicode-page links. It does not crawl, proxy, cache, bulk-download, or redistribute the linked electronic texts.
 - Repository ingestion preserves missing freshness as unknown, bounds YAML streaming to 5 MiB, validates untrusted item fields, restricts links to HTTP(S), supports explicit page/download URLs, and hides unavailable import actions.
 - Local TXT and supported text-URL import are available on the current verified public reader build. EPUB remains unsupported until a real parser, safe rendering policy, and versioned fixtures exist.
@@ -62,10 +70,10 @@
 
 ## Active focus
 
-1. Keep `https://www.webnovel.win/` as the sole canonical documentation/editorial identity and `https://app.webnovel.win/` as the reader runtime; require exact public build evidence after future rendered-site changes.
+1. Complete the 2026-08-10 exact production closeout, then keep `https://www.webnovel.win/` as the sole canonical documentation/editorial identity and `https://app.webnovel.win/` as the reader runtime with exact public build evidence after rendered changes.
 2. Keep `https://autoarchive.github.io/webNR/` as an exact attributable build mirror only and prevent it from regaining public canonical status.
 3. Keep the Chromium desktop/mobile journeys as a permanent gate and expand them alongside backup/restore, storage migration, offline behavior and accessibility improvements.
-4. Continue the reader-facing editorial schedule; the Legado web-alternative explanation is live, while the next scheduled reader topic is the English serial-fiction platform comparison.
+4. Continue the reader-facing editorial schedule; the English serial-fiction platform comparison is the 2026-08-10 asset, and the next scheduled reader topic is the 2026-08-12 map of public reader communities and recommendation channels.
 5. Continue daily source discovery, adapter work, correctly routed GA4/Search Console evidence, and concentrated technical monitoring.
 6. Continue real EPUB and fixture-backed clean-room Legado capability work as product support for the reader program.
 

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -11,6 +11,7 @@ const targets = [
     label: 'application',
     buildUrl: 'https://app.webnovel.win/build.json',
     pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+    targetPattern: /^- Current application verification target: `([0-9a-f]{40})`$/m,
     contentChecks: [
       {
         url: 'https://app.webnovel.win/',
@@ -36,6 +37,7 @@ const targets = [
     label: 'documentation build mirror',
     buildUrl: 'https://autoarchive.github.io/webNR/build.json',
     pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+    targetPattern: /^- Current documentation mirror verification target: `([0-9a-f]{40})`$/m,
     contentChecks: [
       {
         url: 'https://autoarchive.github.io/webNR/troubleshooting/txt-import/',
@@ -49,6 +51,7 @@ const targets = [
     label: 'canonical documentation site',
     buildUrl: 'https://www.webnovel.win/build.json',
     pattern: /^- Last successful canonical Cloudflare documentation deployment: `([0-9a-f]{40})`$/m,
+    targetPattern: /^- Current canonical documentation verification target: `([0-9a-f]{40})`$/m,
     contentChecks: [
       {
         url: 'https://www.webnovel.win/troubleshooting/txt-import/',
@@ -139,10 +142,11 @@ async function verifyContentChecks(target, attempt, expectedCommit) {
 }
 
 async function verifyTarget(target) {
-  const match = status.match(target.pattern);
-  if (!match) throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
+  const lastSuccessfulMatch = status.match(target.pattern);
+  if (!lastSuccessfulMatch) throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
 
-  const expectedCommit = match[1];
+  const verificationTargetMatch = target.targetPattern ? status.match(target.targetPattern) : null;
+  const expectedCommit = verificationTargetMatch?.[1] ?? lastSuccessfulMatch[1];
   let lastObserved = 'no response';
   await describeTarget(target);
 
@@ -161,6 +165,7 @@ async function verifyTarget(target) {
             label: target.label,
             expectedCommit,
             observedCommit: payload.commit,
+            targetSource: verificationTargetMatch ? 'current-verification-target' : 'last-successful-record',
             headers: selectedHeaders(buildResponse),
             contentChecks,
           };

--- a/scripts/verify-production-builds.mjs
+++ b/scripts/verify-production-builds.mjs
@@ -11,13 +11,68 @@ const targets = [
     label: 'application',
     buildUrl: 'https://app.webnovel.win/build.json',
     pattern: /^- Last successful attributable application deployment: `([0-9a-f]{40})`$/m,
+    contentChecks: [
+      {
+        url: 'https://app.webnovel.win/',
+        accept: 'text/html',
+        needles: [
+          'G-DGH8HNQKE4',
+          'window.location.href',
+          'window.location.pathname + window.location.search',
+        ],
+      },
+      {
+        url: 'https://app.webnovel.win/sources/english-serial-platforms-starter/search_index.yml',
+        accept: 'text/plain',
+        needles: [
+          'title: Royal Road — Complete & Rising Stars',
+          'title: Wattpad — Stories',
+          'license: Link-only-WebNR-editorial',
+        ],
+      },
+    ],
   },
   {
     label: 'documentation build mirror',
     buildUrl: 'https://autoarchive.github.io/webNR/build.json',
-    contentUrl: 'https://autoarchive.github.io/webNR/troubleshooting/txt-import/',
-    expectedCanonical: 'https://www.webnovel.win/troubleshooting/txt-import/',
     pattern: /^- Last successful attributable documentation deployment: `([0-9a-f]{40})`$/m,
+    contentChecks: [
+      {
+        url: 'https://autoarchive.github.io/webNR/troubleshooting/txt-import/',
+        accept: 'text/html',
+        expectedCanonical: 'https://www.webnovel.win/troubleshooting/txt-import/',
+        needles: ['TXT import troubleshooting', 'TXT 导入排障'],
+      },
+    ],
+  },
+  {
+    label: 'canonical documentation site',
+    buildUrl: 'https://www.webnovel.win/build.json',
+    pattern: /^- Last successful canonical Cloudflare documentation deployment: `([0-9a-f]{40})`$/m,
+    contentChecks: [
+      {
+        url: 'https://www.webnovel.win/troubleshooting/txt-import/',
+        accept: 'text/html',
+        expectedCanonical: 'https://www.webnovel.win/troubleshooting/txt-import/',
+        needles: ['TXT import troubleshooting', 'TXT 导入排障'],
+      },
+      {
+        url: 'https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/',
+        accept: 'text/html',
+        expectedCanonical: 'https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/',
+        needles: ['2026 英文连载小说平台怎么选', 'English Serial Platforms Starter'],
+      },
+      {
+        url: 'https://www.webnovel.win/sitemap.xml',
+        accept: 'application/xml,text/xml',
+        needles: ['https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/'],
+      },
+      {
+        url: 'https://www.webnovel.win/feed_rss_created.xml',
+        accept: 'application/rss+xml,application/xml,text/xml',
+        needles: ['https://www.webnovel.win/blog/2026/08/10/english-serial-fiction-platforms/'],
+      },
+    ],
   },
 ];
 
@@ -57,6 +112,32 @@ async function fetchNoCache(url, attempt, expectedCommit, accept) {
   });
 }
 
+async function verifyContentChecks(target, attempt, expectedCommit) {
+  const results = [];
+
+  for (const check of target.contentChecks ?? []) {
+    const response = await fetchNoCache(check.url, attempt, expectedCommit, check.accept ?? 'text/plain');
+    const body = response.ok ? await response.text() : '';
+    const contentMatches = response.ok
+      && (check.needles ?? []).every(needle => body.includes(needle))
+      && (!check.expectedCanonical || body.includes(check.expectedCanonical));
+    const result = {
+      url: check.url,
+      status: response.status,
+      headers: selectedHeaders(response),
+      contentMatches,
+      expectedCanonical: check.expectedCanonical ?? null,
+    };
+    results.push(result);
+
+    if (!contentMatches) {
+      throw new Error(`${target.label} content did not match: ${JSON.stringify(result)}`);
+    }
+  }
+
+  return results;
+}
+
 async function verifyTarget(target) {
   const match = status.match(target.pattern);
   if (!match) throw new Error(`Missing recorded ${target.label} deployment in ${statusPath}`);
@@ -74,33 +155,14 @@ async function verifyTarget(target) {
         const payload = await buildResponse.json();
         const buildEvidence = { payload, headers: selectedHeaders(buildResponse) };
         if (payload.commit === expectedCommit) {
-          if (target.contentUrl) {
-            const contentResponse = await fetchNoCache(target.contentUrl, attempt, expectedCommit, 'text/html');
-            const html = contentResponse.ok ? await contentResponse.text() : '';
-            const contentMatches = contentResponse.ok
-              && html.includes('TXT import troubleshooting')
-              && html.includes('TXT 导入排障')
-              && (!target.expectedCanonical || html.includes(target.expectedCanonical));
-            lastObserved = JSON.stringify({
-              build: buildEvidence,
-              content: {
-                status: contentResponse.status,
-                headers: selectedHeaders(contentResponse),
-                contentMatches,
-                expectedCanonical: target.expectedCanonical ?? null,
-              },
-            });
-            if (!contentMatches) throw new Error(`Documentation mirror content did not match: ${lastObserved}`);
-          }
-
+          const contentChecks = await verifyContentChecks(target, attempt, expectedCommit);
           console.log(`Verified ${target.label} commit ${expectedCommit} at ${target.buildUrl}`);
           return {
             label: target.label,
             expectedCommit,
             observedCommit: payload.commit,
             headers: selectedHeaders(buildResponse),
-            contentUrl: target.contentUrl ?? null,
-            expectedCanonical: target.expectedCanonical ?? null,
+            contentChecks,
           };
         }
         lastObserved = JSON.stringify(buildEvidence);


### PR DESCRIPTION
## Outcome
Complete the 2026-08-10 scheduled evidence/closeout cycle after pull request #72 delivered the due reader article and five-platform link-only source. Repair the production-evidence blind spot that previously verified the reader and noncanonical docs mirror but not the canonical `www.webnovel.win` route.

## Evidence and scope
- PR #72 final head `707269a4cc44b3b563d026473c8fb6fec898de11` passed Quality run `31409672801` and squash-merged as `e5de80559e3d9bc4f467c74d81e6eac423eecf47`.
- `app-pages/build.json` and `gh-pages/build.json` both identify exact #72 squash commit `e5de80559e3d9bc4f467c74d81e6eac423eecf47`.
- The configured Google Drive folder is reachable but contains no matching GA4/GSC exports; those metrics remain unavailable rather than zero.
- The currently exposed Cloudflare zone-analytics accounts contain no exact active `webnovel.win` zone; request analytics remain unavailable rather than zero.
- Fresh origin sampling kept the accepted platform directory and rotating Project Madurai/Aozora entries reachable where checked.

## Changes
- Add the public-safe 2026-08-10 daily analysis and six required operating decisions.
- Record #72 as the current product/content delivery and the reviewed SEO-skill pointer `9f0bd4f0b33b28fc22592e5463d95f63cda4d165`.
- Extend `scripts/verify-production-builds.mjs` to verify the canonical documentation build in addition to the reader and documentation mirror, plus today's canonical article, sitemap/RSS discovery, public source output, and the reader's full-URL GA4 configuration.
- Use explicit temporary verification targets only until CI proves a newly deployed commit; after proof, advance the stable last-successful records and remove the temporary targets. The current branch has already completed that transition for #72.

## Preserved behavior
No reader feature, route, source admission, third-party crawling behavior, analytics destination, URL-reporting policy, canonical ownership, DNS, Cloudflare configuration, or external account setting changes in this PR.

## Validation completed before the final metadata update
Initial Quality run `31412094151` passed all four expected jobs: Web quality, Documentation quality, Production evidence, and Chromium user journeys. Production evidence job `93532348626` independently observed exact `e5de80559e3d9bc4f467c74d81e6eac423eecf47` on:
- the public reader, including the single GA4 destination, full-URL strings, and `English Serial Platforms Starter` output;
- the noncanonical GitHub Pages documentation mirror with intended `www` canonical output; and
- the canonical `www.webnovel.win` site, including exact build identity, today's article/canonical, sitemap entry, RSS entry, and representative troubleshooting content.

That proof is now recorded by advancing all three stable last-successful deployment records to `e5de80559e3d9bc4f467c74d81e6eac423eecf47` and removing the temporary targets. The final branch head must rerun the complete four-job Quality suite and undergo a from-scratch review before merge.

## Risk / rollback
The functional change is read-only verification logic. A false positive is constrained by exact build identities plus content needles; a false negative blocks merge rather than mutating production. Rollback is a squash revert of the verifier and closeout metadata.

## Deployment / acceptance
The application and GitHub Pages documentation workflows ignore this closeout's changed paths. The independent canonical documentation project may react to the verifier script path according to its external build rules; after merge, exact public build identity will be rechecked and any post-merge canonical advancement will be recorded through a metadata-only closeout PR.