### PR TITLE
feat: add cross-platform English web-fiction discovery source

### DIFF
--- a/public/sources/english-web-fiction-discovery-starter/README.txt
+++ b/public/sources/english-web-fiction-discovery-starter/README.txt
@@ -1,0 +1,65 @@
+English Web-Fiction Discovery Starter
+=====================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/english-web-fiction-discovery-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fenglish-web-fiction-discovery-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small English-language discovery catalog for
+finding web fiction outside any single publishing platform. It points readers to
+cross-platform rankings, public story libraries, and community-maintained serial
+directories while leaving reading, account state, moderation, age gates,
+comments, and work-specific rights information at the origin site.
+
+Source and reuse boundary
+-------------------------
+The included destinations contain third-party or user-authored material under
+their own terms and work-specific rights. This starter treats them as link
+destinations, not as a reusable text corpus. WebNR stores only the verified
+landing-page URL, a short WebNR-authored description, and discovery labels.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the destination page on the origin site. WebNR does not
+proxy, cache, crawl, mirror, bulk-download, re-host, or redistribute story text,
+comments, covers, rankings, forum posts, profile data, or other user-generated
+content from these destinations. It does not bypass login, payment, moderation,
+age verification, robots, captchas, or other access controls.
+
+A future richer adapter would require a separate source-specific audit with
+versioned fixtures for stable identity, paging, request cadence, timeouts,
+backoff, content warnings, provenance, attribution, deletion/update behavior,
+and work-level rights. The current starter performs no runtime API or HTML
+polling and therefore adds no origin-site API, CORS, or rate-limit dependency to
+the reader path.
+
+Included discovery pages
+------------------------
+- Top Web Fiction — community-run cross-platform ranking and new-listing index
+- SpaceBattles Discover Stories — public library spanning original and fan fiction
+- Sufficient Velocity Story Library — public user-fiction library with filters
+- Reddit Serials Story Directory — community-maintained directory of ongoing serials
+- r/HFY — public writing community with original one-shots and serialized fiction
+
+Verification notes
+------------------
+Top Web Fiction currently describes itself as a community-run listing of online
+serials and other indie-author fiction, with reader boosts feeding weekly and
+all-time rankings. SpaceBattles exposes a public Discover Stories library and a
+separate Original Fiction area. Sufficient Velocity exposes a public Story
+Library with original-fiction, status, tag, and forum filters. The Reddit
+Serials Story Directory exposes an Ongoing Serials index organized by genre and
+author. r/HFY exposes public story posts, series conventions, a wiki, and
+reader/author discovery indexes. The final two are community-maintained surfaces,
+so readers should verify each target story's current status and origin before
+relying on old directory metadata.
+
+Last verified
+-------------
+2026-08-16

--- a/public/sources/english-web-fiction-discovery-starter/search_index.yml
+++ b/public/sources/english-web-fiction-discovery-starter/search_index.yml
@@ -1,0 +1,79 @@
+english-web-fiction-discovery/top-web-fiction.md:
+  title: Top Web Fiction — Popular & New Listings
+  author: Top Web Fiction
+  description: WebNR 核验的跨平台英文网文发现入口。Top Web Fiction 由社区维护，读者 boost 影响周榜与长期榜，同时提供新收录与标签浏览。此条目仅跳转原站，不复制排行、简介或小说正文。
+  page_url: https://topwebfiction.com/
+  source: WebNR English Web-Fiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Top Web Fiction
+    - English web fiction
+    - Cross-platform discovery
+    - Reader ranking
+  categories:
+    - Discovery directory
+  region: en
+
+english-web-fiction-discovery/spacebattles-library.md:
+  title: SpaceBattles — Discover Stories
+  author: SpaceBattles
+  description: SpaceBattles 的公开故事库，覆盖原创与同人作品，并提供标签、状态与 library 视图。WebNR 仅提供发现链接；具体作品类型、内容警告、作者信息与阅读规则以原站为准。
+  page_url: https://forums.spacebattles.com/library/stories/
+  source: WebNR English Web-Fiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - SpaceBattles
+    - English web fiction
+    - Original fiction
+    - Fan fiction
+  categories:
+    - Community library
+  region: en
+
+english-web-fiction-discovery/sufficient-velocity-library.md:
+  title: Sufficient Velocity — Story Library
+  author: Sufficient Velocity
+  description: Sufficient Velocity 的公开 User Fiction 故事库，可按标签、字数、状态、论坛与原创作品等维度筛选。此 WebNR 条目只链接到公开目录，不抓取或重新发布用户作品与讨论。
+  page_url: https://forums.sufficientvelocity.com/library/stories/
+  source: WebNR English Web-Fiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Sufficient Velocity
+    - English web fiction
+    - User fiction
+    - Original fiction
+  categories:
+    - Community library
+  region: en
+
+english-web-fiction-discovery/reddit-serials-directory.md:
+  title: Reddit Serials — Ongoing Story Directory
+  author: Reddit Serials community
+  description: Reddit Serials 社区维护的 Ongoing Serials 目录，按题材与作者组织连载入口。目录元数据可能随社区维护节奏变化，WebNR 仅保存发现页链接，并建议在阅读前核验目标故事的当前状态与来源。
+  page_url: https://redditserials.wordpress.com/
+  source: WebNR English Web-Fiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Reddit Serials
+    - English web fiction
+    - Serialized fiction
+    - Community directory
+  categories:
+    - Community directory
+  region: en
+
+english-web-fiction-discovery/hfy.md:
+  title: Reddit r/HFY — Original & Serialized Fiction
+  author: r/HFY community
+  description: r/HFY 是公开的科幻与奇幻写作社区，使用 OC-OneShot、OC-FirstOfSeries、OC-Series 等分类，并维护作者、系列与找书索引。WebNR 只链接社区入口，不复制帖子、评论或故事正文。
+  page_url: https://www.reddit.com/r/HFY/
+  source: WebNR English Web-Fiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - HFY
+    - Reddit
+    - English web fiction
+    - Serialized fiction
+  categories:
+    - Community discovery
+  region: en


### PR DESCRIPTION
## Why
The 2026-08-16 source program and editorial calendar call for English web-fiction discovery beyond a single publishing platform. Current maintained sources cover several platform-native discovery pages, but do not yet provide a small cross-platform/community discovery layer.

## Scope
- add a WebNR-maintained `english-web-fiction-discovery-starter`
- add five link-only discovery entries: Top Web Fiction, SpaceBattles Discover Stories, Sufficient Velocity Story Library, Reddit Serials Story Directory, and r/HFY
- document that WebNR stores only WebNR-authored descriptions and verified landing-page URLs and performs no runtime crawling, mirroring, or access-control bypass

## Preserved behavior
No existing source, route, ranking behavior, reader data, analytics behavior, or crawler scope is changed. Existing sources remain intact.

## Evidence
All five destinations were publicly reachable during the 2026-08-16 audit. Top Web Fiction currently exposes community-run weekly/all-time rankings and new listings; SpaceBattles and Sufficient Velocity expose public story libraries with discovery filters; Reddit Serials exposes an ongoing-serial directory; r/HFY exposes original/serialized fiction conventions and public discovery indexes.

## Validation
GitHub Quality CI is authoritative for source schema, generated-source validation, lint/type/build checks, and deploy-evidence contracts. After CI is green, the full base-to-head diff and generated behavior will be reviewed from scratch before squash merge.

## Risk / rollback
Low and additive: two new source-directory files only. Rollback is deletion of the new starter in a corrective PR.

## Production acceptance
After squash merge, verify the exact production deployment for the squash commit, confirm the new source is addressable at `https://app.webnovel.win/sources/english-web-fiction-discovery-starter`, confirm the one-click `repos=` route resolves the new source, and re-check an existing maintained source as representative unaffected behavior.