### PR TITLE
sources: add Japanese web-fiction platform starter

### DIFF
--- a/public/sources/japanese-web-fiction-platforms-starter/README.txt
+++ b/public/sources/japanese-web-fiction-platforms-starter/README.txt
@@ -1,0 +1,65 @@
+Japanese Web-Fiction Platforms Starter
+======================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/japanese-web-fiction-platforms-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fjapanese-web-fiction-platforms-starter
+
+Purpose
+-------
+This WebNR-maintained source is a link-only discovery directory for official
+Japanese web-fiction platforms reviewed on 2026-08-19. It helps readers reach
+current first-party search, ranking, and browsing surfaces while leaving reading,
+accounts, payments, comments, recommendations, age gates, and work-specific
+rights at the origin platform.
+
+Included discovery routes
+-------------------------
+- 小説を読もう！ / 小説家になろう (Shōsetsuka ni Narō) — official public search and ranking surface for works posted to the Narō group
+- カクヨム (Kakuyomu) — KADOKAWA's official web-fiction discovery and reading platform
+- エブリスタ (Everystar) — official novel catalog, ranking, and discovery surface
+
+Content and rights boundary
+---------------------------
+The index contains only official destination URLs plus short WebNR-authored
+descriptions and labels. It does not copy story text, chapter lists, covers,
+rankings, reviews, comments, author profiles, account data, or platform-owned
+catalog data.
+
+The reviewed origin rules reserve platform and creator rights and constrain reuse.
+The Narō group's current terms prohibit automated access or data collection except
+through the official Narō Developer APIs. Kakuyomu's current terms reserve service
+intellectual property and prohibit use of obtained data outside the allowed
+private-use scope without permission. Everystar's current member terms reserve
+rights in service content and prohibit unlicensed reproduction, transmission,
+translation, adaptation, and other reuse. Those boundaries are why this starter
+is link-only.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the official origin page. WebNR performs no runtime API,
+HTML, feed, search-result, ranking, or chapter polling for this starter, so it
+creates no automated origin-site crawl, CORS, cookie, login, rate-limit, or
+pagination dependency. WebNR does not automate accounts, payments, premium
+access, age verification, DRM, captchas, robots restrictions, or other access
+controls.
+
+Audit boundary
+--------------
+The public landing routes and rights/access boundaries were rechecked on
+2026-08-19. Because this source sends no automated requests to the origins,
+robots, response-size, timeout, pagination, encoding, and request-cadence behavior
+are outside the admitted runtime boundary. A richer adapter would require a
+separate audit of an explicitly permitted machine interface, robots behavior,
+request cadence, authentication state, pagination, timeouts, provenance,
+attribution, update/deletion behavior, and work-level rights, backed by versioned
+fixtures. For the Narō group, any automated data integration must stay within the
+official Narō Developer API and its applicable rules.
+
+Last verified
+-------------
+2026-08-19

--- a/public/sources/japanese-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/japanese-web-fiction-platforms-starter/search_index.yml
@@ -1,7 +1,7 @@
 japanese-web-fiction-platforms/narou.md:
   title: 小説を読もう！ — 小説家になろう公式作品検索
   author: 小説家になろう
-  description: 小説家になろうグループの公式公開作品検索・ランキング入口。WebNR は公式リンクと自写说明のみを保存し、作品正文、章节、ランキング、评论、账户数据や平台目录数据は取得・复制しません。
+  description: 小説家になろうグループの公式公開作品検索・ランキング入口。WebNR は公式リンクと独自の案内文だけを保存し、作品本文、エピソード、ランキング、コメント、アカウント情報やプラットフォームのカタログデータは取得・複製しません。
   page_url: https://yomou.syosetu.com/
   source: WebNR Japanese Web-Fiction Platform Directory
   license: Link-only-WebNR-editorial
@@ -18,7 +18,7 @@ japanese-web-fiction-platforms/narou.md:
 japanese-web-fiction-platforms/kakuyomu.md:
   title: カクヨム — 公式Web小説検索・ランキング
   author: KADOKAWA
-  description: KADOKAWA が運営するカクヨムの公式入口で、作品検索やランキングからWeb小説を探せます。WebNR は公式リンクと自写说明のみを保存し、作品、エピソード、评论、账户、收费内容や平台数据は再配布しません。
+  description: KADOKAWA が運営するカクヨムの公式入口で、作品検索やランキングからWeb小説を探せます。WebNR は公式リンクと独自の案内文だけを保存し、作品、エピソード、コメント、アカウント、有料コンテンツやプラットフォームデータは再配布しません。
   page_url: https://kakuyomu.jp/
   source: WebNR Japanese Web-Fiction Platform Directory
   license: Link-only-WebNR-editorial
@@ -35,7 +35,7 @@ japanese-web-fiction-platforms/kakuyomu.md:
 japanese-web-fiction-platforms/estar.md:
   title: エブリスタ — 公式小説一覧・ランキング
   author: 株式会社エブリスタ
-  description: エブリスタの公式小説一覧入口で、ジャンル、検索、ランキングなどから作品を探せます。WebNR は公式リンクと自写说明のみを保存し、作品正文、章节、表紙、评论、账户、收费内容や平台目录数据は取得・再配布しません。
+  description: エブリスタの公式小説一覧入口で、ジャンル、検索、ランキングなどから作品を探せます。WebNR は公式リンクと独自の案内文だけを保存し、作品本文、エピソード、表紙、コメント、アカウント、有料コンテンツやプラットフォームのカタログデータは取得・再配布しません。
   page_url: https://estar.jp/novels
   source: WebNR Japanese Web-Fiction Platform Directory
   license: Link-only-WebNR-editorial

--- a/public/sources/japanese-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/japanese-web-fiction-platforms-starter/search_index.yml
@@ -1,0 +1,50 @@
+japanese-web-fiction-platforms/narou.md:
+  title: 小説を読もう！ — 小説家になろう公式作品検索
+  author: 小説家になろう
+  description: 小説家になろうグループの公式公開作品検索・ランキング入口。WebNR は公式リンクと自写说明のみを保存し、作品正文、章节、ランキング、评论、账户数据や平台目录数据は取得・复制しません。
+  page_url: https://yomou.syosetu.com/
+  source: WebNR Japanese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 小説家になろう
+    - 小説を読もう
+    - 日本語Web小説
+    - 公式プラットフォーム
+    - 小説発見
+  categories:
+    - Official platform discovery
+  region: ja-JP
+
+japanese-web-fiction-platforms/kakuyomu.md:
+  title: カクヨム — 公式Web小説検索・ランキング
+  author: KADOKAWA
+  description: KADOKAWA が運営するカクヨムの公式入口で、作品検索やランキングからWeb小説を探せます。WebNR は公式リンクと自写说明のみを保存し、作品、エピソード、评论、账户、收费内容や平台数据は再配布しません。
+  page_url: https://kakuyomu.jp/
+  source: WebNR Japanese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - カクヨム
+    - 日本語Web小説
+    - KADOKAWA
+    - 公式プラットフォーム
+    - 小説発見
+  categories:
+    - Official platform discovery
+  region: ja-JP
+
+japanese-web-fiction-platforms/estar.md:
+  title: エブリスタ — 公式小説一覧・ランキング
+  author: 株式会社エブリスタ
+  description: エブリスタの公式小説一覧入口で、ジャンル、検索、ランキングなどから作品を探せます。WebNR は公式リンクと自写说明のみを保存し、作品正文、章节、表紙、评论、账户、收费内容や平台目录数据は取得・再配布しません。
+  page_url: https://estar.jp/novels
+  source: WebNR Japanese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - エブリスタ
+    - 日本語Web小説
+    - 公式プラットフォーム
+    - ランキング
+    - 小説発見
+  categories:
+    - Official platform discovery
+  region: ja-JP


### PR DESCRIPTION
## Why
The 2026-08-19 source cycle is preparing the repository-authoritative 2026-08-20 Japanese web-fiction discovery assignment. Fresh first-party review identified three useful platforms that can be admitted safely at link-only compatibility while keeping all work text, account, ranking, paid-access, and platform data at the origins.

## Scope
- add `japanese-web-fiction-platforms-starter`
- include official discovery links for 小説を読もう！/小説家になろう, カクヨム, and エブリスタ
- document the reviewed rights/access boundary and explicitly keep the source link-only
- perform no origin API/HTML/feed/ranking/chapter crawling and introduce no authentication, payment, DRM, captcha, robots, or access-control bypass

## Evidence and preserved behavior
- 小説家になろう current terms prohibit automated access/data collection except through the official Narō Developer APIs; this source only opens the official public reader surface
- カクヨム current terms reserve service IP and limit reuse of obtained data outside allowed private use without permission
- エブリスタ current member terms reserve rights in service content and prohibit unlicensed reproduction/translation/adaptation/reuse
- existing source directories, application behavior, canonical ownership, analytics configuration, routes, and all current source records are unchanged

## Validation
The repository Quality workflow must complete all expected jobs: Web quality (dependency audit, lint, typecheck, production build, analytics/source validation), Chromium user journeys, Documentation quality, and Production evidence. After green CI, the complete base-to-head diff and generated expectations will be reviewed again from scratch before merge.

## Production / acceptance
This is an application public-source change. After squash merge, the exact application squash commit must be observed through the repository production-verification lane, and the public source must expose its README and search index while representative existing reader behavior remains healthy. Documentation production identities must remain unchanged.

## Risk / rollback
Risk is narrow: malformed source metadata or a mistaken origin boundary. No origin content is copied or fetched at runtime. Rollback is a revert/removal of this two-file source directory through the normal reviewed PR lane.