### PR TITLE
feat: add Global Grey discovery source

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -102,6 +102,14 @@ jobs:
           grep -Fq 'title: Moby Dick; Or, The Whale' out/sources/project-gutenberg-starter/search_index.yml
           grep -Fq 'license: Link-only-WebNR-editorial' out/sources/project-gutenberg-starter/search_index.yml
           grep -Fq 'https://www.gutenberg.org/ebooks/11' out/sources/project-gutenberg-starter/search_index.yml
+          test -f out/sources/global-grey-starter/search_index.yml
+          test -f out/sources/global-grey-starter/README.txt
+          grep -Fq 'title: The Woman in White' out/sources/global-grey-starter/search_index.yml
+          grep -Fq 'title: The Castle of Otranto' out/sources/global-grey-starter/search_index.yml
+          grep -Fq 'title: North and South' out/sources/global-grey-starter/search_index.yml
+          grep -Fq 'title: The Beetle' out/sources/global-grey-starter/search_index.yml
+          grep -Fq 'license: Link-only-WebNR-editorial' out/sources/global-grey-starter/search_index.yml
+          grep -Fq 'https://www.globalgreyebooks.com/woman-in-white-ebook.html' out/sources/global-grey-starter/search_index.yml
 
   browser-e2e:
     name: Chromium user journeys

--- a/public/sources/global-grey-starter/README.txt
+++ b/public/sources/global-grey-starter/README.txt
@@ -1,0 +1,59 @@
+Global Grey Starter
+===================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/global-grey-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fglobal-grey-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small, link-only discovery catalog for selected
+classic-fiction landing pages on Global Grey. It gives readers another curated
+route into public-domain classics while keeping Global Grey's formatted ebook
+files, branding, download controls, and site presentation at the origin.
+
+Source and reuse boundary
+-------------------------
+Global Grey describes its catalog as public-domain classics and states that free
+ebooks can be downloaded without an account. Its current terms welcome sharing
+links to Global Grey ebooks while reserving rules around hosting, redistribution,
+resale, bundling, and Global Grey branding. The FAQ also asks visitors to avoid
+very large download bursts.
+
+Source: https://www.globalgreyebooks.com/
+Terms: https://www.globalgreyebooks.com/terms-conditions.html
+FAQ and copyright notes: https://www.globalgreyebooks.com/f-a-q.html
+About: https://www.globalgreyebooks.com/about.html
+
+This starter stores only WebNR-authored descriptions plus verified title, author,
+genre context, and official ebook landing-page links. It does not copy, proxy,
+cache, bulk-download, re-host, or redistribute Global Grey ebook files or cover
+art. Readers remain on the origin when they choose a format or read online.
+
+Current WebNR behavior
+----------------------
+The entries are discovery links only. WebNR does not convert Global Grey's PDF,
+EPUB, AZW3, or browser-reading endpoints into direct import actions. This keeps
+the integration inside the origin's explicit link-sharing boundary and avoids
+turning an independently formatted edition into a WebNR-owned artifact.
+
+No public machine-readable catalog or stable import API was established during
+the 2026-08-12 audit. A future richer adapter therefore requires a fresh source
+review covering an explicit machine-access contract, request limits, response
+bounds, rights metadata, failure behavior, and a versioned fixture before any
+runtime fetch is added.
+
+Included discovery pages
+------------------------
+- The Woman in White — Wilkie Collins
+- The Castle of Otranto — Horace Walpole
+- North and South — Elizabeth Gaskell
+- The Beetle — Richard Marsh
+
+Last verified
+-------------
+2026-08-12

--- a/public/sources/global-grey-starter/search_index.yml
+++ b/public/sources/global-grey-starter/search_index.yml
@@ -1,0 +1,63 @@
+global-grey/the-woman-in-white.md:
+  title: The Woman in White
+  author: Wilkie Collins
+  description: Global Grey 的《The Woman in White》官方 ebook 落地页。WebNR 仅提供经过核验的发现链接；格式选择、在线阅读和下载继续由来源站处理。
+  page_url: https://www.globalgreyebooks.com/woman-in-white-ebook.html
+  source: Global Grey
+  license: Link-only-WebNR-editorial
+  tags:
+    - Global Grey
+    - Public-domain classics
+    - Victorian fiction
+    - Gothic fiction
+  categories:
+    - Free reading discovery
+  region: en-GB
+
+global-grey/the-castle-of-otranto.md:
+  title: The Castle of Otranto
+  author: Horace Walpole
+  description: Global Grey 的《The Castle of Otranto》官方 ebook 落地页。来源页标记作品为 public domain，并提供 PDF、EPUB、AZW3 与在线阅读；WebNR 保留来源落地页而不重托管文件。
+  page_url: https://www.globalgreyebooks.com/castle-of-otranto-ebook.html
+  source: Global Grey
+  license: Link-only-WebNR-editorial
+  tags:
+    - Global Grey
+    - Public-domain classics
+    - Gothic fiction
+    - Horror
+  categories:
+    - Free reading discovery
+  region: en-GB
+
+global-grey/north-and-south.md:
+  title: North and South
+  author: Elizabeth Gaskell
+  description: Global Grey 的《North and South》官方 ebook 落地页。WebNR 保存人工核验的发现入口，并把来源站自己的版本说明、格式与下载行为留在来源站。
+  page_url: https://www.globalgreyebooks.com/north-and-south-ebook.html
+  source: Global Grey
+  license: Link-only-WebNR-editorial
+  tags:
+    - Global Grey
+    - Public-domain classics
+    - Victorian fiction
+    - Social novel
+  categories:
+    - Free reading discovery
+  region: en-GB
+
+global-grey/the-beetle.md:
+  title: The Beetle
+  author: Richard Marsh
+  description: Global Grey 的《The Beetle》官方 ebook 落地页。WebNR 当前只做经典小说发现与跳转，不复制来源站的电子书文件、封面或在线正文。
+  page_url: https://www.globalgreyebooks.com/beetle-richard-marsh-ebook.html
+  source: Global Grey
+  license: Link-only-WebNR-editorial
+  tags:
+    - Global Grey
+    - Public-domain classics
+    - Gothic fiction
+    - Horror
+  categories:
+    - Free reading discovery
+  region: en-GB


### PR DESCRIPTION
## Why

The 2026-08-12 source audit found Global Grey suitable for a bounded link-only WebNR discovery source. Global Grey currently describes its catalog as public-domain classics, allows free no-account downloads, explicitly welcomes sharing links, and separately reserves rules for hosting/redistribution of its formatted ebooks and branding. A link-only source stays inside that boundary.

## Scope

- add `global-grey-starter` with four verified classic-fiction landing pages
- add production-build assertions for the new source metadata and representative origin URL
- keep all PDF/EPUB/AZW3/online-text delivery at the origin; WebNR stores only editorial metadata and landing-page URLs
- document current origin/reuse boundary and future adapter requirements
- sync `.github/seo-skills` from `9f0bd4f…` to reviewed upstream `f42128a…`; the upstream delta only extends `collect-seo-data` with guarded read-only off-site visibility scans and is compatible with WebNR

## Preserved behavior

Existing sources, reader behavior, routes, analytics, canonical ownership, docs, source metadata, and application code are unchanged. No existing source content is removed or rewritten.

## Evidence / source audit

- Global Grey terms and FAQ were rechecked on 2026-08-12; link sharing is permitted, free ebooks require no account, and redistribution/branding rules remain origin-owned.
- The four selected landing pages were publicly reachable and exposed title/author/format context.
- Runtime behavior is intentionally link-only: no crawler, API, pagination, cookies, credentials, or download endpoint is introduced.
- Fresh candidates discovered this cycle also include Loyal Books, Planet eBook, PDFBooksWorld, and DigiLibraries; their full disposition is recorded in the daily closeout rather than expanding this PR.

## Validation

Expected repository Quality jobs: Web quality, Chromium user journeys, Documentation quality, Production evidence. `Web quality` now requires the built Global Grey README/index, all four representative titles, the link-only license marker, and a representative official landing URL. After merge, acceptance is the direct source path plus the one-click `?repos=` add flow on the canonical app, with an existing source and reader flow checked as unaffected behavior.

The first CI attempt encountered an environment-only failure while installing the pinned Playwright runner; a targeted retry of that unchanged job completed the install, Chromium setup, build, and browser journeys successfully. The final head receives a complete fresh Quality run after the source-output assertion was added.

## Risk / rollback

Risk is limited to additive public metadata, its focused build assertion, plus the reviewed skill gitlink. Revert the squash commit to remove the source/pointer change if build, source loading, or public acceptance fails.