### PR TITLE
docs: publish 2026 reader community map

### DIFF
--- a/docs/blog/posts/2026-08-12-web-novel-reader-communities.md
+++ b/docs/blog/posts/2026-08-12-web-novel-reader-communities.md
@@ -1,0 +1,274 @@
+---
+title: 2026 网文读者都去哪里找书和聊书？Reddit、Royal Road、Scribble Hub、Novel Updates、Discord 社区地图
+date: 2026-08-12
+slug: web-novel-reader-communities
+description: 从读者任务出发，地图式比较 Reddit、Royal Road、Scribble Hub、Novel Updates、Goodreads、Tapas 与 Discord 的找书、求书、追更讨论、类型社群与公开可检索程度。
+categories:
+  - Reader guides
+  - Ecosystem
+  - Recommendations
+---
+
+# 2026 网文读者都去哪里找书和聊书？Reddit、Royal Road、Scribble Hub、Novel Updates、Discord 社区地图
+
+**直接答案：** 想找 LitRPG、Progression Fantasy、长篇英文连载，先去 **Royal Road Recommendations**、**r/ProgressionFantasy** 和 **r/litrpg**；想带着一长串标签、篇幅、更新状态去精确求书，**Scribble Hub 的 “I’m Looking For”** 很适合；想找亚洲翻译网文、轻小说、耽美等跨语言作品，**Novel Updates 的 Recommendation Lists** 与类型化 Reddit 社群更接近读者实际检索路径；想找更宽泛的奇幻、爱情、通俗小说，**r/Fantasy、r/fantasyromance、r/books 与 Goodreads Recommendation Requests** 覆盖面更宽；想要即时聊天、buddy read、作者或读者群，**Discord Discover / Server Directory** 提供另一层入口。平台内论坛如 Royal Road、Scribble Hub、Tapas 则最适合讨论“这个平台上的作品”。[P1][P2][P5][P7][P8][P9][P10][P11][P14][P15][P16][P20]
+
+这张地图按“读者准备完成什么任务”组织，重点放在任务匹配；社区体量只作为背景信号。2026 年 8 月 12 日的公开采样显示，找书、找回忘记书名的作品、判断连载状态、追某一类型、参与章节讨论、加入长期读书群，分别对应不同的信息结构。公开论坛与 Reddit 留下可检索的长尾问答；平台内社区拥有更丰富的作品状态与标签语境；Discord 强在同步互动与持续关系；Goodreads 和 Novel Updates 更接近由书目、列表和读者记录组织起来的发现层。[P1][P2][P5][P7][P15][P16][A3][A8][A9]
+
+本文同时延续 WebNR 的上一份平台比较：[2026 英文连载小说平台怎么选？](/blog/2026/08/10/english-serial-fiction-platforms/)。上一篇回答“去哪里读”，这一篇回答“去哪里问、去哪里找、去哪里跟人聊”。
+
+## 研究问题与采样方法
+
+本文关注一个具体问题：**公开网络上的网文读者，如何在不同社区里完成推荐与讨论？**
+
+采样日期为 **2026 年 8 月 12 日**。主样本由 24 个公开的一手页面组成，包括平台论坛首页、推荐分区、官方帮助、公开 subreddit、推荐请求页、公开服务器目录与平台社区说明；其中 15 个页面直接呈现推荐、求书、找书或读者交流，9 个页面用于解释平台结构、发现机制与进入门槛。[P1]-[P24] 观察重点放在页面当前结构、讨论入口、公开可见程度、请求格式和平台规则。旧线程只用于识别长期稳定的提问形态，当前索引页与 2026 年页面承担更高权重。
+
+学术背景使用 24 项与参与式文化、数字社会阅读、在线书评、fanfiction affinity spaces、平台化文化生产、推荐系统和数字接受研究有关的研究。[A1]-[A24] 这些研究在本文中承担概念框架功能：读者推荐可视为一种社会阅读实践；标签、评论、列表和讨论串都属于由社区共同生产的发现信息；平台界面与治理规则会改变这些信息被看见、排序与保存的方式。[A1][A2][A3][A8][A9][A14][A16][A17]
+
+本文给出的结论属于**公开社区地图**。它描述公开可观察的入口与行为样式。私密 Discord、封闭群组、私信推荐、线下读书圈和平台内个性化推荐处于更低的公开可见度，因此它们在样本里的权重自然较低。这个可见度差异本身也是读者选择渠道时需要理解的一部分。
+
+## 一张表：先按任务选社区
+
+| 你的任务 | 先去哪里 | 最有用的输入 | 公开检索性 | 互动节奏 |
+| --- | --- | --- | --- | --- |
+| 找 LitRPG / Progression Fantasy 连载 | Royal Road Recommendations、r/ProgressionFantasy、r/litrpg | 已读作品、喜欢的机制、篇幅、连载偏好 | 高 | 小时到天 |
+| 带标签精确求书 | Scribble Hub “I’m Looking For” | 必须有/希望有/避开的标签、更新状态 | 高 | 小时到天 |
+| 找亚洲翻译网文与轻小说 | Novel Updates Recommendation Lists、类型化 subreddit | 原语言、题材、CP/关系、翻译状态 | 高 | 天级 |
+| 找广义奇幻/爱情/大众小说 | r/Fantasy、r/fantasyromance、r/books、Goodreads | 参照作品、情绪、主题、长度 | 高 | 小时到周 |
+| 找回忘记书名的作品 | Royal Road、Scribble Hub、类型 subreddit | 记得的情节、角色、系统、年代 | 高 | 小时到天 |
+| 追平台内作品和作者 | Royal Road / Scribble Hub / Tapas 社区 | 作品链接、章节、更新状态 | 中高 | 分钟到天 |
+| 找长期聊天和 buddy read | Discord Discover / Server Directory | 类型、年龄层、活动频率、时区 | 目录高、聊天低 | 分钟级 |
+| 先浏览“别人整理好的书单” | Novel Updates Lists、Goodreads | 类型、主题、读者标签 | 高 | 异步 |
+
+这张表背后的核心规律很简单：**推荐质量高度依赖问题与社区的匹配。** 一个要求“女性主角、crafting-heavy、至少 300 章、目前仍在更新”的请求，在熟悉 progression/web serial 语言的社区里容易得到精确回答；一个围绕 grief、found family、slow burn、特定文化背景的请求，在更宽的类型读者社区里又会得到更丰富的候选。在线社会阅读研究长期把读者之间的意义建构、书评、列表和讨论看作阅读活动的一部分，而 fan-based affinity spaces 的研究进一步强调共同兴趣如何组织写作与反馈。[A3][A8][A9][A13][A14][A17]
+
+## Royal Road：最像“连载作品故障诊断台”的推荐社区
+
+Royal Road 的论坛把 **Recommendations** 作为独立分区，公开说明这里用于询问推荐和分享喜欢的作品；当前索引同时能看到“找回忘记标题”“需要某类作品”“新读者求推荐”等不同任务。[P1][P2] 这与 Royal Road 自身的作品发现结构互相增强：站内还提供 Ongoing、Complete、Hiatus、Stub、Dropped 等状态，以及 Rising Stars、Latest Updates、Complete 等发现入口。[P3][P4]
+
+因此 Royal Road 的推荐对话经常天然带着“连载工程参数”：更新频率、总篇幅、是否完结、是否 stub、是否仍有免费章节、成长体系走到什么阶段。读者在这里提问时，写出三项信息往往最有效：
+
+1. 两到五本已经喜欢的作品；
+2. 最在意的机制，例如 progression、crafting、kingdom building、academy、deckbuilding；
+3. 对长度、连载状态、视角和 romance 比例的偏好。
+
+**事实层：** Recommendations 是平台公开论坛的正式分区，作品状态与发现榜单也是 Royal Road 官方信息架构的一部分。[P1][P2][P3][P4]
+
+**讨论层：** 2026 年公开线程显示，社区回复常围绕具体机制和已读作品继续追问，推荐过程更接近逐步缩小条件。
+
+**编辑判断：** 对英文长篇连载读者，Royal Road 论坛很适合作为“第二搜索框”。先用站内标签和状态做第一轮过滤，再把剩下的复杂偏好交给人类读者，效率通常高于只刷首页榜单。
+
+## Reddit：一个站点里存在很多彼此独立的“读者协议”
+
+把 Reddit 当成一个单一社区会损失大量信息。r/ProgressionFantasy、r/litrpg、r/Fantasy、r/fantasyromance、r/royalroad、r/DanmeiNovels、r/books 各自形成不同的推荐语言、允许的话题、常见缩写和自我介绍方式。[P8][P9][P10][P11][P12][P13][P14]
+
+### r/ProgressionFantasy 与 r/litrpg：机制优先
+
+这两类社区最适合用机制描述需求。读者更容易理解“power progression 的速度”“system-heavy 程度”“numbers-go-up 的密度”“solo protagonist / party”“crafting / base building”等参数。[P8][P9] 这种语言与连载平台的标签文化高度兼容，也解释了为什么同一批作品会在 Royal Road 榜单、相关 subreddit 与 Discord 之间循环出现。
+
+### r/Fantasy 与 r/fantasyromance：主题和阅读体验优先
+
+r/Fantasy 的大型推荐串经常允许读者按主题、身份、情绪和子类型提出需求；2026 Pride 推荐串就是一个清晰例子。[P10] r/fantasyromance 的请求则更常把 romance 比例、关系动态、世界观和 spice 等读者语言组合起来。[P11] 这里适合描述“读起来像什么”，平台标签可以放在第二层补充。
+
+### r/DanmeiNovels：跨语言发现需要另一套字段
+
+面向中文耽美与翻译网文的社区，原语言、翻译状态、出版/连载状态、CP 类型、题材和平台来源都可能影响推荐。[P13] 这种社区对于英文主流书站的算法来说属于更窄的语义空间，而熟悉作品谱系的读者能直接处理别名、译名和同作者作品。
+
+### r/books：广覆盖的入口
+
+r/books 的 Weekly Recommendation Thread 适合更普遍的书籍请求。[P14] 它覆盖传统出版与数字阅读，适合作为“我只有主题与情绪要求”的入口。对于高度网文化的机制问题，专门 subreddit 会提供更高的术语密度。
+
+这里可以看到参与式文化研究的一条重要线索：社区价值来自成员持续贡献、筛选、解释和再组织信息，而平台只提供了容器的一部分。[A1][A16] “推荐”本身就是一种低门槛参与，它把私人阅读经验转成可供后来读者检索的公共知识。
+
+## Scribble Hub：“I’m Looking For”像手工版多条件查询
+
+Scribble Hub 的 **I’m Looking For** 分区长期承载求书、找回作品和类型建议。[P5] 它与站内 Series Finder 的关系很有意思：Series Finder 本身已经提供题材、标签、章节数、字数、更新时间、评分、读者数、状态等大量条件，[P6] 而论坛处理的是这些字段之外更模糊的需求，例如：
+
+- “我记得一个角色在某个阶段获得某项能力”；
+- “想找主角气质接近 A，但世界观更像 B”；
+- “希望有某种关系结构，同时剧情重心仍然放在冒险”；
+- “已经把筛选器翻过一轮，还想找漏掉的作品”。
+
+这说明**结构化筛选和社区推荐是互补关系**。前者压缩候选集合，后者处理描述模糊、记忆残缺和组合偏好。推荐系统研究也长期面对同一类边界：历史行为和特征可以排序候选，人类语言又能表达当下情境、临时约束和复杂理由。[A22][A23][A24]
+
+**编辑判断：** 如果你能把需求写成数据库条件，先用 Series Finder；如果需求里出现“像”“感觉”“记得一点情节”“希望两种风格同时存在”，再进入 I’m Looking For。
+
+## Novel Updates：跨语言网文的“读者策展层”
+
+Novel Updates 的 Recommendation Lists 把读者整理的作品组合成公开书单。[P7] 对翻译网文读者，这种结构有两个特殊价值。
+
+第一，**别名与翻译生态**经常比单一英文标题复杂。读者可能从中文名、日文罗马字、英文译名、出版版标题中的任一入口进入。第二，**阅读路径有强烈的谱系关系**：同作者、同题材、同套路、同 CP 结构、同世界观类型的作品经常被读者主动打包成列表。
+
+这种“列表策展”与 Goodreads 的书架、读者评论、推荐请求属于相邻的社会阅读形式。[P7][P15][A3][A4][A8][A9] 数据层面的排序会告诉你“很多人看过什么”，读者策展更擅长表达“这些作品为什么应该放在一起”。
+
+**事实层：** Recommendation Lists 当前持续出现读者创建的新列表，列表页公开可索引。[P7]
+
+**编辑判断：** 对日轻、中韩网文和翻译小说，先找一份接近目标的高质量列表，再沿作者、标签和相似作品扩展，往往比从全站关键词起步更快。
+
+## Goodreads：从“评价数据库”转向“读者请求”看会更有用
+
+Goodreads 常被理解成评分与书架网站，而 Recommendation Requests 提供了更接近“向读者提问”的入口。[P15] 它适合传统出版、类型小说和已经有稳定 ISBN/书目身份的作品。对于网文读者，这里最大的价值是把网络连载放进更广的阅读品味中：一个人可能同时喜欢 web serial、传统 fantasy、romance、YA 和 fanfiction，推荐请求可以用跨媒介参照物描述偏好。
+
+围绕 Goodreads 的数字接受研究已经形成一条很长的研究线：从如何在 Goodreads 找书，到在线书评、社会读者建模、数字阅读接受与阅读影响抽取。[A4][A5][A6][A7][A9][A10][A12] 这说明 Goodreads 类数据既是推荐输入，也是文学接受的公共痕迹。
+
+对读者而言，一个实用技巧是把评分数字降到次要位置，把**评论理由、书架标签、相似读者和请求上下文**放到前面。数字提供压缩信号，文字提供偏好原因。
+
+## Discord：最强的即时层，公开网页只看到入口
+
+Discord 的 Discover / Server Directory 让部分 Community Server 通过公开目录被发现；官方帮助同时规定服务器发现能力需要满足规模、活跃、安全和管理要求。[P16][P17][P18][P19] 在公开目录里搜索 books、web novel、fantasy 等词，可以找到面向读书、作者、出版社和特定作品的服务器。
+
+Discord 与前面的社区形成一个明显差异：**目录是公开的，核心对话通常发生在加入服务器之后。** 这使它非常适合：
+
+- buddy read 和 reading sprint；
+- 章节更新后的实时讨论；
+- 长期熟人关系下的个性化推荐；
+- 作者公告、活动与语音交流；
+- 小众类型里连续追问“你还记得类似的第三本吗”。
+
+同时，它给研究者和搜索引擎留下的公共痕迹更少。公开搜索更容易看见服务器名称、简介和规模信号，更难看见聊天频道内部形成的推荐链。本文因此把 Discord 排在“高互动、低公开可检索”象限；搜索结果数量只承担目录观测功能，读者规模另需独立证据。
+
+这也对应数字社区研究里常见的“可见性与参与方式”问题：平台架构决定哪些互动容易被保存、引用和重新发现。[A1][A2][A16] 对个人读者，这是一种优势——长期群聊能形成更细的共同语境；对后来搜索的人，它意味着知识复用更多依赖群内成员再次回答。
+
+## Tapas 与平台内论坛：作品、作者、读者在同一语境里
+
+Tapas Community 把用户创作的 webcomics 和 webnovels 置于平台社区框架中，[P21] 官方论坛则长期存在推荐、作品分享与创作者讨论。[P20] 这种空间与 Royal Road、Scribble Hub 相似：读者讨论和作者活动共享同一平台语境。
+
+平台内社区的优势在于**上下文成本低**。当有人说“最新一章”“这个作者”“Community 作品”“Free Access”时，其他成员已经熟悉平台的术语与入口。上一篇 WebNR 平台比较已经说明 Tapas 的 Community、Free Access、Premium 分区会影响读者理解“免费”和“平台内容”的方式；这类产品结构也会自然进入推荐对话。[P21]
+
+Fanfiction 与在线写作社区研究进一步表明，写作者、读者、评论者之间的角色经常重叠，反馈、标签和讨论既服务阅读也服务创作。[A13][A14][A15][A16][A17][A18][A19][A20] 对 web serial 平台尤其如此：今天留下章节评论的人，明天可能发布自己的故事；作者也会作为读者参与推荐。
+
+## 三种推荐任务，三种最优路径
+
+### 1. “我想找下一本”
+
+从结构化发现开始最省力。Royal Road、Scribble Hub、Novel Updates、Goodreads 都能先把候选缩小，然后把复杂偏好带到社区。[P3][P6][P7][P15]
+
+推荐请求可以使用一个简单模板：
+
+> 我最近喜欢 A、B、C；最看重 X 和 Y；希望篇幅在某个范围；更喜欢某种视角/关系/节奏；现在想找 Z 类型。
+
+这个模板把“相似作品”变成多个可回答的维度，也减少回复者猜测你的核心偏好。
+
+### 2. “我忘了书名，只记得几个情节”
+
+这时公共论坛的长期索引价值很高。Royal Road Recommendations 与 Scribble Hub I’m Looking For 都持续出现找回作品类请求。[P2][P5] 最有效的信息包括：大致阅读年份、平台、主角能力、一个罕见场景、关系设定、封面印象、章节长度、是否翻译作品。罕见细节往往比“男主、奇幻、升级”更有区分度。
+
+### 3. “我已经在追这本，想持续聊”
+
+平台论坛、作品评论区与 Discord 更合适。这里的目标从“检索”转向“关系与节奏”：持续跟进更新、参与活动、交换推测、一起读。在线 fandom 与 affinity-space 研究长期关注这种由共同兴趣维系的连续参与。[A1][A13][A14][A16][A17][A18]
+
+这三类任务组合起来，可以得到一条非常稳定的路线：
+
+**目录/标签层 → 专门社区求书层 → 即时聊天与长期关系层。**
+
+WebNR 的编辑判断是，把所有发现都塞进一个“推荐算法”会丢掉很多读者真正使用的上下文。一个好的读者工具更适合保留这些外部社区的入口，让本地阅读器负责阅读与个人书库，让社区继续负责讨论、策展和人际推荐。
+
+## 社区地图里的几个关键差异
+
+### 差异一：公开可检索性决定“旧答案”的寿命
+
+Reddit、公开论坛、Novel Updates 列表、Goodreads 请求都能形成长期 URL。一次高质量回复可能几年后仍然被搜索到。[P2][P5][P7][P15] Discord 的核心聊天更强调当下互动。两者服务的时间尺度不同：前者像公共知识库，后者像持续运行的读书会。
+
+### 差异二：标签系统决定推荐语言
+
+Royal Road 和 Scribble Hub 的读者习惯用平台标签、连载状态和机制表达偏好；fanfiction 社群依赖 fandom、relationship、trope 和 tagging；Goodreads 与大众书社区更常使用主题、作者、类型和阅读感受。[P3][P4][P6][A11][A17] 标签研究提醒我们，标签同时是分类工具和社区实践；同一个词在不同社区里可能承担不同粒度。
+
+### 差异三：平台治理决定自荐、广告与讨论的边界
+
+推荐空间永远面临作者自荐、商业推广、重复提问与低信息请求。社区规则、版主实践、专用 flair/分区会改变信息质量。r/royalroad 对 Recommendation flair 的使用语境、各平台论坛的分区设计、Discord Community Server 的治理要求都属于这套机制的一部分。[P12][P18][P19]
+
+在线社区治理研究说明，自我管理、版主规范和社会规则会共同塑造参与体验。[A21] 对读者而言，进入一个新社区时先读 pinned rules、flair 说明和推荐模板，常常能显著提高提问质量。
+
+### 差异四：推荐理由比“热门”更能迁移
+
+热门榜会随着时间、平台算法和活跃度变化；“我为什么喜欢这本”更容易迁移到另一个社区。在线书评和阅读影响研究正是围绕这种文字理由展开：情绪、人物、风格、主题、节奏等信息能揭示单一评分里被压缩掉的阅读体验。[A9][A10][A12]
+
+所以，当你从 Reddit 转到 Discord，或者从 Novel Updates 转到 Goodreads 时，最值得携带的是**偏好理由**；数字分数放在次要位置。
+
+## 反证与样本边界：公开网络会放大哪些社区
+
+这份地图天然偏向公开网页。可被搜索引擎抓到的 Reddit、论坛、公开列表和帮助中心拥有更高的可观测性；邀请制 Discord、QQ群、Telegram 群、私密论坛、私信推荐、线下读书会留下的公开证据更少。公开页面的活跃程度也会受到置顶规则、归档策略、登录墙与搜索引擎收录节奏影响。
+
+此外，社区发帖者代表“愿意公开发帖的读者”。潜水读者、只使用平台推荐流的人、移动端应用用户和私密群成员会形成不同的行为分布。平台上的高频作品也容易在推荐串里获得更多曝光，形成注意力回路。推荐系统与平台化文化生产研究提供了理解这些反馈回路的框架。[A2][A22][A23][A24]
+
+因此，本文的“更适合”指向任务匹配；群体代表性需要另一套抽样设计。一个很小但术语高度专业的社区，可能对某类问题极其有效；一个超大社区则可能提供更宽的候选集合。读者可以根据问题粒度在两者之间切换。
+
+## 给读者的最短行动路线
+
+今天就想找一本新网文，可以按下面顺序走：
+
+1. **先写出三个条件。** 参照作品、最在意的机制/主题、篇幅或连载状态。
+2. **选一个专门社区。** Progression/LitRPG 去 Royal Road、r/ProgressionFantasy、r/litrpg；翻译网文先看 Novel Updates 和对应类型 subreddit；广义 fantasy/romance 用 r/Fantasy、r/fantasyromance、Goodreads。
+3. **先搜旧帖，再发新帖。** 公开论坛的历史线程经常已经覆盖相似请求。
+4. **拿到候选后回到平台状态页。** 检查更新、完结、可访问范围与官方入口。
+5. **真正想长期聊，再进 Discord 或平台社区。** 这一步把一次性求书转成持续读者关系。
+
+如果你使用 WebNR，上一篇 [英文连载平台比较](/blog/2026/08/10/english-serial-fiction-platforms/) 可以先帮你判断阅读平台；WebNR 本身继续保持本地优先，把外部社区当作发现与讨论入口，而把你的 TXT、阅读进度和个人书库留在浏览器端。
+
+## 结论：网文发现其实是一条“社区管线”
+
+2026 年公开网络里的网文推荐，很少由一个入口包办。读者通常在三层之间移动：
+
+**第一层是目录与标签。** Royal Road、Scribble Hub、Novel Updates、Goodreads 帮你快速缩小范围。
+
+**第二层是可检索的公共社区。** Reddit 和平台论坛处理复杂偏好、忘记书名、相似作品与长尾问题，并把答案保存成后来还能找到的公共记录。
+
+**第三层是持续关系。** Discord、作品评论区、平台社区把一次推荐延伸成追更、buddy read、作者交流和熟人式推荐。
+
+这条管线解释了为什么“最好的推荐网站”很难有单一答案：你需要的是**在正确阶段使用正确社区**。先让结构化数据负责筛选，再让熟悉类型的人类读者处理语义与情境，最后把真正喜欢的社区留作长期交流。对于网文这种更新快、类型语言细、平台迁移频繁的阅读生态，这种组合比单独依赖一个榜单更贴近读者日常。
+
+---
+
+## 一手与社区来源
+
+- [P1] Royal Road, Forums — https://www.royalroad.com/forums
+- [P2] Royal Road, Recommendations forum — https://www.royalroad.com/forums/5850
+- [P3] Royal Road, Discovery & Ranking — https://www.royalroad.com/support/knowledgebase/78
+- [P4] Royal Road, Fiction Status — https://www.royalroad.com/support/knowledgebase/88
+- [P5] Scribble Hub Forum, I’m Looking For — https://forum.scribblehub.com/forums/im-looking-for.15/
+- [P6] Scribble Hub, Series Finder — https://www.scribblehub.com/series-finder/
+- [P7] Novel Updates, Recommendation Lists — https://www.novelupdates.com/recommendation-lists/
+- [P8] Reddit, r/ProgressionFantasy — https://www.reddit.com/r/ProgressionFantasy/
+- [P9] Reddit, r/litrpg — https://www.reddit.com/r/litrpg/
+- [P10] Reddit, r/Fantasy — https://www.reddit.com/r/Fantasy/
+- [P11] Reddit, r/fantasyromance — https://www.reddit.com/r/fantasyromance/
+- [P12] Reddit, r/royalroad — https://www.reddit.com/r/royalroad/
+- [P13] Reddit, r/DanmeiNovels — https://www.reddit.com/r/DanmeiNovels/
+- [P14] Reddit, r/books — https://www.reddit.com/r/books/
+- [P15] Goodreads, Recommendation Requests — https://www.goodreads.com/recommendation_requests
+- [P16] Discord, Server Directory: books — https://discord.com/servers?query=books
+- [P17] Discord, Server Directory: web novel query — https://discord.com/servers?query=webno
+- [P18] Discord Help Center, Server Discovery — https://support.discord.com/hc/en-us/articles/360023968311-Server-Discovery
+- [P19] Discord Help Center, Enabling Server Discovery — https://support.discord.com/hc/en-us/articles/360030843331-Enabling-Server-Discovery
+- [P20] Tapas Forums — https://forums.tapas.io/
+- [P21] Tapas Help Center, What is Tapas Community? — https://help.tapas.io/hc/en-us/articles/4409607638171-What-is-Tapas-Community
+- [P22] Wattpad official Google Play listing — https://play.google.com/store/apps/details?id=wp.wattpad
+- [P23] Honeyfeed, About — https://www.honeyfeed.fm/about/
+- [P24] Discord, Community Server Guidelines — https://discord.com/guidelines
+
+## 学术与研究来源
+
+- [A1] Henry Jenkins & Ravi Purushotma, *Confronting the Challenges of Participatory Culture: Media Education for the 21st Century*. https://openresearchlibrary.org/ext/api/media/035b2379-8107-48cf-a023-14a25c7f4243/assets/external_content.pdf
+- [A2] David B. Nieborg & Thomas Poell, “The platformization of cultural production: Theorizing the contingent cultural commodity.” https://pure.uva.nl/ws/files/31895348/The_platformization_of_cultural_production.pdf
+- [A3] Hana Khaled Abdelrahman Shamaa, *Online Social Reading Platforms: An Investigation into the Participatory Cultures on Goodreads, LibraryThing, Amazon and Wattpad* (2021). https://thesis.eur.nl/pub/60440/Khaled-Abdelrahman-Shamaa-Hana.pdf
+- [A4] N. Wyatt, “Finding good reads on Goodreads.” *Reference & User Services Quarterly* (2009). https://www.jstor.org/stable/pdf/refuseserq.51.4.319.pdf
+- [A5] M. Willand, J. Beck & N. Reiter, “Reading Data: On Digital Reception Studies” (2018). https://www.academia.edu/download/76362237/34.pdf
+- [A6] P. Holur, S. Shahsavari, E. Ebrahimzadeh & R. Timothy, “Modeling Social Readers: Novel Tools for Addressing Reception from Online Book Communities.” https://www.academia.edu/download/77198721/2105.01150v2.pdf
+- [A7] L. De Greve & G. Martens, “Judging a Book by Its Criticism: A digital analysis of professional and community driven literary criticism” (2022). https://journal.dhbenelux.org/wp-content/uploads/2022/07/jdhbenelux4_09-DeGreve.pdf
+- [A8] E. Beale, *Literally: social reading and meaning-making* (2018). https://rshare.library.torontomu.ca/articles/thesis/Literally_social_reading_and_meaning-making/14652126/files/28133889.pdf
+- [A9] P. Boot, “The Voice of the Reader: The Landscape of Online Book Discussion in the Netherlands, 1997–2016” (2020). https://pure.knaw.nl/portal/files/37457470/Boot_EHR_preprint.pdf
+- [A10] M. Koolen, P. Boot & J. J. van Zundert, “Online book reviews and the computational modelling of reading impact” (2020). https://ceur-ws.org/Vol-2723/long13.pdf
+- [A11] J. Frederick, “C&C and Fandom Squee: Considering Fanfiction Reader Reviews on Archive of Our Own.” https://theseacs.org/wp-content/uploads/Frederick_CC.pdf
+- [A12] M. Koolen, J. L. Neugarten & P. Boot, “‘This book makes me happy and sad and I love it’: A Rule-based Model for Extracting Reading Impact from English Book Reviews” (2022). https://repository.ubn.ru.nl/bitstream/handle/2066/298014/298014.pdf?sequence=1
+- [A13] J. C. Lammers, A. M. Magnifico & J. S. Curwood, “Exploring Tools, Places, and Ways of Being: Audience Matters for Developing Writers.” https://www.academia.edu/download/31594525/Lammers_Magnifico_Curwood_2014_Exploring_Tools_Places_and_Ways_of_Being_AuthorsAcceptedManuscript.pdf
+- [A14] B. Thomas, “‘Stand out from the crowd!’: literary advice in online writing communities” (2021). https://library.oapen.org/bitstream/handle/20.500.12657/46124/1/2021_Book_WritingManualsForTheMasses.pdf#page=166
+- [A15] F. Silberstein-Bamford, “The ‘fanfic lens’: Fan writing’s impact on media consumption” (2023). https://www.researchgate.net/profile/Fabienne-Silberstein-Bamford/publication/371539416_The_'Fanfic_Lens'_Fan_Writing's_Impact_on_Media_Consumption/links/6489679b9605ba270e436998/The-Fanfic-Lens-Fan-Writings-Impact-on-Media-Consumption.pdf
+- [A16] N. Lamerichs, *Productive Fandom* (2018). https://library.oapen.org/bitstream/handle/20.500.12657/28223/1001770.pdf
+- [A17] C. M. Messina, “Tracing fan uptakes: Tagging, language, and ideological practices in The Legend of Korra fanfictions” (2019). https://wac.colostate.edu/docs/jwa/vol3/messina.pdf
+- [A18] A. Sereda, “‘Dirty stories saved my life’: Fanfiction as a source of emotional support” (2019). https://dspace.cuni.cz/bitstream/handle/20.500.11956/110315/130257705.pdf?sequence=1
+- [A19] S. Mosher, “Exploration of Derivative Works: The Appeal of Fanfiction to Creative Minds Within Fan Communities” (2024). https://escholarship.org/content/qt0qs5m0zg/qt0qs5m0zg.pdf?v=lg
+- [A20] K. Bahoric & E. Swaggerty, “Fanfiction: Exploring in- and out-of-school literacy practices” (2015). https://www.researchgate.net/profile/Elizabeth-Swaggerty/publication/280531703_Fanfiction_Exploring_in-_and_out-of-school_literacy_practices/links/563a5e4208ae405111a5864b/Fanfiction-Exploring-in-and-out-of-school-literacy-practices.pdf
+- [A21] Joseph Seering, “Reconsidering Self-Moderation.” *Proceedings of the ACM on Human-Computer Interaction*. https://dl.acm.org/doi/pdf/10.1145/3415178
+- [A22] Linyuan Lü, Matúš Medo, Chi Ho Yeung, Yicheng Zhang, Zi-Ke Zhang & Tao Zhou, “Recommender systems.” https://arxiv.org/pdf/1202.1112
+- [A23] Yuncong Li et al., “Modeling User Repeat Consumption Behavior for Online Novel Recommendation.” https://arxiv.org/abs/2209.01963
+- [A24] Hannes Rosenbusch & Erdem Ozan Meral, “Which books do I like?” https://arxiv.org/abs/2503.03300

--- a/docs/blog/posts/2026-08-12-web-novel-reader-communities.md
+++ b/docs/blog/posts/2026-08-12-web-novel-reader-communities.md
@@ -13,6 +13,12 @@ categories:
 
 **直接答案：** 想找 LitRPG、Progression Fantasy、长篇英文连载，先去 **Royal Road Recommendations**、**r/ProgressionFantasy** 和 **r/litrpg**；想带着一长串标签、篇幅、更新状态去精确求书，**Scribble Hub 的 “I’m Looking For”** 很适合；想找亚洲翻译网文、轻小说、耽美等跨语言作品，**Novel Updates 的 Recommendation Lists** 与类型化 Reddit 社群更接近读者实际检索路径；想找更宽泛的奇幻、爱情、通俗小说，**r/Fantasy、r/fantasyromance、r/books 与 Goodreads Recommendation Requests** 覆盖面更宽；想要即时聊天、buddy read、作者或读者群，**Discord Discover / Server Directory** 提供另一层入口。平台内论坛如 Royal Road、Scribble Hub、Tapas 则最适合讨论“这个平台上的作品”。[P1][P2][P5][P7][P8][P9][P10][P11][P14][P15][P16][P20]
 
+## 摘要
+
+本文以 2026 年 8 月 12 日公开可观察的网文读者社区为样本，结合 24 个平台、论坛、社区与帮助页面和 24 项社会阅读、参与式文化、在线书评、fanfiction、平台化与推荐系统研究，比较不同社区怎样承接找下一本、精确求书、找回忘记书名的作品、追更讨论与长期读书关系。核心发现是一条三层“社区管线”：目录与标签先压缩候选集合，可检索的论坛、Reddit 与读者列表处理复杂语义和长尾问题，Discord 与平台内社区承接持续互动。读者获得更高匹配度的关键来自问题粒度与社区信息结构的对应；公开可检索性、标签语言、治理方式与互动节奏共同决定一条推荐在何处产生、如何被保存，以及后来读者还能怎样复用。
+
+**关键词：** 网文发现；社会阅读；读者推荐；社区检索；Reddit；Discord；Royal Road；Novel Updates
+
 这张地图按“读者准备完成什么任务”组织，重点放在任务匹配；社区体量只作为背景信号。2026 年 8 月 12 日的公开采样显示，找书、找回忘记书名的作品、判断连载状态、追某一类型、参与章节讨论、加入长期读书群，分别对应不同的信息结构。公开论坛与 Reddit 留下可检索的长尾问答；平台内社区拥有更丰富的作品状态与标签语境；Discord 强在同步互动与持续关系；Goodreads 和 Novel Updates 更接近由书目、列表和读者记录组织起来的发现层。[P1][P2][P5][P7][P15][P16][A3][A8][A9]
 
 本文同时延续 WebNR 的上一份平台比较：[2026 英文连载小说平台怎么选？](/blog/2026/08/10/english-serial-fiction-platforms/)。上一篇回答“去哪里读”，这一篇回答“去哪里问、去哪里找、去哪里跟人聊”。
@@ -20,6 +26,8 @@ categories:
 ## 研究问题与采样方法
 
 本文关注一个具体问题：**公开网络上的网文读者，如何在不同社区里完成推荐与讨论？**
+
+**中心论点：** 网文发现的有效路径由三层协同组成：目录与标签负责快速缩小候选，可检索公共社区负责复杂偏好、遗忘书名和相似作品等语义任务，即时聊天与平台内社区负责持续讨论和关系维持。读者选择社区时，把问题粒度、可检索性与互动节奏放在社区体量之前，更容易获得可用答案。
 
 采样日期为 **2026 年 8 月 12 日**。主样本由 24 个公开的一手页面组成，包括平台论坛首页、推荐分区、官方帮助、公开 subreddit、推荐请求页、公开服务器目录与平台社区说明；其中 15 个页面直接呈现推荐、求书、找书或读者交流，9 个页面用于解释平台结构、发现机制与进入门槛。[P1]-[P24] 观察重点放在页面当前结构、讨论入口、公开可见程度、请求格式和平台规则。旧线程只用于识别长期稳定的提问形态，当前索引页与 2026 年页面承担更高权重。
 
@@ -115,7 +123,7 @@ Goodreads 常被理解成评分与书架网站，而 Recommendation Requests 提
 
 ## Discord：最强的即时层，公开网页只看到入口
 
-Discord 的 Discover / Server Directory 让部分 Community Server 通过公开目录被发现；官方帮助同时规定服务器发现能力需要满足规模、活跃、安全和管理要求。[P16][P17][P18][P19] 在公开目录里搜索 books、web novel、fantasy 等词，可以找到面向读书、作者、出版社和特定作品的服务器。
+Discord 的公开 Server Directory 可以直接按关键词发现可公开展示的 Community Server；Discover Tab 帮助页说明应用内 Discover 处于实验性分发阶段，服务器搜索在该实验中以桌面端为主。服务器进入公开发现还需满足规模、活跃、安全与管理条件。[P16][P17][P18][P19]
 
 Discord 与前面的社区形成一个明显差异：**目录是公开的，核心对话通常发生在加入服务器之后。** 这使它非常适合：
 
@@ -238,7 +246,7 @@ Royal Road 和 Scribble Hub 的读者习惯用平台标签、连载状态和机�
 - [P15] Goodreads, Recommendation Requests — https://www.goodreads.com/recommendation_requests
 - [P16] Discord, Server Directory: books — https://discord.com/servers?query=books
 - [P17] Discord, Server Directory: web novel query — https://discord.com/servers?query=webno
-- [P18] Discord Help Center, Server Discovery — https://support.discord.com/hc/en-us/articles/360023968311-Server-Discovery
+- [P18] Discord Help Center, Discover Tab — https://support.discord.com/hc/en-us/articles/25323248535319-Discover-Tab
 - [P19] Discord Help Center, Enabling Server Discovery — https://support.discord.com/hc/en-us/articles/360030843331-Enabling-Server-Discovery
 - [P20] Tapas Forums — https://forums.tapas.io/
 - [P21] Tapas Help Center, What is Tapas Community? — https://help.tapas.io/hc/en-us/articles/4409607638171-What-is-Tapas-Community


### PR DESCRIPTION
## Rationale
Publish the scheduled 2026-08-12 reader-facing asset: a task-oriented map of public web-novel recommendation and discussion communities. The article answers where readers can ask for LitRPG/progression, translated web novels, broad genre recommendations, forgotten-title identification, platform-native discussion, and persistent live chat.

## Research and scope
- 5,400+ Chinese main-text characters before references
- 24 public first-party/community sources sampled on 2026-08-12
- 24 academic/research sources gathered across multiple Scholar search rounds
- explicit sampling method, facts/discussion/editorial separation, counterevidence and public-visibility boundary
- direct reader answer near the top and internal link to the 2026-08-10 English serial-platform comparison
- literal scan of the author-written body found none of the repository research skill's prohibited defensive constructions

## Product/source boundary
This PR changes only the scheduled editorial article. Today's source-growth lane was already delivered and production-verified by PR #78 (`Global Grey Starter`); no third-party crawling, account automation, redistribution, analytics-policy change, or Legado compatibility claim is added here.

## Validation and acceptance
Expected Quality jobs: Web quality, Documentation quality, Production evidence, Chromium user journeys. Documentation quality must build the article under the established `www.webnovel.win` canonical origin. After squash merge, the exact canonical production build, article route, sitemap and RSS entry will be verified before closeout.

## Risk and rollback
Documentation-only reader content. Rollback is a revert of the article if build, citation, canonical, or public acceptance checks fail.