### PR TITLE
feat: add Project Gutenberg discovery source

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -94,6 +94,14 @@ jobs:
           grep -Fq 'title: Tapas — Novels' out/sources/english-serial-platforms-starter/search_index.yml
           grep -Fq 'title: Honeyfeed — Novels' out/sources/english-serial-platforms-starter/search_index.yml
           grep -Fq 'license: Link-only-WebNR-editorial' out/sources/english-serial-platforms-starter/search_index.yml
+          test -f out/sources/project-gutenberg-starter/search_index.yml
+          test -f out/sources/project-gutenberg-starter/README.txt
+          grep -Fq "title: Alice's Adventures in Wonderland" out/sources/project-gutenberg-starter/search_index.yml
+          grep -Fq 'title: The Adventures of Sherlock Holmes' out/sources/project-gutenberg-starter/search_index.yml
+          grep -Fq 'title: Dracula' out/sources/project-gutenberg-starter/search_index.yml
+          grep -Fq 'title: Moby Dick; Or, The Whale' out/sources/project-gutenberg-starter/search_index.yml
+          grep -Fq 'license: Link-only-WebNR-editorial' out/sources/project-gutenberg-starter/search_index.yml
+          grep -Fq 'https://www.gutenberg.org/ebooks/11' out/sources/project-gutenberg-starter/search_index.yml
 
   browser-e2e:
     name: Chromium user journeys

--- a/public/sources/project-gutenberg-starter/README.txt
+++ b/public/sources/project-gutenberg-starter/README.txt
@@ -1,0 +1,60 @@
+Project Gutenberg Starter
+=========================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/project-gutenberg-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fproject-gutenberg-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small, link-only discovery catalog for selected
+Project Gutenberg ebooks. It gives readers stable official landing pages for
+classic fiction without turning Project Gutenberg's downloadable files into
+WebNR-owned copies or pretending that a landing page is a direct TXT import.
+
+Source and reuse boundary
+-------------------------
+Project Gutenberg says the vast majority of its ebooks are public domain in the
+United States, while some items remain copyrighted and readers outside the United
+States must check the law that applies where they are located. Project Gutenberg
+also explicitly permits linking and asks links to individual ebooks to use the
+ebook landing page rather than deep links to specific files.
+
+Source: https://www.gutenberg.org/
+Policies: https://www.gutenberg.org/policy/
+Permissions and linking: https://www.gutenberg.org/policy/permission
+Terms of use: https://www.gutenberg.org/policy/terms_of_use.html
+Offline catalogs and OPDS: https://www.gutenberg.org/ebooks/offline_catalogs.html
+
+This starter catalog stores only WebNR-authored descriptions plus verified title,
+author, public-domain-in-the-USA status, and official ebook landing-page links. It
+does not copy, proxy, cache, bulk-download, or redistribute Project Gutenberg
+files, and it does not use the Project Gutenberg trademark to imply affiliation.
+
+Current WebNR behavior
+----------------------
+The entries are discovery links only. Project Gutenberg exposes plain-text and
+ebook formats on each landing page, but its linking guidance discourages deep
+links to those individual files. WebNR therefore sends readers to the stable
+landing page instead of converting an origin download URL into an import action.
+
+Project Gutenberg also documents an OPDS catalog for machine-to-machine access
+with request-identification and rate-behavior requirements. This starter source
+does not poll or crawl that feed. A later bounded OPDS adapter may be evaluated
+with a versioned fixture, explicit User-Agent/contact handling, timeout and rate
+limits, and the repository's normal source-admission review.
+
+Included discovery pages
+------------------------
+- Alice's Adventures in Wonderland — Lewis Carroll
+- The Adventures of Sherlock Holmes — Arthur Conan Doyle
+- Dracula — Bram Stoker
+- Moby Dick; Or, The Whale — Herman Melville
+
+Last verified
+-------------
+2026-08-11

--- a/public/sources/project-gutenberg-starter/search_index.yml
+++ b/public/sources/project-gutenberg-starter/search_index.yml
@@ -1,0 +1,60 @@
+project-gutenberg/alices-adventures-in-wonderland.md:
+  title: Alice's Adventures in Wonderland
+  author: Lewis Carroll
+  description: Project Gutenberg 官方 ebook #11 落地页。来源页标记该作品在美国属于公有领域；WebNR 仅提供稳定落地页发现链接，不深链、缓存或重新分发来源文件。
+  page_url: https://www.gutenberg.org/ebooks/11
+  source: Project Gutenberg
+  license: Link-only-WebNR-editorial
+  tags:
+    - Project Gutenberg
+    - Public domain in the USA
+    - Fantasy
+  categories:
+    - Free reading discovery
+  region: en-US
+
+project-gutenberg/the-adventures-of-sherlock-holmes.md:
+  title: The Adventures of Sherlock Holmes
+  author: Arthur Conan Doyle
+  description: Project Gutenberg 官方 ebook #1661 落地页。来源页标记该作品在美国属于公有领域；WebNR 保留官方落地页而不把 Plain Text 或 EPUB 文件包装成自己的下载地址。
+  page_url: https://www.gutenberg.org/ebooks/1661
+  source: Project Gutenberg
+  license: Link-only-WebNR-editorial
+  tags:
+    - Project Gutenberg
+    - Public domain in the USA
+    - Detective fiction
+  categories:
+    - Free reading discovery
+  region: en-US
+
+project-gutenberg/dracula.md:
+  title: Dracula
+  author: Bram Stoker
+  description: Project Gutenberg 官方 ebook #345 落地页。来源页标记该作品在美国属于公有领域；WebNR 当前只做发现与跳转，并提醒美国以外读者自行确认适用法域。
+  page_url: https://www.gutenberg.org/ebooks/345
+  source: Project Gutenberg
+  license: Link-only-WebNR-editorial
+  tags:
+    - Project Gutenberg
+    - Public domain in the USA
+    - Gothic fiction
+    - Horror
+  categories:
+    - Free reading discovery
+  region: en-US
+
+project-gutenberg/moby-dick.md:
+  title: Moby Dick; Or, The Whale
+  author: Herman Melville
+  description: Project Gutenberg 官方 ebook #2701 落地页。来源页标记该作品在美国属于公有领域；WebNR 仅保存人工核验的发现链接，不抓取或同步来源正文。
+  page_url: https://www.gutenberg.org/ebooks/2701
+  source: Project Gutenberg
+  license: Link-only-WebNR-editorial
+  tags:
+    - Project Gutenberg
+    - Public domain in the USA
+    - Adventure fiction
+  categories:
+    - Free reading discovery
+  region: en-US


### PR DESCRIPTION
## Outcome
Add one audited Project Gutenberg starter source as the 2026-08-11 passing source-integration target, using only stable official ebook landing-page links and WebNR-authored descriptions.

## Evidence and scope
- Project Gutenberg explicitly permits linking and asks specific-book links to use ebook landing pages rather than deep links to downloadable files.
- The selected landing pages for Alice's Adventures in Wonderland, The Adventures of Sherlock Holmes, Dracula, and Moby Dick identify those items as public domain in the USA.
- Project Gutenberg documents separate machine-readable catalog/OPDS routes and automated-access requirements; this source deliberately does not crawl, poll, proxy, cache, or redistribute those resources.
- Add `public/sources/project-gutenberg-starter/{README.txt,search_index.yml}` and source-output assertions in the existing Quality workflow only.

## Preserved behavior
No reader code, analytics configuration, canonical ownership, documentation routes, existing sources, Legado behavior, or third-party content is changed. The source is link-only and uses `license: Link-only-WebNR-editorial` rather than claiming a redistribution license for Project Gutenberg content.

## Validation
Quality must complete all four expected jobs: Web quality, Documentation quality, Production evidence, and Chromium user journeys. Web quality now checks the generated Project Gutenberg starter files, representative titles, stable landing URL, and link-only license marker.

## Production acceptance
After squash merge, the exact application deployment must expose the new source at `https://app.webnovel.win/sources/project-gutenberg-starter/search_index.yml`, while the reader keeps the single GA4 destination and full-URL policy. Documentation and existing source behavior remain representative unaffected checks.

## Risk / rollback
Low-risk additive static source. The main risks are stale external landing pages or an inaccurate rights statement; the source avoids deep links and redistribution and records the jurisdiction boundary. Rollback is a squash revert removing the starter and its validation assertions.