### PR TITLE
content: map the 2026 English web-fiction discovery ecosystem

### DIFF
--- a/.github/seo-data/.pr92-ci-refresh
+++ b/.github/seo-data/.pr92-ci-refresh
@@ -1,0 +1,1 @@
+Temporary CI refresh marker after production-state closeout. This file is removed in the immediately following commit; the final base-to-head diff remains content-only.

--- a/.github/seo-data/.pr92-ci-refresh
+++ b/.github/seo-data/.pr92-ci-refresh
@@ -1,1 +1,0 @@
-Temporary CI refresh marker after production-state closeout. This file is removed in the immediately following commit; the final base-to-head diff remains content-only.

--- a/docs/blog/posts/2026-08-16-english-web-fiction-ecosystem.md
+++ b/docs/blog/posts/2026-08-16-english-web-fiction-ecosystem.md
@@ -21,7 +21,7 @@ WebNR 今天同时加入一个只做跳转发现的 **English Web-Fiction Discov
 
 本文以 **2026 年 8 月 16 日**公开可观察的英文网文发现入口为样本，结合 30 个平台、目录、社区、作者站、公共目录与官方说明页面，以及 26 项参与式文化、社会阅读、fanfiction、平台化文化生产、数字文学与推荐系统研究，回答一个读者导向的问题：当英文 web fiction 分散在平台、论坛、作者站、newsletter 与公共目录里时，怎样用更少的试错成本找到真正适合自己的下一本？
 
-核心发现是一张“发现网络”。平台原生榜单提供新鲜度和状态字段，跨平台目录提供横向迁移，论坛故事库提供作品与讨论共存的长尾空间，读者社区提供自然语言推荐，newsletter 与作者站提供连续订阅，公共目录提供稳定书目与长期可访问入口。读者在这些层之间移动时，最有价值的携带物是自己的偏好向量：参照作品、题材、机制、篇幅、连载状态、更新节奏、关系结构、内容边界与阅读设备。[A1][A2][A3][A8][A9][A22][A23][A24][A25][A27]
+核心发现是一张“发现网络”。平台原生榜单提供新鲜度和状态字段，跨平台目录提供横向迁移，论坛故事库提供作品与讨论共存的长尾空间，读者社区提供自然语言推荐，newsletter 与作者站提供连续订阅，公共目录提供稳定书目与长期可访问入口。读者在这些层之间移动时，最有价值的携带物是自己的偏好向量：参照作品、题材、机制、篇幅、连载状态、更新节奏、关系结构、内容边界与阅读设备。[A1][A2][A3][A8][A9][A22][A23][A24][A25][A26]
 
 **关键词：** 英文网文；web serial；web fiction；Royal Road；Top Web Fiction；SpaceBattles；newsletter；社会阅读；跨平台发现
 
@@ -52,7 +52,7 @@ WebNR 今天同时加入一个只做跳转发现的 **English Web-Fiction Discov
 | 找经典免费文本 | Project Gutenberg、Standard Ebooks、Wikisource | WebNR 公共来源 | 版本、格式、版权/许可说明 |
 | 找“像 A 但更偏 B”的作品 | 专门 Reddit / 论坛推荐区 | Discord 读者群 | 参照作品、理由、情绪、机制 |
 
-这张表的重点在“任务”。同一个平台在不同任务里的价值差异很大。Royal Road 的 Rising Stars 适合捕捉快速上升作品，Complete 适合降低追更风险；Scribble Hub 的 Series Finder 适合把需求拆成字段；Top Web Fiction 适合跨站迁移；论坛故事库适合寻找平台首页覆盖较少的作品；newsletter 适合持续关系；公共目录适合稳定入口。推荐研究长期把候选生成、排序与用户偏好表达视为多阶段过程，社会阅读研究则展示了评论、书单与讨论如何补充结构化字段。[A3][A9][A10][A22][A23][A24]
+这张表的重点在“任务”。同一个平台在各类任务里的价值分布很鲜明。Royal Road 的 Rising Stars 适合捕捉快速上升作品，Complete 适合降低追更风险；Scribble Hub 的 Series Finder 适合把需求拆成字段；Top Web Fiction 适合跨站迁移；论坛故事库适合寻找平台首页覆盖较少的作品；newsletter 适合持续关系；公共目录适合稳定入口。推荐研究长期把候选生成、排序与用户偏好表达视为多阶段过程，社会阅读研究则展示了评论、书单与讨论如何补充结构化字段。[A3][A9][A10][A22][A23][A24]
 
 ## 第一层：平台原生榜单负责“快”和“细”
 
@@ -104,7 +104,7 @@ Reddit 的强项来自“类型社区先于平台”。r/ProgressionFantasy、r/
 
 Substack 当前提供 Fiction 分类与 Top Fiction 页面，页面聚合原创 fiction、文学写作与相关出版内容。[P14] SFWA 在 2026 年 4 月专门讨论了使用 newsletter platform 发布 serial fiction 的实践，说明邮件平台已经成为英文连载的现实发行路径之一。[P15]
 
-newsletter 的发现逻辑与 Royal Road 很不一样。榜单平台强调统一库存中的排序与筛选；newsletter 强调订阅关系、作者声音、邮件到达和推荐网络。读者一旦找到喜欢的作者，后续章节可以通过 inbox、reader app 或网页目录持续到达。对于已经形成读者关系的项目，这种“推送式连续性”很有价值。
+newsletter 的发现逻辑与 Royal Road 形成鲜明对照。榜单平台强调统一库存中的排序与筛选；newsletter 强调订阅关系、作者声音、邮件到达和推荐网络。读者一旦找到喜欢的作者，后续章节可以通过 inbox、reader app 或网页目录持续到达。对于已经形成读者关系的项目，这种“推送式连续性”很有价值。
 
 作者自托管站则把控制权进一步移向作品本身。The Wandering Inn 的官方目录当前明确区分 Web Serial、Audiobook 与 Ebook，并以 volume、chapter、interlude 组织长篇阅读。[P22] Parahumans 2 的目录用 arc 和 chapter 组织 Ward，同时保留 Glow-worm 等过渡内容。[P23] 这些例子显示，英文 web serial 的“平台”有时就是作者自己维护的网站，外部发现入口承担把读者带到这里的任务。
 
@@ -128,13 +128,13 @@ Standard Ebooks 当前还明确提供可供 ereader 或 RSS reader 使用的 cat
 
 这份地图呈现出四种结构性差异。
 
-**第一，库存边界不同。** Royal Road、Scribble Hub 的榜单从站内作品出发；Top Web Fiction 从被列出的跨站作品出发；SpaceBattles、Sufficient Velocity 从论坛社区出发；Substack 从 newsletter publication 出发；作者站从单一作品或作者宇宙出发。[P1][P4][P6][P8][P10][P14][P22]
+**第一，库存边界各异。** Royal Road、Scribble Hub 的榜单从站内作品出发；Top Web Fiction 从被列出的跨站作品出发；SpaceBattles、Sufficient Velocity 从论坛社区出发；Substack 从 newsletter publication 出发；作者站从单一作品或作者宇宙出发。[P1][P4][P6][P8][P10][P14][P22]
 
-**第二，排序信号不同。** Rising Stars 关注近期增长与榜单逻辑，Top Web Fiction 使用 reader boosts，论坛故事库暴露更新、watchers、views、replies 和标签，newsletter 依赖订阅与推荐网络。每一种排序都在回答不同问题。[P1][P6][P8][P10][P14]
+**第二，排序信号各异。** Rising Stars 关注近期增长与榜单逻辑，Top Web Fiction 使用 reader boosts，论坛故事库暴露更新、watchers、views、replies 和标签，newsletter 依赖订阅与推荐网络。每一种排序都在回答不同问题。[P1][P6][P8][P10][P14]
 
-**第三，文本粒度不同。** 平台把 fiction 当作品对象，论坛把作品与线程绑定，Reddit 可以把一章当一帖，作者站按 chapter/arc/volume 组织，公共目录则把 edition、ebook 与书目记录放在中心。[P8][P12][P13][P22][P23][P27][P28]
+**第三，文本粒度各异。** 平台把 fiction 当作品对象，论坛把作品与线程绑定，Reddit 可以把一章当一帖，作者站按 chapter/arc/volume 组织，公共目录则把 edition、ebook 与书目记录放在中心。[P8][P12][P13][P22][P23][P27][P28]
 
-**第四，社区记忆不同。** 公开论坛、Reddit、Top Web Fiction 和目录页容易形成长期 URL；Discord 与 newsletter 更强调持续关系和时间流；公共目录强调版本与书目稳定性。在线社区与社会阅读研究都表明，平台结构会改变哪些互动容易保存、哪些信息容易再次检索。[A1][A3][A9][A16][A21]
+**第四，社区记忆形态各异。** 公开论坛、Reddit、Top Web Fiction 和目录页容易形成长期 URL；Discord 与 newsletter 更强调持续关系和时间流；公共目录强调版本与书目稳定性。在线社区与社会阅读研究都表明，平台结构会改变哪些互动容易保存、哪些信息容易再次检索。[A1][A3][A9][A16][A21]
 
 因此，读者获得更高命中率的关键是组合入口，让每一层负责自己擅长的任务。
 
@@ -176,7 +176,7 @@ Standard Ebooks 当前还明确提供可供 ereader 或 RSS reader 使用的 cat
 
 公开网页天然更容易进入本文样本。Top Web Fiction、公开论坛、Reddit、作者站、公开 newsletter 页面和公共目录都拥有可搜索 URL；私密 Discord、封闭 Patreon 社区、邮件正文、作者群聊和邀请制读书会留下的公开证据更少。搜索可见度因此会放大开放网页层的存在感。
 
-另外，各入口的“活跃”含义也不同。Royal Road 的当前榜单变化很快；Top Web Fiction 的 boost 以周为周期；论坛故事可以持续多年；newsletter 依赖作者发送节奏；公共目录的更新重点是新版本与新收录。把这些信号压成一个统一热度数字会丢失大量语境。[P1][P6][P8][P10][P14][P27][P28]
+另外，各入口的“活跃”含义也各有尺度。Royal Road 的当前榜单变化很快；Top Web Fiction 的 boost 以周为周期；论坛故事可以持续多年；newsletter 依赖作者发送节奏；公共目录的更新重点是新版本与新收录。把这些信号压成一个统一热度数字会丢失大量语境。[P1][P6][P8][P10][P14][P27][P28]
 
 平台上的高曝光作品还可能形成反馈回路：获得更多展示后积累更多阅读与互动，再进一步提高可见性。推荐系统与平台化文化生产研究为理解这种循环提供了成熟框架。[A2][A22][A23][A24] 所以本文把“推荐哪个入口”定义为任务匹配，而把“哪个生态最大”留给需要统一口径、统一时间窗和独立流量数据的研究。
 
@@ -188,13 +188,13 @@ Standard Ebooks 当前还明确提供可供 ereader 或 RSS reader 使用的 cat
 
 这种分工带来一个实用结果：读者可以把“平台忠诚”转换成“路径忠诚”。路径本身稳定：**结构化筛选 → 跨平台扩展 → 社区语义检索 → 官方跟随 → 本地阅读状态。** 具体站点可以随着题材与作品变化，路径仍然可复用。
 
-从研究角度，这也解释了为什么 web fiction 很难被一个单站数据库完整表示。作品身份可能跨越多个站点；作者可能同时维护免费 serial、ebook、audiobook、Patreon 或 newsletter；同一作品的讨论又分布在平台评论、Reddit、Discord 与论坛。真正有价值的发现基础设施更接近图：节点是作品、作者、平台、目录、社区与版本，边是“托管于”“推荐于”“讨论于”“订阅于”“改编为”“收录于”。[A2][A9][A25][A27]
+从研究角度，这也解释了为什么 web fiction 很难被一个单站数据库完整表示。作品身份可能跨越多个站点；作者可能同时维护免费 serial、ebook、audiobook、Patreon 或 newsletter；同一作品的讨论又分布在平台评论、Reddit、Discord 与论坛。真正有价值的发现基础设施更接近图：节点是作品、作者、平台、目录、社区与版本，边是“托管于”“推荐于”“讨论于”“订阅于”“改编为”“收录于”。[A2][A9][A25][A26]
 
 WebNR 当前采用的轻量来源策略可以视为这张图的第一步：先记录公开、可解释、来源明确的入口和 provenance，再逐渐为具有清晰机器接口与授权边界的来源增加结构化能力。
 
 ## 结论：找英文网文，从“选平台”升级成“走路径”
 
-2026 年的英文 web fiction 生态已经足够分散，也足够互联。Royal Road 与 Scribble Hub 提供高密度平台发现；Top Web Fiction 提供跨站排名；SpaceBattles 与 Sufficient Velocity 把论坛创作整理成故事库；Reddit Serials 与 r/HFY 展示社区原生连载；Novel Updates、Reddit 与 Discord提供读者策展和语义推荐；Substack、newsletter 与作者官网负责持续跟随；Project Gutenberg、Standard Ebooks、Wikisource 提供稳定的公开书目层。[P1]-[P30]
+2026 年的英文 web fiction 生态已经足够分散，也足够互联。Royal Road 与 Scribble Hub 提供高密度平台发现；Top Web Fiction 提供跨站排名；SpaceBattles 与 Sufficient Velocity 把论坛创作整理成故事库；Reddit Serials 与 r/HFY 展示社区原生连载；Novel Updates、Reddit 与 Discord 提供读者策展和语义推荐；Substack、newsletter 与作者官网负责持续跟随；Project Gutenberg、Standard Ebooks、Wikisource 提供稳定的公开书目层。[P1]-[P30]
 
 对读者，最有效的策略可以压缩成一句话：**先用字段找到候选，再用跨平台目录扩大范围，用社区解释口味，最后回到官方入口持续跟随。**
 
@@ -224,7 +224,7 @@ WebNR 当前采用的轻量来源策略可以视为这张图的第一步：先�
 - [P18] Reddit, r/litrpg — https://www.reddit.com/r/litrpg/
 - [P19] Reddit, r/Fantasy — https://www.reddit.com/r/Fantasy/
 - [P20] Goodreads, Recommendation Requests — https://www.goodreads.com/recommendation_requests
-- [P21] Discord, Server Discovery / Discover — https://support.discord.com/hc/en-us/articles/360023968311-Server-Discovery
+- [P21] Discord, Discover Tab — https://support.discord.com/hc/en-us/articles/25323248535319-Discover-Tab
 - [P22] The Wandering Inn, Table of Contents — https://wanderinginn.com/table-of-contents/
 - [P23] Parahumans 2, Table of Contents — https://www.parahumans.net/table-of-contents/
 - [P24] Tapas Help Center, What is Tapas Community? — https://help.tapas.io/hc/en-us/articles/4409607638171-What-is-Tapas-Community
@@ -256,7 +256,7 @@ WebNR 当前采用的轻量来源策略可以视为这张图的第一步：先�
 - [A17] C. M. Messina, “Tracing fan uptakes: Tagging, language, and ideological practices in The Legend of Korra fanfictions” (2019). https://wac.colostate.edu/docs/jwa/vol3/messina.pdf
 - [A18] A. Sereda, “‘Dirty stories saved my life’: Fanfiction as a source of emotional support” (2019). https://dspace.cuni.cz/bitstream/handle/20.500.11956/110315/130257705.pdf?sequence=1
 - [A19] S. Mosher, “Exploration of Derivative Works: The Appeal of Fanfiction to Creative Minds Within Fan Communities” (2024). https://escholarship.org/content/qt0qs5m0zg/qt0qs5m0zg.pdf?v=lg
-- [A20] K. Bahoric & E. Swaggerty, “Fanfiction: Exploring in- and out-of-school literacy practices” (2015). https://www.researchgate.net/profile/Elizabeth-Swaggerty/publication/280531703_Fanfiction_Exploring_in-_and_out-of-school_literacy_practices/links/563a5e4208ae405111a5864b/Fanfiction-Exploring-in-and-out-of-school-literacy-practices.pdf
+- [A20] K. Bahoric & E. Swaggerty, “Fanfiction: Exploring in- and out-of-school literacy practices” (2015). https://www.researchgate.net/profile/Elizabeth-Swaggerty/publication/280531703_Fanfiction_Exploring_in-_and_out-of-school_literacy_practices/links/563a5e4208ae405111a5864b/Fanfiction-Exploring-in-and_out-of-school_literacy_practices.pdf
 - [A21] Joseph Seering, “Reconsidering Self-Moderation.” *Proceedings of the ACM on Human-Computer Interaction*. https://dl.acm.org/doi/pdf/10.1145/3415178
 - [A22] Linyuan Lü, Matúš Medo, Chi Ho Yeung, Yicheng Zhang, Zi-Ke Zhang & Tao Zhou, “Recommender systems.” https://arxiv.org/pdf/1202.1112
 - [A23] Yuncong Li et al., “Modeling User Repeat Consumption Behavior for Online Novel Recommendation.” https://arxiv.org/abs/2209.01963

--- a/docs/blog/posts/2026-08-16-english-web-fiction-ecosystem.md
+++ b/docs/blog/posts/2026-08-16-english-web-fiction-ecosystem.md
@@ -130,7 +130,7 @@ Standard Ebooks 当前还明确提供可供 ereader 或 RSS reader 使用的 cat
 
 **第一，库存边界各异。** Royal Road、Scribble Hub 的榜单从站内作品出发；Top Web Fiction 从被列出的跨站作品出发；SpaceBattles、Sufficient Velocity 从论坛社区出发；Substack 从 newsletter publication 出发；作者站从单一作品或作者宇宙出发。[P1][P4][P6][P8][P10][P14][P22]
 
-**第二，排序信号各异。** Rising Stars 关注近期增长与榜单逻辑，Top Web Fiction 使用 reader boosts，论坛故事库暴露更新、watchers、views、replies 和标签，newsletter 依赖订阅与推荐网络。每一种排序都在回答不同问题。[P1][P6][P8][P10][P14]
+**第二，排序信号各异。** Rising Stars 关注近期增长与榜单逻辑，Top Web Fiction 使用 reader boosts，论坛故事库暴露更新、watchers、views、replies 和标签，newsletter 依赖订阅与推荐网络。每一种排序都对应一类问题。[P1][P6][P8][P10][P14]
 
 **第三，文本粒度各异。** 平台把 fiction 当作品对象，论坛把作品与线程绑定，Reddit 可以把一章当一帖，作者站按 chapter/arc/volume 组织，公共目录则把 edition、ebook 与书目记录放在中心。[P8][P12][P13][P22][P23][P27][P28]
 
@@ -256,7 +256,7 @@ WebNR 当前采用的轻量来源策略可以视为这张图的第一步：先�
 - [A17] C. M. Messina, “Tracing fan uptakes: Tagging, language, and ideological practices in The Legend of Korra fanfictions” (2019). https://wac.colostate.edu/docs/jwa/vol3/messina.pdf
 - [A18] A. Sereda, “‘Dirty stories saved my life’: Fanfiction as a source of emotional support” (2019). https://dspace.cuni.cz/bitstream/handle/20.500.11956/110315/130257705.pdf?sequence=1
 - [A19] S. Mosher, “Exploration of Derivative Works: The Appeal of Fanfiction to Creative Minds Within Fan Communities” (2024). https://escholarship.org/content/qt0qs5m0zg/qt0qs5m0zg.pdf?v=lg
-- [A20] K. Bahoric & E. Swaggerty, “Fanfiction: Exploring in- and out-of-school literacy practices” (2015). https://www.researchgate.net/profile/Elizabeth-Swaggerty/publication/280531703_Fanfiction_Exploring_in-_and_out-of-school_literacy_practices/links/563a5e4208ae405111a5864b/Fanfiction-Exploring-in-and_out-of-school_literacy_practices.pdf
+- [A20] K. Bahoric & E. Swaggerty, “Fanfiction: Exploring in- and out-of-school literacy practices” (2015). https://www.researchgate.net/profile/Elizabeth-Swaggerty/publication/280531703_Fanfiction_Exploring_in-_and_out-of-school_literacy_practices/links/563a5e4208ae405111a5864b/Fanfiction-Exploring-in-and-out-of-school-literacy-practices.pdf
 - [A21] Joseph Seering, “Reconsidering Self-Moderation.” *Proceedings of the ACM on Human-Computer Interaction*. https://dl.acm.org/doi/pdf/10.1145/3415178
 - [A22] Linyuan Lü, Matúš Medo, Chi Ho Yeung, Yicheng Zhang, Zi-Ke Zhang & Tao Zhou, “Recommender systems.” https://arxiv.org/pdf/1202.1112
 - [A23] Yuncong Li et al., “Modeling User Repeat Consumption Behavior for Online Novel Recommendation.” https://arxiv.org/abs/2209.01963

--- a/docs/blog/posts/2026-08-16-english-web-fiction-ecosystem.md
+++ b/docs/blog/posts/2026-08-16-english-web-fiction-ecosystem.md
@@ -1,0 +1,265 @@
+---
+title: 2026 英文网文去哪里找？跨平台目录、论坛故事库、newsletter、社区与公开目录地图
+date: 2026-08-16
+slug: english-web-fiction-ecosystem
+description: 从读者任务出发，梳理 Royal Road、Scribble Hub、Top Web Fiction、SpaceBattles、Sufficient Velocity、Reddit、Substack、作者站与公共电子书目录如何组成英文网文发现网络，并给出一条跨平台找书路线。
+categories:
+  - Reader guides
+  - Ecosystem
+  - Recommendations
+---
+
+# 2026 英文网文去哪里找？跨平台目录、论坛故事库、newsletter、社区与公开目录地图
+
+**直接答案：** 想找英文 web serial，最省力的路线通常分成五层。第一层用 **Royal Road Rising Stars / Complete** 与 **Scribble Hub Series Finder** 做高密度筛选；第二层用 **Top Web Fiction** 这类跨平台榜单发现作者站与小平台作品；第三层进入 **SpaceBattles、Sufficient Velocity、Reddit Serials、r/HFY** 这类论坛故事库和社区目录寻找长尾作品；第四层用 **Reddit、Novel Updates、Discord** 处理“像某本书”“某种机制”“某种情绪”这类语义需求；第五层用 **Substack、作者官网、RSS/邮件订阅** 持续追更。Project Gutenberg、Standard Ebooks、Wikisource 这类公共目录则承担稳定、可检索、可长期保存的经典作品发现层。[P1][P2][P4][P6][P8][P10][P12][P13][P14][P16][P21][P22][P27][P28][P29]
+
+WebNR 今天同时加入一个只做跳转发现的 **English Web-Fiction Discovery Starter**，把 Top Web Fiction、SpaceBattles Discover Stories、Sufficient Velocity Story Library、Reddit Serials Story Directory 与 r/HFY 放进同一个轻量入口。它保存 WebNR 自己写的说明和公开入口 URL，阅读、账号、内容警告、评论与作品权利继续由原站呈现。
+
+[添加 English Web-Fiction Discovery Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fenglish-web-fiction-discovery-starter){ .md-button .md-button--primary }
+
+## 摘要
+
+本文以 **2026 年 8 月 16 日**公开可观察的英文网文发现入口为样本，结合 30 个平台、目录、社区、作者站、公共目录与官方说明页面，以及 26 项参与式文化、社会阅读、fanfiction、平台化文化生产、数字文学与推荐系统研究，回答一个读者导向的问题：当英文 web fiction 分散在平台、论坛、作者站、newsletter 与公共目录里时，怎样用更少的试错成本找到真正适合自己的下一本？
+
+核心发现是一张“发现网络”。平台原生榜单提供新鲜度和状态字段，跨平台目录提供横向迁移，论坛故事库提供作品与讨论共存的长尾空间，读者社区提供自然语言推荐，newsletter 与作者站提供连续订阅，公共目录提供稳定书目与长期可访问入口。读者在这些层之间移动时，最有价值的携带物是自己的偏好向量：参照作品、题材、机制、篇幅、连载状态、更新节奏、关系结构、内容边界与阅读设备。[A1][A2][A3][A8][A9][A22][A23][A24][A25][A27]
+
+**关键词：** 英文网文；web serial；web fiction；Royal Road；Top Web Fiction；SpaceBattles；newsletter；社会阅读；跨平台发现
+
+本文延续 WebNR 前两篇读者研究：[英文连载小说平台怎么选？](/blog/2026/08/10/english-serial-fiction-platforms/) 负责“去哪里读”，[网文读者都去哪里找书和聊书？](/blog/2026/08/12/web-novel-reader-communities/) 负责“去哪里问”。这一篇把两者之间的连接层展开：目录、论坛故事库、跨平台榜单、newsletter、作者站与公共目录怎样共同完成发现。
+
+## 研究问题、样本与判断方法
+
+本文的研究问题是：**一个英文网文读者怎样跨越平台边界，建立一条稳定、可复用的找书路径？**
+
+采样分成六组。第一组是平台原生发现页，包括 Royal Road 与 Scribble Hub；第二组是跨平台目录与榜单，以 Top Web Fiction 为代表；第三组是论坛故事库与社区目录，包括 SpaceBattles、Sufficient Velocity、Reddit Serials 与 r/HFY；第四组是读者社区与策展层，包括 Reddit 类型社区、Novel Updates、Goodreads 与 Discord；第五组是 newsletter 与作者自托管入口，包括 Substack Fiction、SFWA 的 serial newsletter 实践资料、The Wandering Inn 与 Parahumans；第六组是 Project Gutenberg、Standard Ebooks、Wikisource 这类公共目录。[P1]-[P30]
+
+观察字段包括：作品发现方式、筛选粒度、连载状态、更新信号、标签、跨站链接、公开检索性、持续订阅能力、讨论结构、内容边界与入口稳定性。平台首页的“热门”只承担一种信号；当平台同时提供状态、标签、更新时间、字数、类型、论坛讨论和跨站链接时，这些字段共同决定它适合哪类找书任务。
+
+学术部分使用 26 项研究建立解释框架。参与式文化与 affinity space 研究解释读者、作者、评论者之间持续交换信息的机制；数字社会阅读研究解释书评、列表、标签与讨论如何形成阅读基础设施；平台化研究解释排序、界面与商业规则怎样塑造文化可见性；推荐系统研究解释结构化特征与行为历史怎样压缩候选集合；数字文学研究则帮助理解网页、浏览器、链接与基础设施本身怎样进入文学传播。[A1]-[A26]
+
+## 一张表：按“找书任务”选择入口
+
+| 读者任务 | 第一入口 | 第二入口 | 关键字段 |
+| --- | --- | --- | --- |
+| 找正在快速上升的新连载 | Royal Road Rising Stars | Scribble Hub Trending / Finder | 更新时间、状态、标签、篇幅 |
+| 找已经完结的长篇 | Royal Road Complete | Top Web Fiction complete / all-time | 完结状态、总量、历史口碑 |
+| 找某种精确机制 | Scribble Hub Series Finder | r/ProgressionFantasy、r/litrpg | 必选标签、排除标签、字数、更新 |
+| 找平台外作者站作品 | Top Web Fiction | Reddit 类型社区、作者官网 | 标签、跨站 URL、读者 boost |
+| 找论坛原生长篇 | SpaceBattles / Sufficient Velocity Story Library | 各自 Original Fiction 分区 | threadmark、字数、状态、标签 |
+| 找 Reddit 原生连载 | Reddit Serials directory、r/HFY | subreddit 内索引与系列链接 | flair、series、上一章/下一章 |
+| 找亚洲翻译网文 | Novel Updates Recommendation Lists | r/noveltranslations 等社区 | 原语言、翻译状态、题材、读者列表 |
+| 找持续推送 | Substack Fiction、作者 newsletter | RSS、作者官网 | 邮件频率、目录页、更新节奏 |
+| 找经典免费文本 | Project Gutenberg、Standard Ebooks、Wikisource | WebNR 公共来源 | 版本、格式、版权/许可说明 |
+| 找“像 A 但更偏 B”的作品 | 专门 Reddit / 论坛推荐区 | Discord 读者群 | 参照作品、理由、情绪、机制 |
+
+这张表的重点在“任务”。同一个平台在不同任务里的价值差异很大。Royal Road 的 Rising Stars 适合捕捉快速上升作品，Complete 适合降低追更风险；Scribble Hub 的 Series Finder 适合把需求拆成字段；Top Web Fiction 适合跨站迁移；论坛故事库适合寻找平台首页覆盖较少的作品；newsletter 适合持续关系；公共目录适合稳定入口。推荐研究长期把候选生成、排序与用户偏好表达视为多阶段过程，社会阅读研究则展示了评论、书单与讨论如何补充结构化字段。[A3][A9][A10][A22][A23][A24]
+
+## 第一层：平台原生榜单负责“快”和“细”
+
+### Royal Road：把状态、新鲜度和增长速度放在一起看
+
+Royal Road 的 Rising Stars 当前直接展示作品状态、标签、followers、页数、浏览量、章节与发布日期，页面还按类型提供 Rising Stars 子榜。[P1] Complete 则把完结作品集中在一个明确入口。[P2] 对长篇连载读者，这两种入口承担两种互补任务：一个寻找正在形成读者群的新作品，一个寻找已经形成完整阅读弧线的作品。
+
+Royal Road 的 Recommendations 论坛再提供一层人工语义检索。[P3] 当读者可以写出“喜欢 A 的升级速度、B 的队伍结构、C 的世界观，同时偏好某个篇幅和状态”，社区回复会把作品标签之外的阅读体验带进候选集合。平台内部因此形成一条很完整的链：榜单压缩范围，状态筛选控制连载风险，论坛处理复杂偏好。
+
+### Scribble Hub：把读者需求写成查询条件
+
+Scribble Hub Series Finder 当前提供章节数、每周章节、收藏、评分、读者、评论、最后更新、页数、浏览量、总字数、题材、标签、内容警告与作品状态等条件。[P4] 对口味已经很清楚的读者，这种结构更接近数据库查询：先把“至少多长、最近多活跃、想看哪些标签、希望避开什么标签”写成条件，再从较小的结果集合中阅读简介与评论。
+
+Scribble Hub 的 I’m Looking For 论坛承接另一类请求：模糊记忆、组合偏好、相似作品、某个罕见桥段。[P5] 结构化过滤与自然语言推荐放在同一平台里，形成“字段筛选 → 人类语义补充”的两步路线。在线推荐系统研究也长期面对相似分工：算法擅长规模化排序，人类描述擅长表达临时情境与复杂理由。[A22][A23][A24]
+
+## 第二层：Top Web Fiction 把“平台”变成“作品入口”
+
+Top Web Fiction 当前把自己定义为由社区维护的 online serial 与 indie fiction listing；读者通过 boost 影响周榜，网站同时提供 all-time favourites、complete、新收录和大量标签入口。[P6][P7] 这个结构的价值来自跨平台：榜单条目的终点可以是独立作者站，也可以是大型连载平台，读者从作品与类型出发，再跳向实际托管位置。
+
+这与平台原生榜单形成很有意思的差别。平台原生榜单天然围绕站内库存组织；跨平台榜单围绕“被列出的作品”组织。对读者而言，前者适合高密度浏览一个生态，后者适合打破站点习惯、发现作者自托管项目和较小平台。
+
+Top Web Fiction 的历史也展示了这种独立目录的基础设施意义。它的 About 页面记录了 2020 年重建并与旧 Web Fiction Guide 脱钩的过程。[P7] 数字文学研究长期强调浏览器、链接、界面和发行基础设施共同塑造作品被看见的方式；平台化研究进一步指出文化商品的可见性与平台机制持续互动。[A2][A25][A26] 从这个视角看，跨平台目录是一种很轻的“互操作层”：它保存发现关系，把阅读继续交给作品实际所在的位置。
+
+**WebNR 的对应策略**也采用这一思路。新加入的 English Web-Fiction Discovery Starter 只保存入口、WebNR 自写说明与发现标签，让源站继续承担作品内容、评论、账号和社区规则。对读者，结果是一个可组合的入口；对来源方，流量与内容上下文仍然留在原站。
+
+## 第三层：论坛故事库把“作品”和“讨论”放在同一空间
+
+### SpaceBattles：从论坛线程进化出的故事库
+
+SpaceBattles 的 Discover Stories 当前把 Creative Writing 与 Quests 中的作品以接近传统故事档案的方式组织，并同时覆盖 original 与 fan fiction。[P8] Original Fiction 分区则明确聚焦原创作品，当前页面提供标签、字数、状态、更新时间与讨论线程。[P9] 这类结构的独特之处在于作品正文、threadmark、读者回复、作者更新和论坛身份共享同一个社区上下文。
+
+对读者来说，论坛故事库特别适合两类需求。第一类是长尾：作品可以在一个大型兴趣社区里慢慢累积读者，而其发现路径可能来自论坛标签、推荐讨论和签名链接。第二类是连续反馈：章节发布后，讨论直接沿线程发生，阅读与社区参与的距离很短。fanfiction 与 affinity-space 研究已经反复观察到读者、写作者和反馈者角色之间的流动，以及反馈关系对创作参与的影响。[A13][A14][A16][A17][A18][A19][A20]
+
+### Sufficient Velocity：Story Library 让论坛作品获得结构化检索
+
+Sufficient Velocity 的 Story Library 当前提供标签、排除标签、字数、ongoing/complete/hiatus/dropped、forum、作者与更新时间等过滤器；Original Fiction 也作为独立分区存在。[P10][P11] 这意味着“论坛作品”已经具备接近平台目录的发现能力，同时保留论坛的讨论结构。
+
+读者可以把它理解成另一类 web fiction 平台：作品的组织单位依旧是社区线程和 threadmark，发现层则增加了 library 视图。数字阅读平台研究提醒我们，浏览器 frame、界面与基础设施都会参与塑造阅读；论坛故事库正好展示了同一文本在“讨论线程”和“故事库视图”之间切换时，阅读体验怎样发生变化。[A25][A26]
+
+## 第四层：Reddit 把“类型社区”变成连载渠道和推荐网络
+
+Reddit Serials Story Directory 当前仍公开一个 Ongoing Serials 入口，按 Fantasy、SciFi、Romance、LitRPG、Horror、Urban Fantasy 等题材与作者组织链接。[P12] r/HFY 则把原创写作、系列连载、找书和社区索引结合起来，当前规则使用 OC-OneShot、OC-FirstOfSeries、OC-Series 等分类，并维护 Classics、Must Read、All Authors、All Series 与 Looking For Story 等入口。[P13]
+
+Reddit 的强项来自“类型社区先于平台”。r/ProgressionFantasy、r/litrpg、r/Fantasy 等空间把某一类读者语言持续积累起来。[P17][P18][P19] 读者进入这些社区时，可以直接使用 progression speed、system-heavy、crafting、kingdom building、slow burn、found family 等高信息密度描述。2026 年 8 月的 r/noveltranslations 推荐线程也继续鼓励读者写清楚自己寻找的书、已经喜欢的作品和关键要求。[P30]
+
+这种社区结构与参与式文化研究十分接近：成员通过推荐、评论、标签、索引与规则共同维护知识环境。[A1][A14][A16][A21] 对发现来说，一条高质量推荐串兼具两个时间尺度：当下帮助发帖者，随后又作为可检索页面继续帮助后来读者。
+
+## 第五层：newsletter 与作者站负责“跟随”，同时形成另一种发现
+
+Substack 当前提供 Fiction 分类与 Top Fiction 页面，页面聚合原创 fiction、文学写作与相关出版内容。[P14] SFWA 在 2026 年 4 月专门讨论了使用 newsletter platform 发布 serial fiction 的实践，说明邮件平台已经成为英文连载的现实发行路径之一。[P15]
+
+newsletter 的发现逻辑与 Royal Road 很不一样。榜单平台强调统一库存中的排序与筛选；newsletter 强调订阅关系、作者声音、邮件到达和推荐网络。读者一旦找到喜欢的作者，后续章节可以通过 inbox、reader app 或网页目录持续到达。对于已经形成读者关系的项目，这种“推送式连续性”很有价值。
+
+作者自托管站则把控制权进一步移向作品本身。The Wandering Inn 的官方目录当前明确区分 Web Serial、Audiobook 与 Ebook，并以 volume、chapter、interlude 组织长篇阅读。[P22] Parahumans 2 的目录用 arc 和 chapter 组织 Ward，同时保留 Glow-worm 等过渡内容。[P23] 这些例子显示，英文 web serial 的“平台”有时就是作者自己维护的网站，外部发现入口承担把读者带到这里的任务。
+
+从数字文学视角看，作者站把 URL、目录结构、章节导航与作品身份绑定在一起；从平台化视角看，它也提供一条相对独立的发行路径。[A2][A25][A26] 对读者，最实用的动作是把“发现”和“跟随”分开：发现阶段使用跨平台目录与社区，找到作品后再订阅作者最稳定的官方更新渠道。
+
+## 第六层：公共目录解决“稳定文本发现”，与实时连载形成互补
+
+Project Gutenberg 当前提供数万本免费电子书并支持浏览器在线阅读与多种下载格式；Standard Ebooks 提供经过编辑制作的公共领域电子书目录，并公开 ebook catalog feeds；Wikisource 提供基于作品和版本的自由文本入口。[P27][P28][P29]
+
+这些目录与当代 web serial 的更新节奏差异很大，却在“网页阅读生态”里承担重要补充角色。一个本地优先阅读器既可以承接自己导入的 TXT，也可以通过公开、稳定、授权清晰的目录发现经典作品；同一个读者又可以从 Top Web Fiction、论坛或 newsletter 追当代连载。两类来源共同扩展“浏览器里找书和读书”的边界。
+
+Standard Ebooks 当前还明确提供可供 ereader 或 RSS reader 使用的 catalog feeds。[P28] 这种公开机器接口对 WebNR 特别有价值，因为它把来源契约写得更清楚：目录、格式、许可与更新方式都有稳定说明。WebNR 当前的公共领域来源计划也优先使用这种具有清晰 provenance 与 reuse boundary 的入口。
+
+## 跨语言读者还有一条旁路：Novel Updates 与翻译社区
+
+英文阅读生态还包含大量翻译网文。Novel Updates 的 Recommendation Lists 当前持续出现读者维护的主题书单，读者可以沿作品、题材、译名与列表关系继续扩展。[P16] 这类策展层尤其适合中文、日文、韩文来源作品，因为同一部作品可能拥有原文名、罗马字、英文译名、出版名和多个翻译入口。
+
+对于这类任务，“英文网文发现”更像跨语言书目解析。读者需要携带原语言、翻译状态、题材、关系结构、章节进度和译名线索。社会阅读研究对 Goodreads、在线书评与读者书单的分析说明，书目数据与读者解释共同形成作品的接受痕迹；Novel Updates 把这种机制放进翻译网文语境里。[A3][A4][A5][A6][A7][A9][A10][A12]
+
+## 为什么一个统一“总榜”很难覆盖全部英文网文
+
+这份地图呈现出四种结构性差异。
+
+**第一，库存边界不同。** Royal Road、Scribble Hub 的榜单从站内作品出发；Top Web Fiction 从被列出的跨站作品出发；SpaceBattles、Sufficient Velocity 从论坛社区出发；Substack 从 newsletter publication 出发；作者站从单一作品或作者宇宙出发。[P1][P4][P6][P8][P10][P14][P22]
+
+**第二，排序信号不同。** Rising Stars 关注近期增长与榜单逻辑，Top Web Fiction 使用 reader boosts，论坛故事库暴露更新、watchers、views、replies 和标签，newsletter 依赖订阅与推荐网络。每一种排序都在回答不同问题。[P1][P6][P8][P10][P14]
+
+**第三，文本粒度不同。** 平台把 fiction 当作品对象，论坛把作品与线程绑定，Reddit 可以把一章当一帖，作者站按 chapter/arc/volume 组织，公共目录则把 edition、ebook 与书目记录放在中心。[P8][P12][P13][P22][P23][P27][P28]
+
+**第四，社区记忆不同。** 公开论坛、Reddit、Top Web Fiction 和目录页容易形成长期 URL；Discord 与 newsletter 更强调持续关系和时间流；公共目录强调版本与书目稳定性。在线社区与社会阅读研究都表明，平台结构会改变哪些互动容易保存、哪些信息容易再次检索。[A1][A3][A9][A16][A21]
+
+因此，读者获得更高命中率的关键是组合入口，让每一层负责自己擅长的任务。
+
+## 一条可复用的 15 分钟找书流程
+
+### 第 1 步：写出一个“偏好向量”
+
+先记录五个字段：参照作品、最重要的题材/机制、希望的篇幅、连载状态、内容边界。比如：
+
+> 参照：The Wandering Inn、Mother of Learning；偏好：成长、团队、世界持续展开；篇幅：长篇；状态：ongoing 或 complete；节奏：章节稳定更新。
+
+这种写法同时适合平台筛选和社区提问。
+
+### 第 2 步：用平台原生筛选制造第一批候选
+
+先跑 Royal Road Rising Stars / Complete 与 Scribble Hub Series Finder。[P1][P2][P4] 目标是快速收集 10–20 个候选，只记录标题、入口、状态、标签和一两句理由。
+
+### 第 3 步：用跨平台目录扩展站外候选
+
+再看 Top Web Fiction 的 Popular、New Listings、All-Time 与标签入口。[P6][P7] 把作者站、小平台和独立 serial 加入同一个候选表。今天上线的 WebNR English Web-Fiction Discovery Starter 也把这一步需要的几个跨站入口收在一起。
+
+### 第 4 步：去论坛故事库找长尾
+
+根据题材进入 SpaceBattles Discover Stories / Original Fiction 与 Sufficient Velocity Story Library / Original Fiction。[P8][P9][P10][P11] 重点看 tag、status、word count、last update 和讨论密度，然后把有吸引力的作品加入候选。
+
+### 第 5 步：把复杂条件交给读者社区
+
+从候选里选三本最接近目标的作品，再去 r/ProgressionFantasy、r/litrpg、r/Fantasy、Royal Road Recommendations、Scribble Hub I’m Looking For 或对应 Discord 社区搜索旧帖与提出请求。[P3][P5][P17][P18][P19][P21] 这一步的输入已经很具体，社区更容易给出高质量相似项。
+
+### 第 6 步：确认官方跟随渠道
+
+找到作品后，确认其官方站、平台页面、newsletter、RSS、Discord 公告或作者主页。The Wandering Inn 这类项目把 web serial 目录放在自己的站点；newsletter serial 则把持续更新送到订阅渠道。[P14][P15][P22]
+
+### 第 7 步：把阅读与发现分开管理
+
+发现入口负责“下一本在哪里”，阅读器负责“我正在读什么”。WebNR 的本地优先设计适合后者：TXT、书库与进度保持在浏览器侧；外部平台与社区继续承担发现、讨论和官方更新。这样一来，平台迁移、作者换站、某个目录热度变化时，个人阅读状态仍然保持稳定。
+
+## 反向证据与样本边界：这张地图会偏向公开 Web
+
+公开网页天然更容易进入本文样本。Top Web Fiction、公开论坛、Reddit、作者站、公开 newsletter 页面和公共目录都拥有可搜索 URL；私密 Discord、封闭 Patreon 社区、邮件正文、作者群聊和邀请制读书会留下的公开证据更少。搜索可见度因此会放大开放网页层的存在感。
+
+另外，各入口的“活跃”含义也不同。Royal Road 的当前榜单变化很快；Top Web Fiction 的 boost 以周为周期；论坛故事可以持续多年；newsletter 依赖作者发送节奏；公共目录的更新重点是新版本与新收录。把这些信号压成一个统一热度数字会丢失大量语境。[P1][P6][P8][P10][P14][P27][P28]
+
+平台上的高曝光作品还可能形成反馈回路：获得更多展示后积累更多阅读与互动，再进一步提高可见性。推荐系统与平台化文化生产研究为理解这种循环提供了成熟框架。[A2][A22][A23][A24] 所以本文把“推荐哪个入口”定义为任务匹配，而把“哪个生态最大”留给需要统一口径、统一时间窗和独立流量数据的研究。
+
+## 原创综合：英文网文发现正在形成一个“松耦合书目网络”
+
+把这些入口放在一起，会看到一个很适合 WebNR 的结构：**作品托管、作品发现、社会推荐、持续订阅和个人阅读状态正在分离。**
+
+作品托管由 Royal Road、Scribble Hub、论坛、作者站、Substack 等承担；发现由站内榜单、Top Web Fiction、Story Library、搜索引擎和读者列表承担；社会推荐由 Reddit、论坛、Discord、评论区承担；持续订阅由 follow、email、RSS、Discord announcement 承担；个人阅读状态则可以由本地优先阅读器保存。
+
+这种分工带来一个实用结果：读者可以把“平台忠诚”转换成“路径忠诚”。路径本身稳定：**结构化筛选 → 跨平台扩展 → 社区语义检索 → 官方跟随 → 本地阅读状态。** 具体站点可以随着题材与作品变化，路径仍然可复用。
+
+从研究角度，这也解释了为什么 web fiction 很难被一个单站数据库完整表示。作品身份可能跨越多个站点；作者可能同时维护免费 serial、ebook、audiobook、Patreon 或 newsletter；同一作品的讨论又分布在平台评论、Reddit、Discord 与论坛。真正有价值的发现基础设施更接近图：节点是作品、作者、平台、目录、社区与版本，边是“托管于”“推荐于”“讨论于”“订阅于”“改编为”“收录于”。[A2][A9][A25][A27]
+
+WebNR 当前采用的轻量来源策略可以视为这张图的第一步：先记录公开、可解释、来源明确的入口和 provenance，再逐渐为具有清晰机器接口与授权边界的来源增加结构化能力。
+
+## 结论：找英文网文，从“选平台”升级成“走路径”
+
+2026 年的英文 web fiction 生态已经足够分散，也足够互联。Royal Road 与 Scribble Hub 提供高密度平台发现；Top Web Fiction 提供跨站排名；SpaceBattles 与 Sufficient Velocity 把论坛创作整理成故事库；Reddit Serials 与 r/HFY 展示社区原生连载；Novel Updates、Reddit 与 Discord提供读者策展和语义推荐；Substack、newsletter 与作者官网负责持续跟随；Project Gutenberg、Standard Ebooks、Wikisource 提供稳定的公开书目层。[P1]-[P30]
+
+对读者，最有效的策略可以压缩成一句话：**先用字段找到候选，再用跨平台目录扩大范围，用社区解释口味，最后回到官方入口持续跟随。**
+
+这也是 WebNR 接下来扩展来源时最值得坚持的方向：围绕读者任务增加可组合入口，让来源的身份、边界与更新方式保持清晰，让本地阅读体验与外部发现网络彼此连接。
+
+---
+
+## 一手、平台与社区来源
+
+- [P1] Royal Road, Rising Stars — https://www.royalroad.com/fictions/rising-stars
+- [P2] Royal Road, Complete — https://www.royalroad.com/fictions/complete
+- [P3] Royal Road, Recommendations forum — https://www.royalroad.com/forums/5850
+- [P4] Scribble Hub, Series Finder — https://www.scribblehub.com/series-finder/
+- [P5] Scribble Hub Forum, I’m Looking For — https://forum.scribblehub.com/forums/im-looking-for.15/
+- [P6] Top Web Fiction, Popular Stories — https://topwebfiction.com/
+- [P7] Top Web Fiction, About — https://topwebfiction.com/about/
+- [P8] SpaceBattles, Discover Stories — https://forums.spacebattles.com/library/stories/
+- [P9] SpaceBattles, Original Fiction — https://forums.spacebattles.com/forums/original-fiction.48/
+- [P10] Sufficient Velocity, Story Library — https://forums.sufficientvelocity.com/library/stories/
+- [P11] Sufficient Velocity, Original Fiction — https://forums.sufficientvelocity.com/forums/original-fiction.157/
+- [P12] Reddit Serials Story Directory — https://redditserials.wordpress.com/
+- [P13] Reddit, r/HFY — https://www.reddit.com/r/HFY/
+- [P14] Substack, Top Fiction Newsletters — https://substack.com/top/fiction
+- [P15] Science Fiction & Fantasy Writers Association, “Using a Newsletter Platform for Serial Fiction” (2026-04-14) — https://sfwa.org/2026/04/14/using-a-newsletter-platform-for-serial-fiction/
+- [P16] Novel Updates, Recommendation Lists — https://www.novelupdates.com/recommendation-lists/
+- [P17] Reddit, r/ProgressionFantasy — https://www.reddit.com/r/ProgressionFantasy/
+- [P18] Reddit, r/litrpg — https://www.reddit.com/r/litrpg/
+- [P19] Reddit, r/Fantasy — https://www.reddit.com/r/Fantasy/
+- [P20] Goodreads, Recommendation Requests — https://www.goodreads.com/recommendation_requests
+- [P21] Discord, Server Discovery / Discover — https://support.discord.com/hc/en-us/articles/360023968311-Server-Discovery
+- [P22] The Wandering Inn, Table of Contents — https://wanderinginn.com/table-of-contents/
+- [P23] Parahumans 2, Table of Contents — https://www.parahumans.net/table-of-contents/
+- [P24] Tapas Help Center, What is Tapas Community? — https://help.tapas.io/hc/en-us/articles/4409607638171-What-is-Tapas-Community
+- [P25] Honeyfeed, About — https://www.honeyfeed.fm/about/
+- [P26] Wattpad official Google Play listing — https://play.google.com/store/apps/details?id=wp.wattpad
+- [P27] Project Gutenberg — https://www.gutenberg.org/
+- [P28] Standard Ebooks, Browse Ebooks — https://standardebooks.org/ebooks
+- [P29] English Wikisource — https://en.wikisource.org/
+- [P30] Reddit, r/noveltranslations, Monthly Recommendation Thread, 2026-08-09 — https://www.reddit.com/r/noveltranslations/comments/1vjx4jf/monthly_recommendation_thread_august_09_2026/
+
+## 学术与研究来源
+
+- [A1] Henry Jenkins & Ravi Purushotma, *Confronting the Challenges of Participatory Culture: Media Education for the 21st Century*. https://openresearchlibrary.org/ext/api/media/035b2379-8107-48cf-a023-14a25c7f4243/assets/external_content.pdf
+- [A2] David B. Nieborg & Thomas Poell, “The platformization of cultural production: Theorizing the contingent cultural commodity.” https://pure.uva.nl/ws/files/31895348/The_platformization_of_cultural_production.pdf
+- [A3] Hana Khaled Abdelrahman Shamaa, *Online Social Reading Platforms: An Investigation into the Participatory Cultures on Goodreads, LibraryThing, Amazon and Wattpad* (2021). https://thesis.eur.nl/pub/60440/Khaled-Abdelrahman-Shamaa-Hana.pdf
+- [A4] N. Wyatt, “Finding good reads on Goodreads.” *Reference & User Services Quarterly*. https://www.jstor.org/stable/pdf/refuseserq.51.4.319.pdf
+- [A5] M. Willand, J. Beck & N. Reiter, “Reading Data: On Digital Reception Studies” (2018). https://www.academia.edu/download/76362237/34.pdf
+- [A6] P. Holur, S. Shahsavari, E. Ebrahimzadeh & R. Timothy, “Modeling Social Readers: Novel Tools for Addressing Reception from Online Book Communities.” https://www.academia.edu/download/77198721/2105.01150v2.pdf
+- [A7] L. De Greve & G. Martens, “Judging a Book by Its Criticism: A digital analysis of professional and community driven literary criticism” (2022). https://journal.dhbenelux.org/wp-content/uploads/2022/07/jdhbenelux4_09-DeGreve.pdf
+- [A8] E. Beale, *Literally: social reading and meaning-making* (2018). https://rshare.library.torontomu.ca/articles/thesis/Literally_social_reading_and_meaning-making/14652126/files/28133889.pdf
+- [A9] P. Boot, “The Voice of the Reader: The Landscape of Online Book Discussion in the Netherlands, 1997–2016” (2020). https://pure.knaw.nl/portal/files/37457470/Boot_EHR_preprint.pdf
+- [A10] M. Koolen, P. Boot & J. J. van Zundert, “Online book reviews and the computational modelling of reading impact” (2020). https://ceur-ws.org/Vol-2723/long13.pdf
+- [A11] J. Frederick, “C&C and Fandom Squee: Considering Fanfiction Reader Reviews on Archive of Our Own.” https://theseacs.org/wp-content/uploads/Frederick_CC.pdf
+- [A12] M. Koolen, J. L. Neugarten & P. Boot, “‘This book makes me happy and sad and I love it’: A Rule-based Model for Extracting Reading Impact from English Book Reviews” (2022). https://repository.ubn.ru.nl/bitstream/handle/2066/298014/298014.pdf?sequence=1
+- [A13] J. C. Lammers, A. M. Magnifico & J. S. Curwood, “Exploring Tools, Places, and Ways of Being: Audience Matters for Developing Writers.” https://www.academia.edu/download/31594525/Lammers_Magnifico_Curwood_2014_Exploring_Tools_Places_and_Ways_of_Being_AuthorsAcceptedManuscript.pdf
+- [A14] B. Thomas, “‘Stand out from the crowd!’: literary advice in online writing communities” (2021). https://library.oapen.org/bitstream/handle/20.500.12657/46124/1/2021_Book_WritingManualsForTheMasses.pdf#page=166
+- [A15] F. Silberstein-Bamford, “The ‘fanfic lens’: Fan writing’s impact on media consumption” (2023). https://www.researchgate.net/profile/Fabienne-Silberstein-Bamford/publication/371539416_The_'Fanfic_Lens'_Fan_Writing's_Impact_on_Media_Consumption/links/6489679b9605ba270e436998/The-Fanfic-Lens-Fan-Writings-Impact-on-Media-Consumption.pdf
+- [A16] N. Lamerichs, *Productive Fandom* (2018). https://library.oapen.org/bitstream/handle/20.500.12657/28223/1001770.pdf
+- [A17] C. M. Messina, “Tracing fan uptakes: Tagging, language, and ideological practices in The Legend of Korra fanfictions” (2019). https://wac.colostate.edu/docs/jwa/vol3/messina.pdf
+- [A18] A. Sereda, “‘Dirty stories saved my life’: Fanfiction as a source of emotional support” (2019). https://dspace.cuni.cz/bitstream/handle/20.500.11956/110315/130257705.pdf?sequence=1
+- [A19] S. Mosher, “Exploration of Derivative Works: The Appeal of Fanfiction to Creative Minds Within Fan Communities” (2024). https://escholarship.org/content/qt0qs5m0zg/qt0qs5m0zg.pdf?v=lg
+- [A20] K. Bahoric & E. Swaggerty, “Fanfiction: Exploring in- and out-of-school literacy practices” (2015). https://www.researchgate.net/profile/Elizabeth-Swaggerty/publication/280531703_Fanfiction_Exploring_in-_and_out-of-school_literacy_practices/links/563a5e4208ae405111a5864b/Fanfiction-Exploring-in-and-out-of-school-literacy-practices.pdf
+- [A21] Joseph Seering, “Reconsidering Self-Moderation.” *Proceedings of the ACM on Human-Computer Interaction*. https://dl.acm.org/doi/pdf/10.1145/3415178
+- [A22] Linyuan Lü, Matúš Medo, Chi Ho Yeung, Yicheng Zhang, Zi-Ke Zhang & Tao Zhou, “Recommender systems.” https://arxiv.org/pdf/1202.1112
+- [A23] Yuncong Li et al., “Modeling User Repeat Consumption Behavior for Online Novel Recommendation.” https://arxiv.org/abs/2209.01963
+- [A24] Hannes Rosenbusch & Erdem Ozan Meral, “Which books do I like?” https://arxiv.org/abs/2503.03300
+- [A25] Simone Murray, “Charting the digital literary sphere.” *Contemporary Literature* (2015). https://cl.uwpress.org/content/wpcl/56/2/311.full-text.pdf
+- [A26] T. Barnett, “Read in Browser: Reading platforms, frames, interfaces, and infrastructure.” *Participations* (2019). https://www.participations.org/16-01-15-barnett.pdf


### PR DESCRIPTION
## Why
The 2026-08-16 editorial calendar requires a substantial reader-facing asset answering where readers can discover English web fiction beyond one platform. This article connects platform-native discovery, cross-platform indexes, forum story libraries, reader communities, newsletters, author sites, and public catalogs into one reusable discovery path.

## Research scope
- 30 current primary/platform/community sources sampled across Royal Road, Scribble Hub, Top Web Fiction, SpaceBattles, Sufficient Velocity, Reddit, Substack/newsletters, author-run serial sites, Novel Updates, Discord, and public ebook catalogs
- 26 academic/research sources spanning participatory culture, social reading, fandom, online reviews, platformization, digital literary infrastructure, and recommender systems
- explicit method, counterevidence/sample-boundary section, and original synthesis
- final author-prose scan removed defensive/negative constructions required by the pinned research-blog skill

## Product linkage
The guide links to the English Web-Fiction Discovery Starter added by #91. #91 is already squash-merged to main, so the public CTA targets a source that is part of the current product tree.

## Scope
Adds one substantial blog post only. Existing routes, content, sources, reader behavior, analytics, and product code remain unchanged.

## Validation
Quality CI is authoritative for documentation build/output validation, application build/analytics/source checks, production-evidence contract, and browser journeys. After CI is green, the full diff, references, rendered-output expectations, comments, and merge state will be re-reviewed from scratch before squash merge.

## Risk / rollback
Low and content-only. Rollback is a corrective PR removing or revising this article.

## Production acceptance
After squash merge, verify the exact canonical documentation build for the merge commit, confirm the public article at `/blog/2026/08/16/english-web-fiction-ecosystem/`, confirm its CTA resolves the new discovery starter, confirm sitemap/feed discovery where applicable, and re-check the canonical GA4/full-URL disclosure and an existing article as representative unaffected behavior.