### PR TITLE
sources: expand Chinese web-fiction platform starter

### DIFF
--- a/public/sources/chinese-web-fiction-platforms-starter/README.txt
+++ b/public/sources/chinese-web-fiction-platforms-starter/README.txt
@@ -12,7 +12,7 @@ https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fchine
 Purpose
 -------
 This WebNR-maintained source is a link-only discovery directory for official
-Chinese web-fiction platforms reviewed on 2026-08-17. It helps readers reach
+Chinese web-fiction platforms reviewed on 2026-08-18. It helps readers reach
 current first-party browsing and discovery surfaces while leaving reading,
 accounts, payments, comments, rankings, age gates, and work-specific rights at
 the origin platform.
@@ -22,6 +22,8 @@ Included discovery routes
 - 起点中文网 (Qidian) — official platform home and catalog discovery
 - 晋江文学城 (JJWXC) — official public work-library discovery
 - 纵横中文网 (Zongheng) — official platform home, categories, rankings, and library
+- 17K小说网 (17K) — official platform home and discovery entry
+- 七猫中文网 (Qimao) — official free-fiction platform home and discovery entry
 
 Content and rights boundary
 ---------------------------
@@ -37,25 +39,30 @@ current user agreement and authorization notices reserve site information and
 creator works and prohibit unauthorized copying, downloading, distribution, and
 commercial use. Zongheng's current legal notice restricts modification,
 distribution, recreation, copying, reposting, and other reuse without permission.
+17K's public rights notice states that site content may not be reproduced without
+permission, and its user agreement governs the service and user-published content.
+Qimao's official pages carry an all-rights-reserved notice, while its current
+writer-service rules place publication and distribution of submitted works inside
+an explicit platform authorization framework.
 
 Current WebNR behavior
 ----------------------
 Selecting an item opens the official origin page. WebNR performs no runtime API,
-HTML, feed, or chapter polling for this starter, so it creates no automated
-origin-site crawl, CORS, cookie, login, rate-limit, or pagination dependency.
-WebNR does not automate accounts, payments, VIP access, age verification, DRM,
-captchas, robots restrictions, or other access controls.
+HTML, feed, search-result, ranking, or chapter polling for this starter, so it
+creates no automated origin-site crawl, CORS, cookie, login, rate-limit, or
+pagination dependency. WebNR does not automate accounts, payments, VIP access,
+age verification, DRM, captchas, robots restrictions, or other access controls.
 
 Audit boundary
 --------------
 The public landing routes and rights/access boundaries were rechecked on
-2026-08-17. Direct robots-file retrieval was not relied on for admission because
-this source sends no automated requests to the origins. A richer adapter would
-require a separate audit that can reproduce robots behavior, machine-interface
-permission, request cadence, authentication state, pagination, timeouts,
-provenance, attribution, update/deletion behavior, and work-level rights with
-versioned fixtures.
+2026-08-18. Direct robots-file retrieval is not used as an admission dependency
+because this source sends no automated requests to the origins. A richer adapter
+would require a separate audit that can reproduce robots behavior,
+machine-interface permission, request cadence, authentication state, pagination,
+timeouts, provenance, attribution, update/deletion behavior, and work-level
+rights with versioned fixtures.
 
 Last verified
 -------------
-2026-08-17
+2026-08-18

--- a/public/sources/chinese-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/chinese-web-fiction-platforms-starter/search_index.yml
@@ -45,3 +45,36 @@ chinese-web-fiction-platforms/zongheng.md:
   categories:
     - Official platform discovery
   region: zh-CN
+
+chinese-web-fiction-platforms/17k.md:
+  title: 17K小说网 — 官方小说发现入口
+  author: 17K小说网
+  description: 17K小说网的官方入口，提供原创小说阅读与站内分类、搜索等发现路径。WebNR 只保存官方入口和自写说明，作品正文、章节、评论、账户与版权信息继续由17K小说网呈现。
+  page_url: https://www.17k.com/
+  source: WebNR Chinese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 17K小说网
+    - 中文网文
+    - 官方平台
+    - 小说发现
+  categories:
+    - Official platform discovery
+  region: zh-CN
+
+chinese-web-fiction-platforms/qimao.md:
+  title: 七猫中文网 — 官方免费小说发现入口
+  author: 七猫中文网
+  description: 七猫中文网的官方入口，提供免费阅读、小说推荐与排行榜等读者发现路径。WebNR 仅保存官方跳转链接与自写说明，阅读、广告、账户、评论、作者作品及授权状态均由七猫中文网负责。
+  page_url: https://www.qimao.com/
+  source: WebNR Chinese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 七猫中文网
+    - 中文网文
+    - 免费阅读
+    - 官方平台
+    - 小说发现
+  categories:
+    - Official platform discovery
+  region: zh-CN


### PR DESCRIPTION
## Outcome
Expand the existing link-only Chinese Web-Fiction Platforms Starter with two additional first-party discovery routes: 17K小说网 and 七猫中文网.

## Evidence and admission boundary
- 17K official home/about/rights surfaces: https://www.17k.com/ and https://www.17k.com/aboutus/
- 17K user agreement: https://www.17k.com/inc/agreement/users.html
- Qimao official platform: https://www.qimao.com/
- Qimao official writer-service terms confirm the platform authorization framework: https://zhushou.qimao.com/writer-rules/68464fdfe4a81e7ec312f874/

Both additions are link-only. WebNR stores only the first-party destination URL plus WebNR-authored metadata and performs no runtime API, HTML, ranking, feed, chapter, login, payment, or access-control automation against either origin.

## Scope
- add 17K and Qimao entries to `public/sources/chinese-web-fiction-platforms-starter/search_index.yml`
- update the source README with the current route list, rights/access boundary, and 2026-08-18 verification date
- preserve the three existing Qidian/JJWXC/Zongheng entries unchanged

## Validation
- source index remains valid YAML-shaped WebNR catalog data with unique keys and first-party HTTPS URLs
- origin landing pages and rights/terms surfaces were rechecked on 2026-08-18
- no source-adapter code, crawler scope, account behavior, ranking behavior, or existing source record is modified
- repository `Quality` workflow is the authoritative CI gate for source structure, build, production evidence, and browser journeys

## Production / acceptance
This changes the reader app's public source catalog. After squash merge, verify the exact app deployment for the squash commit and confirm `chinese-web-fiction-platforms-starter` exposes five entries with the existing one-click-add route still functional. Representative unaffected behavior: existing Qidian/JJWXC/Zongheng entries remain present and the canonical docs site remains unchanged.

## Risk and rollback
Risk is limited to two additive link-only directory entries and README metadata. Rollback is a revert of these two file changes; no origin content or user data is stored.