### PR TITLE
sources: correct current RIDI terms version

### DIFF
--- a/public/sources/korean-web-fiction-platforms-starter/README.txt
+++ b/public/sources/korean-web-fiction-platforms-starter/README.txt
@@ -38,8 +38,8 @@ provider content and restrict unapproved commercial reuse of information or
 platform-owned materials. NAVER WEBTOON's current service terms reserve rights
 in the service while keeping author rights in user postings and apply separate
 conditions to paid content, age-restricted access, and other service areas.
-RIDI's current v5.0 terms, effective 2026-08-20, reserve rights in company-created
-content and expressly restrict unauthorized macros, scripts, bots, scraping,
+RIDI's published terms page currently identifies service terms v4.14, effective
+2026-04-02, and expressly restricts unauthorized macros, scripts, bots, scraping,
 abnormal traffic, unauthorized extraction, and circumvention of technical
 protections. Novelpia's current service terms took effect on 2026-08-13 and its
 public pages state that registered content remains protected by the site and


### PR DESCRIPTION
## Rationale
A same-cycle recheck of RIDI's first-party policy page showed that the public current terms page identifies service terms v4.14, effective 2026-04-02. The Korean starter still carried an older operating note that described v5.0/effective 2026-08-20.

## Scope
Correct only the RIDI terms version/effective-date sentence in the Korean starter README. Preserve the existing link-only capability and automation restrictions, which are directly supported by the current first-party terms.

## Validation
Run the repository's complete expected Quality suite. After all expected jobs succeed, restart review from the original operating contract and inspect the complete final diff before squash merge.

## Risk / rollback
Documentation-only factual correction inside one source README. Roll back the squash commit if the first-party policy page changes again.

## Production acceptance
The Korean starter public README should state v4.14/effective 2026-04-02 while preserving the existing link-only behavior and all source routes.