### PR TITLE
sources: add progression and LitRPG publisher discovery

### DIFF
--- a/public/sources/progression-litrpg-publisher-discovery-starter/README.txt
+++ b/public/sources/progression-litrpg-publisher-discovery-starter/README.txt
@@ -1,0 +1,70 @@
+Progression & LitRPG Publisher Discovery Starter
+================================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/progression-litrpg-publisher-discovery-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fprogression-litrpg-publisher-discovery-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small link-only discovery directory for readers
+looking for progression fantasy, LitRPG, GameLit, cultivation, and adjacent
+publisher catalogs. It points to first-party publisher discovery surfaces while
+leaving book metadata, pricing, availability, purchases, account state, ratings,
+and work-specific rights at the origin.
+
+Included discovery routes
+-------------------------
+- Aethon Books — first-party catalog with a dedicated GameLit/LitRPG section and progression-fantasy releases
+- Mountaindale Press — first-party publisher catalog centered on LitRPG and related progression fiction
+- Portal Books — first-party catalog for LitRPG, progression fantasy, cultivation, and portal adventure
+
+Content and rights boundary
+---------------------------
+The index contains only first-party destination URLs plus short WebNR-authored
+descriptions and discovery labels. It does not copy book descriptions, covers,
+prices, ratings, reviews, release schedules, author biographies, retailer data,
+or book text from any publisher.
+
+The current Aethon catalog identifies GameLit/LitRPG as a first-party genre and
+also exposes progression-fantasy titles under its fantasy catalog. Mountaindale's
+current public catalog identifies itself as "The Peak Of LitRPG" and marks its
+site content as copyright 2026 Mountaindale Press, all rights reserved. Portal's
+current catalog describes its scope as LitRPG, progression fantasy, and portal
+adventure, while its public privacy notice does not provide a general content-
+reuse license. No reviewed origin exposes an explicit machine-interface license
+that would justify copying or continuously polling its catalog. The admitted
+capability is therefore link-only.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the corresponding public publisher catalog. WebNR does
+not call origin APIs, crawl catalog HTML, poll search or release pages, proxy
+responses, mirror metadata, cache publisher assets, automate accounts, or perform
+purchases. This starter adds no origin-site cookie, CORS, pagination, request-
+cadence, response-size, or rate-limit dependency to the WebNR reader path.
+
+Audit boundary
+--------------
+The three included HTTPS catalog routes were rechecked on 2026-08-23 and were
+publicly reachable without an account. Because the source makes no runtime
+requests to those origins beyond a reader choosing to follow a normal link,
+robots rules, automated-request cadence, pagination, CORS, response-size limits,
+timeouts, and authenticated sessions are outside the admitted runtime boundary.
+The committed search index is the versioned fixture for this static link-only
+capability.
+
+A richer adapter would require a separate source-specific audit of an explicitly
+permitted machine interface, current terms and robots behavior, stable work and
+edition identity, pagination, request cadence, timeouts and backoff, provenance,
+attribution, update and deletion semantics, regional availability, and
+representative versioned fixtures. Until then, publisher content remains at the
+origin.
+
+Last verified
+-------------
+2026-08-23

--- a/public/sources/progression-litrpg-publisher-discovery-starter/search_index.yml
+++ b/public/sources/progression-litrpg-publisher-discovery-starter/search_index.yml
@@ -1,0 +1,50 @@
+progression-litrpg-publisher-discovery/aethon-books.md:
+  title: Aethon Books — GameLit/LitRPG & Progression Catalog
+  author: Aethon Books
+  description: Aethon Books 的官方目录提供独立的 GameLit/LitRPG 分类，并在奇幻目录中收录 progression fantasy 作品。WebNR 仅保存官方目录链接和自行撰写的发现说明，不抓取或复制书籍简介、封面、价格、评分、作者资料或正文。
+  page_url: https://aethonbooks.com/catalog/
+  source: WebNR Progression & LitRPG Publisher Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Aethon Books
+    - LitRPG
+    - GameLit
+    - Progression fantasy
+    - Publisher catalog
+  categories:
+    - Publisher discovery
+  region: en
+
+progression-litrpg-publisher-discovery/mountaindale-press.md:
+  title: Mountaindale Press — LitRPG Catalog
+  author: Mountaindale Press
+  description: Mountaindale Press 的官方目录集中展示 LitRPG、GameLit 与相关 progression fiction，并提供作者、系列、新作与已完结系列等发现入口。WebNR 仅链接官方目录，不抓取或复制目录数据、书籍内容、价格、封面、评分或购买信息。
+  page_url: https://www.mountaindalepress.store/pages/catalog
+  source: WebNR Progression & LitRPG Publisher Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Mountaindale Press
+    - LitRPG
+    - GameLit
+    - Progression fantasy
+    - Publisher catalog
+  categories:
+    - Publisher discovery
+  region: en
+
+progression-litrpg-publisher-discovery/portal-books.md:
+  title: Portal Books — LitRPG, Progression & Cultivation Catalog
+  author: Portal Books
+  description: Portal Books 的官方书目面向 LitRPG、progression fantasy、cultivation 与 portal adventure，读者可从原站查看系列与当前出版状态。WebNR 仅保存官方发现链接与自行撰写的标签，不复制书籍简介、封面、评分、价格、作者资料、零售数据或正文。
+  page_url: https://portal-books.com/our-books/
+  source: WebNR Progression & LitRPG Publisher Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Portal Books
+    - LitRPG
+    - Progression fantasy
+    - Cultivation
+    - Publisher catalog
+  categories:
+    - Publisher discovery
+  region: en


### PR DESCRIPTION
## Why
Prepare reader-facing source discovery for the upcoming progression-fantasy / LitRPG recommendation work while satisfying the daily source-growth target with a conservative, reproducible capability boundary.

## Scope
- add a new `progression-litrpg-publisher-discovery-starter` repository
- include three first-party publisher catalog routes: Aethon Books, Mountaindale Press, and Portal Books
- keep every entry strictly link-only with WebNR-authored descriptions and labels
- document the 2026-08-23 rights/runtime audit boundary and requirements for any future richer adapter

## Source audit
Five previously untracked candidate families were screened: Aethon Books, Mountaindale Press, Portal Books, Ascendant Reads, and ProgFans. Aethon, Mountaindale, and Portal received the full admission review and are the only candidates admitted here. Their public HTTPS catalog routes were reachable without an account; their current first-party pages directly support LitRPG/progression discovery. No reviewed origin supplied an explicit machine-interface/content-reuse grant that would justify catalog ingestion, so WebNR stores no origin metadata or content and performs no runtime API/HTML/feed/search polling. Ascendant Reads and ProgFans remain discovery candidates for a later source-specific audit rather than being admitted by association.

## Preserved behavior
- no existing source is changed or removed
- no origin content, rankings, ratings, prices, covers, profiles, retailer data, or book text is copied
- no account, payment, DRM, captcha, robots, age-gate, regional-control, or other access behavior is automated
- GA4 configuration, full-URL reporting, canonical hosts, routes, and existing source behavior are unchanged

## Validation
Expected repository Quality jobs must all succeed: Web quality, Documentation quality, Production evidence, and Chromium user journeys. The production build must copy the new static source directory unchanged and preserve existing analytics/source assertions.

## Risk / rollback
Risk is limited to adding a static source directory. Rollback is the squash commit for this PR; removing the two newly added source files restores the previous behavior without schema or migration work.

## Production acceptance
After squash merge, verify the exact merged application build and confirm that `/sources/progression-litrpg-publisher-discovery-starter/search_index.yml` and `README.txt` are publicly reachable while representative existing source and analytics behavior remain intact.