### PR TITLE
feat: add Wikisource discovery source

### DIFF
--- a/public/sources/wikisource-starter/README.txt
+++ b/public/sources/wikisource-starter/README.txt
@@ -1,0 +1,56 @@
+Wikisource Starter
+==================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/wikisource-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fwikisource-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small English-language discovery catalog for
+selected classic novels on English Wikisource. It gives readers stable work or
+edition landing pages while leaving reading, edition selection, downloads,
+proofreading state, and work-specific rights information at Wikisource.
+
+Source and reuse boundary
+-------------------------
+Wikisource is a Wikimedia project for free-content source texts. English
+Wikisource's copyright policy requires hosted works to be in the public domain
+or available under a compatible free license, while contributor-created text is
+licensed under CC BY-SA 4.0 and GFDL unless otherwise noted. Individual source
+or edition pages still carry the authoritative rights template and edition
+status, so this starter does not treat the whole site as one undifferentiated
+public-domain corpus.
+
+Source: https://en.wikisource.org/
+Copyright policy: https://en.wikisource.org/wiki/Wikisource:Copyright_policy
+Terms of use: https://foundation.wikimedia.org/wiki/Policy:Terms_of_Use
+
+Current WebNR behavior
+----------------------
+The entries are discovery links only. Selecting an item opens its English
+Wikisource work or edition page. WebNR stores only basic bibliographic facts,
+WebNR-authored descriptions, and the verified landing-page URL. It does not
+proxy, cache, crawl, bulk-download, or redistribute Wikisource text, scans,
+EPUB/MOBI/PDF exports, images, or contributor annotations.
+
+A future richer adapter would require versioned fixtures for MediaWiki/API
+pagination, stable revision identity, request cadence, size limits, timeout and
+backoff behavior, attribution, and work-level license/status fields. The current
+starter performs no runtime Wikisource API polling and therefore adds no API,
+CORS, or rate-limit dependency to the reader path.
+
+Included discovery pages
+------------------------
+- Pride and Prejudice (1813) — Jane Austen
+- Frankenstein, or the Modern Prometheus (Revised Edition, 1831) — Mary Shelley
+- Dracula — Bram Stoker
+- The Time Machine (Holt text) — H. G. Wells
+
+Last verified
+-------------
+2026-08-15

--- a/public/sources/wikisource-starter/search_index.yml
+++ b/public/sources/wikisource-starter/search_index.yml
@@ -1,0 +1,66 @@
+wikisource/pride-and-prejudice-1813.md:
+  title: Pride and Prejudice (1813)
+  author: Jane Austen
+  description: English Wikisource 的《Pride and Prejudice》1813 年版作品页。WebNR 仅保存书目事实、人工核验的发现链接与自写说明；正文、扫描、导出格式、校对状态及具体权利标记继续由 Wikisource 页面提供。
+  page_url: https://en.wikisource.org/wiki/Pride_and_Prejudice_(1813)
+  source: English Wikisource
+  license: Link-only-WebNR-editorial
+  tags:
+    - Wikisource
+    - English literature
+    - Public domain edition
+    - Novel
+  categories:
+    - Free reading discovery
+  region: en-US
+
+wikisource/frankenstein-1831.md:
+  title: Frankenstein, or the Modern Prometheus (Revised Edition, 1831)
+  author: Mary Shelley
+  description: English Wikisource 的《Frankenstein》1831 修订版作品页。该条目只提供稳定的发现入口；WebNR 不复制 Wikisource 正文、页面扫描、下载文件或编辑者注释，并把版本状态与许可核对留在来源页。
+  page_url: https://en.wikisource.org/wiki/Frankenstein,_or_the_Modern_Prometheus_(Revised_Edition,_1831)
+  source: English Wikisource
+  license: Link-only-WebNR-editorial
+  tags:
+    - Wikisource
+    - English literature
+    - Public domain edition
+    - Gothic fiction
+    - Science fiction
+  categories:
+    - Free reading discovery
+  region: en-US
+
+wikisource/dracula.md:
+  title: Dracula
+  author: Bram Stoker
+  description: English Wikisource 的《Dracula》作品页。WebNR 当前仅维护标题、作者、来源与经核验的阅读发现链接，不把来源站的正文、扫描或可下载格式重新包装为 WebNR 内容。
+  page_url: https://en.wikisource.org/wiki/Dracula
+  source: English Wikisource
+  license: Link-only-WebNR-editorial
+  tags:
+    - Wikisource
+    - English literature
+    - Public domain edition
+    - Gothic fiction
+    - Horror
+  categories:
+    - Free reading discovery
+  region: en-US
+
+wikisource/the-time-machine-holt.md:
+  title: The Time Machine (Holt text)
+  author: H. G. Wells
+  description: English Wikisource 的《The Time Machine》Holt 版作品页。WebNR 仅提供人工核验的发现链接和基础书目事实；具体版本、正文、导出格式与页面权利说明仍由 Wikisource 维护。
+  page_url: https://en.wikisource.org/wiki/The_Time_Machine_(Holt_text)
+  source: English Wikisource
+  license: Link-only-WebNR-editorial
+  tags:
+    - Wikisource
+    - English literature
+    - Public domain edition
+    - Science fiction
+    - Novel
+  categories:
+    - Free reading discovery
+  region: en-US


### PR DESCRIPTION
## Scope

Add a small WebNR-maintained, link-only English Wikisource discovery catalog with four classic novels. The source stores only bibliographic facts, WebNR-authored descriptions, and verified Wikisource landing-page URLs; it does not copy, proxy, cache, bulk-download, or redistribute Wikisource text, scans, exports, images, or annotations.

## Admission evidence

- English Wikisource copyright policy requires hosted source works to be public domain or compatible free content, while individual work/edition pages remain authoritative for status.
- Verified landing pages: *Pride and Prejudice* (1813), *Frankenstein* (1831 revised edition), *Dracula*, and *The Time Machine* (Holt text).
- No runtime API polling is introduced; the catalog is static link-only discovery, so it adds no CORS/rate-limit dependency to the reader.
- The README records the origin, policy boundary, future-adapter requirements, and verification date.

## Validation and blast radius

- Additive only under `public/sources/wikisource-starter/`; no existing source, route, metadata, analytics, canonical, UI, or Legado behavior is changed.
- Repository parser accepts the existing `search_index.yml` mapping shape and resolves explicit HTTPS `page_url` fields.
- Rollback is deletion of this new source directory.

CI must complete all expected repository checks before merge. After green CI I will perform a fresh base-to-head review; if clean, this PR should be squash-merged and the exact production application deployment/public source artifact verified before closeout.