### PR TITLE
feat: add Chinese web-fiction platform discovery source

### DIFF
--- a/public/sources/chinese-web-fiction-platforms-starter/README.txt
+++ b/public/sources/chinese-web-fiction-platforms-starter/README.txt
@@ -1,0 +1,61 @@
+Chinese Web-Fiction Platforms Starter
+=====================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/chinese-web-fiction-platforms-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fchinese-web-fiction-platforms-starter
+
+Purpose
+-------
+This WebNR-maintained source is a link-only discovery directory for official
+Chinese web-fiction platforms reviewed on 2026-08-17. It helps readers reach
+current first-party browsing and discovery surfaces while leaving reading,
+accounts, payments, comments, rankings, age gates, and work-specific rights at
+the origin platform.
+
+Included discovery routes
+-------------------------
+- 起点中文网 (Qidian) — official platform home and catalog discovery
+- 晋江文学城 (JJWXC) — official public work-library discovery
+- 纵横中文网 (Zongheng) — official platform home, categories, rankings, and library
+
+Content and rights boundary
+---------------------------
+The index contains only official destination URLs plus short WebNR-authored
+descriptions and labels. It does not copy story text, chapter lists, covers,
+rankings, reviews, comments, author profiles, account data, or platform-owned
+catalog data.
+
+The reviewed origin terms and legal notices reserve platform and creator rights.
+Qidian's current user agreement reserves service content and prohibits
+unauthorized copying, distribution, derivative use, and related reuse. JJWXC's
+current user agreement and authorization notices reserve site information and
+creator works and prohibit unauthorized copying, downloading, distribution, and
+commercial use. Zongheng's current legal notice restricts modification,
+distribution, recreation, copying, reposting, and other reuse without permission.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the official origin page. WebNR performs no runtime API,
+HTML, feed, or chapter polling for this starter, so it creates no automated
+origin-site crawl, CORS, cookie, login, rate-limit, or pagination dependency.
+WebNR does not automate accounts, payments, VIP access, age verification, DRM,
+captchas, robots restrictions, or other access controls.
+
+Audit boundary
+--------------
+The public landing routes and rights/access boundaries were rechecked on
+2026-08-17. Direct robots-file retrieval was not relied on for admission because
+this source sends no automated requests to the origins. A richer adapter would
+require a separate audit that can reproduce robots behavior, machine-interface
+permission, request cadence, authentication state, pagination, timeouts,
+provenance, attribution, update/deletion behavior, and work-level rights with
+versioned fixtures.
+
+Last verified
+-------------
+2026-08-17

--- a/public/sources/chinese-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/chinese-web-fiction-platforms-starter/search_index.yml
@@ -1,0 +1,47 @@
+chinese-web-fiction-platforms/qidian.md:
+  title: 起点中文网 — 官方小说发现入口
+  author: 起点中文网
+  description: 起点中文网的官方入口，提供分类、榜单、完本、免费等读者发现路径。WebNR 仅保存官方跳转链接与自写说明，不复制作品、章节、榜单、评论或平台目录数据。
+  page_url: https://www.qidian.com/
+  source: WebNR Chinese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 起点中文网
+    - 中文网文
+    - 官方平台
+    - 小说发现
+  categories:
+    - Official platform discovery
+  region: zh-CN
+
+chinese-web-fiction-platforms/jjwxc.md:
+  title: 晋江文学城 — 官方作品库
+  author: 晋江文学城
+  description: 晋江文学城的官方公开作品库入口，可按作品类型、状态等条件发现作品。WebNR 只链接原站；作者作品、收费章节、评论、收藏与授权状态均以晋江文学城及作者的当前说明为准。
+  page_url: https://www.jjwxc.net/bookbase.php?fw=0
+  source: WebNR Chinese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 晋江文学城
+    - 中文网文
+    - 官方平台
+    - 作品库
+  categories:
+    - Official platform discovery
+  region: zh-CN
+
+chinese-web-fiction-platforms/zongheng.md:
+  title: 纵横中文网 — 官方小说发现入口
+  author: 纵横中文网
+  description: 纵横中文网的官方入口，提供分类、榜单、书库与完本等读者发现路径。WebNR 仅维护官方跳转链接与自写说明，不抓取、缓存或重新发布作品、目录、评论、榜单或账户数据。
+  page_url: https://www.zongheng.com/
+  source: WebNR Chinese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 纵横中文网
+    - 中文网文
+    - 官方平台
+    - 小说发现
+  categories:
+    - Official platform discovery
+  region: zh-CN


### PR DESCRIPTION
## Why
Complete the 2026-08-17 daily source-growth lane with a bounded, official-platform Chinese web-fiction discovery source that also prepares the next reader-facing Chinese ecosystem assignment.

## Scope
- add a WebNR-maintained `chinese-web-fiction-platforms-starter`
- include three fully audited first-party discovery routes: Qidian, JJWXC, and Zongheng
- keep the source strictly link-only: official URLs plus WebNR-authored labels/descriptions only
- make no runtime API, HTML, feed, chapter, account, payment, or catalog request to the origins

## Evidence and boundary
Current official pages expose reader discovery surfaces for all three platforms. Current Qidian/JJWXC/Zongheng agreements or legal notices reserve platform/creator content and do not grant blanket reuse rights, so the smallest safe integration is navigation-only. Direct robots-file behavior is not relied on for admission because the source performs zero automated origin requests; any richer adapter remains gated on a separate reproducible rights/access/robots/rate/pagination/fixture audit.

Two additional current candidates, Fanqie and Changpei, were discovered for the daily candidate queue but are intentionally not admitted by this PR until their source-specific boundaries are fully documented.

## Preserved behavior
No existing source, reader route, canonical, analytics behavior, navigation, or content is changed or removed. The configured GA4 destination and full-URL policy remain untouched.

## Validation
CI must pass the complete repository Quality gate, including source-output validation, production build, dependency audit, docs validation, production evidence, and Chromium journeys. Final review will restart from the repository contract only after all expected checks succeed.

## Production / acceptance
This change affects the reader application source artifacts. After squash merge, the exact merge commit must be published by the normal application deployment and the public `https://app.webnovel.win/sources/chinese-web-fiction-platforms-starter/` artifact must expose the reviewed README/index while representative existing reader and documentation routes remain healthy.

## Risk / rollback
Low additive risk. Rollback is removal of this isolated source directory through the same PR lifecycle if validation or public verification identifies a defect.