### PR TITLE
feat: add Korean web-fiction discovery source

### DIFF
--- a/public/sources/korean-web-fiction-platforms-starter/README.txt
+++ b/public/sources/korean-web-fiction-platforms-starter/README.txt
@@ -1,0 +1,68 @@
+Korean Web-Fiction Platforms Starter
+====================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/korean-web-fiction-platforms-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fkorean-web-fiction-platforms-starter
+
+Purpose
+-------
+This WebNR-maintained source is a link-only discovery directory for official
+Korean web-fiction platforms reviewed on 2026-08-21. It helps readers reach
+current first-party web-novel browsing and discovery surfaces while leaving
+reading, accounts, purchases, comments, age gates, recommendations, and
+work-specific rights at the origin platform.
+
+Included discovery routes
+-------------------------
+- 문피아 (Munpia) — official Korean web-novel platform and discovery surface
+- 네이버 시리즈 (NAVER SERIES) — NAVER WEBTOON's official web-novel discovery and reading surface
+- 리디 (RIDI) — official Korean web-novel recommendation, category, and ranking surface
+
+Content and rights boundary
+---------------------------
+The index contains only official destination URLs plus short WebNR-authored
+descriptions and labels. It does not copy story text, episode lists, covers,
+rankings, reviews, comments, author profiles, account data, purchase data, or
+platform-owned catalog data.
+
+The reviewed origin rules preserve platform, creator, publisher, and other
+rightsholder interests. Munpia's current terms keep rights in creator and
+provider content and restrict unapproved commercial reuse of information or
+platform-owned materials. NAVER WEBTOON's current service terms reserve rights
+in the service while keeping author rights in user postings and apply separate
+conditions to paid content, age-restricted access, and other service areas.
+RIDI's current v5.0 terms, effective 2026-08-20, reserve rights in company-created
+content and expressly restrict unauthorized macros, scripts, bots, scraping,
+abnormal traffic, unauthorized extraction, and circumvention of technical
+protections. Those boundaries are why this starter is link-only.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the official origin page. WebNR performs no runtime API,
+HTML, feed, ranking, search-result, or chapter polling for this starter, so it
+creates no automated origin-site crawl, account, cookie, CORS, pagination,
+rate-limit, or session dependency. WebNR does not automate accounts, purchases,
+free-ticket systems, age verification, DRM, captchas, access controls, or
+regional restrictions.
+
+Audit boundary
+--------------
+The public landing routes and current rights/access boundaries were rechecked on
+2026-08-21. Because this source sends no automated requests to the origins,
+robots behavior, request cadence, response-size limits, pagination, timeouts,
+encoding, and authenticated-session behavior are outside the admitted runtime
+boundary. A richer adapter would require a separate audit of an explicitly
+permitted machine interface, current origin rules, request cadence, authentication
+state, pagination, rate limits and backoff, provenance, attribution,
+update/deletion behavior, work-level rights, and representative versioned
+fixtures. RIDI must not be upgraded to an automated scraper under its current
+terms.
+
+Last verified
+-------------
+2026-08-21

--- a/public/sources/korean-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/korean-web-fiction-platforms-starter/search_index.yml
@@ -1,0 +1,50 @@
+korean-web-fiction-platforms/munpia.md:
+  title: 문피아 — 공식 웹소설 발견 입구
+  author: 주식회사 문피아
+  description: 문피아의 공식 웹소설 입구입니다. 판타지, 무협을 비롯한 장르와 작품 탐색 경로를 원문 플랫폼에서 이용할 수 있습니다. WebNR은 공식 링크와 독자 안내용으로 직접 작성한 설명만 저장하며 작품 본문, 회차, 랭킹 값, 댓글, 계정, 구매 정보 또는 플랫폼 카탈로그를 수집·복제하지 않습니다.
+  page_url: https://www.munpia.com/
+  source: WebNR Korean Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 문피아
+    - 한국 웹소설
+    - 판타지
+    - 무협
+    - 공식 플랫폼
+  categories:
+    - Official platform discovery
+  region: ko-KR
+
+korean-web-fiction-platforms/naver-series.md:
+  title: 네이버 시리즈 — 공식 웹소설 홈
+  author: 네이버웹툰 유한회사
+  description: 네이버웹툰이 운영하는 네이버 시리즈의 공식 웹소설 홈입니다. 추천, TOP 100, 카테고리, 신간 및 연재 작품 등 현재 원문 플랫폼의 발견 경로를 이용할 수 있습니다. WebNR은 공식 링크와 직접 작성한 안내문만 저장하고 작품, 회차, 표지, 평점, 랭킹, 댓글, 유료 콘텐츠나 계정 데이터를 다시 배포하지 않습니다.
+  page_url: https://series.naver.com/novel/home.series
+  source: WebNR Korean Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 네이버 시리즈
+    - 한국 웹소설
+    - 네이버웹툰
+    - 공식 플랫폼
+    - 웹소설 발견
+  categories:
+    - Official platform discovery
+  region: ko-KR
+
+korean-web-fiction-platforms/ridi.md:
+  title: 리디 — 공식 웹소설 추천·발견
+  author: 리디 주식회사
+  description: 리디의 공식 웹소설 추천 입구입니다. 로맨스, 로맨스판타지, 판타지, BL 등 장르와 신작, 베스트, 키워드 기반 발견 경로를 원문 플랫폼에서 이용할 수 있습니다. WebNR은 공식 링크와 직접 작성한 설명만 저장하며 작품 본문, 회차, 표지, 랭킹 값, 구매·계정 정보나 플랫폼 데이터를 수집·복제하지 않습니다.
+  page_url: https://ridibooks.com/webnovel/recommendation
+  source: WebNR Korean Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 리디
+    - 한국 웹소설
+    - 로맨스
+    - 판타지
+    - 공식 플랫폼
+  categories:
+    - Official platform discovery
+  region: ko-KR


### PR DESCRIPTION
## Summary
- add a WebNR-maintained link-only Korean web-fiction platform starter
- admit current official discovery routes for Munpia, NAVER SERIES, and RIDI
- preserve origin reading, accounts, purchases, age gates, content rights, and platform data at the first-party services

## Admission evidence
The 2026-08-21 source cycle screened five Korean platform families: Munpia, NAVER SERIES, RIDI, KakaoPage, and Joara. Munpia, NAVER SERIES, and RIDI received current first-party landing-page and terms/access review and are admitted only as authored link-only records. KakaoPage and Joara remain deferred from this source until their current service-specific policy/access boundary can be captured as cleanly as the admitted routes.

RIDI's current terms are v5.0 effective 2026-08-20 and explicitly restrict unauthorized macros, scripts, bots, scraping, abnormal traffic, unauthorized extraction, and technical-protection circumvention. This source makes no runtime requests to RIDI or the other origins.

## Scope and risk
- changed scope: `public/sources/korean-web-fiction-platforms-starter/**` only
- no application logic, analytics, authentication, storage, deployment, or documentation-canonical change
- no copied story text, chapters, covers, rankings, reviews, comments, author profiles, account data, purchase data, or platform catalog data
- no automated origin crawl/API/feed/search/ranking polling

## Production acceptance
After merge, the application artifact should expose:
- `/sources/korean-web-fiction-platforms-starter/README.txt`
- `/sources/korean-web-fiction-platforms-starter/search_index.yml`
with the three official destination URLs unchanged. Existing maintained sources must remain present and unchanged.

Rollback is deletion of the two added source files if the reviewed link-only boundary or build behavior fails verification.