### PR TITLE
sources: extend Japanese web-fiction discovery

### DIFF
--- a/public/sources/japanese-web-fiction-platforms-starter/README.txt
+++ b/public/sources/japanese-web-fiction-platforms-starter/README.txt
@@ -12,7 +12,7 @@ https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fjapan
 Purpose
 -------
 This WebNR-maintained source is a link-only discovery directory for official
-Japanese web-fiction platforms reviewed on 2026-08-19. It helps readers reach
+Japanese web-fiction platforms reviewed on 2026-08-20. It helps readers reach
 current first-party search, ranking, and browsing surfaces while leaving reading,
 accounts, payments, comments, recommendations, age gates, and work-specific
 rights at the origin platform.
@@ -22,6 +22,8 @@ Included discovery routes
 - 小説を読もう！ / 小説家になろう (Shōsetsuka ni Narō) — official public search and ranking surface for works posted to the Narō group
 - カクヨム (Kakuyomu) — KADOKAWA's official web-fiction discovery and reading platform
 - エブリスタ (Everystar) — official novel catalog, ranking, and discovery surface
+- 野いちご (Noichigo) — Starts Publishing's official discovery surface for romance, school-life, youth, mystery, and related reader categories
+- ノベマ！ (Novema) — Starts Publishing's official discovery surface spanning youth/romance, fantasy, human drama, mystery, horror, BL, and other categories
 
 Content and rights boundary
 ---------------------------
@@ -33,11 +35,15 @@ catalog data.
 The reviewed origin rules reserve platform and creator rights and constrain reuse.
 The Narō group's current terms prohibit automated access or data collection except
 through the official Narō Developer APIs. Kakuyomu's current terms reserve service
-intellectual property and prohibit use of obtained data outside the allowed
-private-use scope without permission. Everystar's current member terms reserve
-rights in service content and prohibit unlicensed reproduction, transmission,
-translation, adaptation, and other reuse. Those boundaries are why this starter
-is link-only.
+intellectual property and restrict use outside the permitted scope. Everystar's
+current member terms reserve rights in service content and constrain unlicensed
+reproduction, transmission, translation, adaptation, and other reuse. Noichigo's
+current terms reserve platform and provider rights, limit use to the service's
+provided interfaces, and state that the service is offered for access and use
+from Japan. Novema's current terms restrict use of site-provided information
+outside the copyright owner's permitted scope and preserve the origin site's
+account, content, and access rules. Those boundaries are why this starter is
+link-only.
 
 Current WebNR behavior
 ----------------------
@@ -46,12 +52,13 @@ HTML, feed, search-result, ranking, or chapter polling for this starter, so it
 creates no automated origin-site crawl, CORS, cookie, login, rate-limit, or
 pagination dependency. WebNR does not automate accounts, payments, premium
 access, age verification, DRM, captchas, robots restrictions, or other access
-controls.
+controls. The Noichigo route is discovery metadata only; readers remain
+responsible for origin-region availability and the current origin terms.
 
 Audit boundary
 --------------
 The public landing routes and rights/access boundaries were rechecked on
-2026-08-19. Because this source sends no automated requests to the origins,
+2026-08-20. Because this source sends no automated requests to the origins,
 robots, response-size, timeout, pagination, encoding, and request-cadence behavior
 are outside the admitted runtime boundary. A richer adapter would require a
 separate audit of an explicitly permitted machine interface, robots behavior,
@@ -62,4 +69,4 @@ official Narō Developer API and its applicable rules.
 
 Last verified
 -------------
-2026-08-19
+2026-08-20

--- a/public/sources/japanese-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/japanese-web-fiction-platforms-starter/search_index.yml
@@ -48,3 +48,37 @@ japanese-web-fiction-platforms/estar.md:
   categories:
     - Official platform discovery
   region: ja-JP
+
+japanese-web-fiction-platforms/noichigo.md:
+  title: 野いちご — 公式小説検索・ランキング
+  author: スターツ出版株式会社
+  description: 野いちごの公式入口で、恋愛、学園、青春、ミステリーなどのジャンル別一覧や週間・殿堂ランキングから作品を探せます。WebNR は公式リンクと独自の案内文だけを保存し、作品本文、表紙、ランキング値、レビュー、アカウントやプラットフォームデータは取得・再配布しません。利用時は配信地域を含む公式の最新条件を確認してください。
+  page_url: https://www.no-ichigo.jp/
+  source: WebNR Japanese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 野いちご
+    - 日本語Web小説
+    - 恋愛小説
+    - 学園小説
+    - 公式プラットフォーム
+  categories:
+    - Official platform discovery
+  region: ja-JP
+
+japanese-web-fiction-platforms/novema.md:
+  title: ノベマ！ — 公式小説検索・ランキング
+  author: スターツ出版株式会社
+  description: ノベマ！の公式入口で、青春・恋愛、ファンタジー、ヒューマンドラマ、ミステリー、ホラー、BLなどのジャンルとランキングから作品を探せます。WebNR は公式リンクと独自の案内文だけを保存し、作品本文、表紙、ランキング値、レビュー、アカウントやプラットフォームデータは取得・再配布しません。
+  page_url: https://novema.jp/
+  source: WebNR Japanese Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - ノベマ
+    - 日本語Web小説
+    - 青春小説
+    - ファンタジー
+    - 公式プラットフォーム
+  categories:
+    - Official platform discovery
+  region: ja-JP


### PR DESCRIPTION
## Scope
Extend the existing link-only Japanese Web-Fiction Platforms Starter with two first-party Starts Publishing discovery routes: 野いちご and ノベマ！.

## Evidence and boundary
- Rechecked the existing Narou/Kakuyomu/Everystar origin boundaries on 2026-08-20.
- Audited new candidate families including 野いちご, ノベマ！, ノベモア, ノベルアップ＋, pixiv/other Japanese platform candidates; this PR admits only the two routes with current first-party discovery surfaces and sufficiently clear rights/access boundaries.
- 野いちご publishes current public genre/ranking discovery but its terms state Japan access/use scope and restrict access to provided interfaces.
- ノベマ！ publishes current public genre/ranking discovery and restricts reuse outside the copyright owner's permitted scope.
- The WebNR integration remains URL + WebNR-authored metadata only: no story text, covers, ranking data, reviews, account data, API calls, HTML polling, or automated origin crawl.

## Preserved behavior
No existing route, source record, Legado compatibility behavior, analytics behavior, or URL layout changes. The three previously admitted Japanese platform entries remain unchanged.

## Validation
Authoritative repository Quality workflow must pass all expected jobs. Final review will recheck the complete base-to-head diff, source scope, origin rights/access statements, and rendered/source-add behavior.

## Production / acceptance
This changes the public app source index. After squash merge, verify the exact production artifact for the squash commit and confirm the Japanese starter exposes five official discovery records while representative existing records remain functional.

## Risk / rollback
Low, additive link-only metadata. Rollback is removal of the two new records and corresponding README statements via a corrective PR if origin policy or production validation conflicts with this boundary.