### PR TITLE
sources: expand Korean web-fiction discovery

### DIFF
--- a/public/sources/korean-web-fiction-platforms-starter/README.txt
+++ b/public/sources/korean-web-fiction-platforms-starter/README.txt
@@ -12,7 +12,7 @@ https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fkorea
 Purpose
 -------
 This WebNR-maintained source is a link-only discovery directory for official
-Korean web-fiction platforms reviewed on 2026-08-21. It helps readers reach
+Korean web-fiction platforms reviewed on 2026-08-22. It helps readers reach
 current first-party web-novel browsing and discovery surfaces while leaving
 reading, accounts, purchases, comments, age gates, recommendations, and
 work-specific rights at the origin platform.
@@ -22,6 +22,8 @@ Included discovery routes
 - 문피아 (Munpia) — official Korean web-novel platform and discovery surface
 - 네이버 시리즈 (NAVER SERIES) — NAVER WEBTOON's official web-novel discovery and reading surface
 - 리디 (RIDI) — official Korean web-novel recommendation, category, and ranking surface
+- 노벨피아 (Novelpia) — official Korean web-novel search, ranking, free-serialization, and subscription discovery surface
+- 브릿G (BritG) — official fiction platform with serial fiction, reviews, community discovery, and reader tools
 
 Content and rights boundary
 ---------------------------
@@ -39,7 +41,13 @@ conditions to paid content, age-restricted access, and other service areas.
 RIDI's current v5.0 terms, effective 2026-08-20, reserve rights in company-created
 content and expressly restrict unauthorized macros, scripts, bots, scraping,
 abnormal traffic, unauthorized extraction, and circumvention of technical
-protections. Those boundaries are why this starter is link-only.
+protections. Novelpia's current service terms took effect on 2026-08-13 and its
+public pages state that registered content remains protected by the site and
+original rightsholders against unauthorized copying, transmission, modification,
+and distribution. BritG's current published member and registered-author terms
+keep member-posted work rights with their authors and restrict copying or reuse
+of service-obtained information without authorization. Those boundaries are why
+this starter remains link-only.
 
 Current WebNR behavior
 ----------------------
@@ -47,13 +55,13 @@ Selecting an item opens the official origin page. WebNR performs no runtime API,
 HTML, feed, ranking, search-result, or chapter polling for this starter, so it
 creates no automated origin-site crawl, account, cookie, CORS, pagination,
 rate-limit, or session dependency. WebNR does not automate accounts, purchases,
-free-ticket systems, age verification, DRM, captchas, access controls, or
-regional restrictions.
+free-ticket systems, subscriptions, age verification, DRM, captchas, access
+controls, or regional restrictions.
 
 Audit boundary
 --------------
 The public landing routes and current rights/access boundaries were rechecked on
-2026-08-21. Because this source sends no automated requests to the origins,
+2026-08-22. Because this source sends no automated requests to the origins,
 robots behavior, request cadence, response-size limits, pagination, timeouts,
 encoding, and authenticated-session behavior are outside the admitted runtime
 boundary. A richer adapter would require a separate audit of an explicitly
@@ -61,8 +69,9 @@ permitted machine interface, current origin rules, request cadence, authenticati
 state, pagination, rate limits and backoff, provenance, attribution,
 update/deletion behavior, work-level rights, and representative versioned
 fixtures. RIDI must not be upgraded to an automated scraper under its current
-terms.
+terms. Novelpia and BritG likewise remain link-only until an explicitly permitted
+machine interface and complete runtime fixtures justify a different capability.
 
 Last verified
 -------------
-2026-08-21
+2026-08-22

--- a/public/sources/korean-web-fiction-platforms-starter/search_index.yml
+++ b/public/sources/korean-web-fiction-platforms-starter/search_index.yml
@@ -48,3 +48,37 @@ korean-web-fiction-platforms/ridi.md:
   categories:
     - Official platform discovery
   region: ko-KR
+
+korean-web-fiction-platforms/novelpia.md:
+  title: 노벨피아 — 공식 웹소설 검색·발견
+  author: 주식회사 메타크래프트
+  description: 노벨피아의 공식 웹소설 입구입니다. 검색, 랭킹, 자유연재, 플러스 작품 등 원문 플랫폼의 발견 경로를 이용할 수 있습니다. WebNR은 공식 링크와 직접 작성한 안내만 저장하며 작품 본문, 회차, 표지, 랭킹 값, 댓글, 멤버십·계정·결제 정보 또는 플랫폼 카탈로그를 수집·복제하지 않습니다.
+  page_url: https://novelpia.com/
+  source: WebNR Korean Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 노벨피아
+    - 한국 웹소설
+    - 자유연재
+    - 플러스
+    - 공식 플랫폼
+  categories:
+    - Official platform discovery
+  region: ko-KR
+
+korean-web-fiction-platforms/britg.md:
+  title: 브릿G — 공식 소설·연재 발견 입구
+  author: 주식회사 민음인
+  description: 브릿G의 공식 소설 플랫폼 입구입니다. 장편·중단편 연재, 리뷰와 커뮤니티 기능, 독자용 작품 탐색 경로를 원문 플랫폼에서 이용할 수 있습니다. WebNR은 공식 링크와 직접 작성한 안내만 저장하며 작품 본문, 회차, 리뷰, 댓글, 작가·계정·구매 정보 또는 플랫폼 데이터를 수집·복제하지 않습니다.
+  page_url: https://britg.kr/
+  source: WebNR Korean Web-Fiction Platform Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - 브릿G
+    - 한국 소설
+    - 웹소설
+    - 리뷰
+    - 공식 플랫폼
+  categories:
+    - Official platform discovery
+  region: ko-KR


### PR DESCRIPTION
## Rationale
The 2026-08-22 Korean web-fiction source cycle screened a new set of Korean discovery platforms and found two additional first-party destinations that fit WebNR's existing conservative link-only capability.

## Scope
- add Novelpia as a link-only official discovery route
- add BritG as a link-only official fiction/discovery route
- refresh the starter's rights/access boundary and verification date

## Preserved behavior
No origin story text, episodes, covers, rankings, reviews, comments, accounts, purchases, subscription state, or platform catalog data is copied or polled. WebNR performs no runtime API/HTML/feed/search/ranking/chapter requests for these routes. Existing Munpia, NAVER SERIES, and RIDI entries are preserved.

## Evidence and validation
Novelpia's current published service terms took effect 2026-08-13 and its live pages explicitly preserve site/rightsholder rights against unauthorized copying and redistribution. BritG's published member and registered-author terms preserve author rights and restrict unauthorized reuse of service-obtained material; current public reader/community surfaces remain reachable. Both are therefore admitted only at link-only capability.

Expected repository validation is the normal complete Quality suite. After green CI, the complete final PR will be reviewed again from the original operating contract before squash merge.

## Risk and rollback
Risk is limited to two additive discovery links and authored metadata. Rollback is the squash commit for this PR. No credentials, automated crawling, account flow, payment flow, or access-control change is introduced.

## Production acceptance
After merge, the application source directory must expose the two new entries under the Korean starter while existing source routes and analytics behavior remain intact. Exact production identity will be reconciled by the repository production verifier and daily closeout.