### PR TITLE
Expand progression and LitRPG publisher discovery

### DIFF
--- a/public/sources/progression-litrpg-publisher-discovery-starter/README.txt
+++ b/public/sources/progression-litrpg-publisher-discovery-starter/README.txt
@@ -22,6 +22,9 @@ Included discovery routes
 - Aethon Books — first-party catalog with a dedicated GameLit/LitRPG section and progression-fantasy releases
 - Mountaindale Press — first-party publisher catalog centered on LitRPG and related progression fiction
 - Portal Books — first-party catalog for LitRPG, progression fantasy, cultivation, and portal adventure
+- Wraithmarked Creative — first-party series collections that include Arcane Ascension, Mother of Learning, and Warformed
+- Shadow Alley Press — first-party library with LitRPG, cultivation, isekai, and progression-adjacent series
+- Timeless Wind Publishing — first-party publisher site explicitly covering progression fantasy, LitRPG, time loops, cultivation, and system-apocalypse fiction
 
 Content and rights boundary
 ---------------------------
@@ -40,17 +43,40 @@ reuse license. No reviewed origin exposes an explicit machine-interface license
 that would justify copying or continuously polling its catalog. The admitted
 capability is therefore link-only.
 
+The 2026-08-24 audit added three first-party discovery routes. Wraithmarked's
+public collections page exposes named fantasy series and normal reader-facing
+collection links. Shadow Alley Press exposes a public Library and identifies its
+focus as adult science fiction, fantasy, and action-adventure; its current catalog
+and release pages include LitRPG, cultivation, isekai, and progression-related
+series. Timeless Wind Publishing identifies itself as an independent fantasy and
+science-fiction publisher and explicitly lists progression fantasy, power fantasy,
+LitRPG, time loops, cultivation, and system apocalypse among the genres it seeks
+to publish. All three pages were reachable through a normal browser without an
+account on 2026-08-24. Their public pages provide no machine-readable reuse grant
+that WebNR relies on, so the admitted behavior stays link-only and copies no
+origin catalog data.
+
+Two additional candidates were screened during the same cycle and left outside
+the source. Royal Guard Publishing presents LitRPG and fantasy publishing but its
+first-party site currently emphasizes author submissions and links readers onward
+to retailer searches rather than exposing a stable reader catalog. The Legion
+Publishers publicly accepts LitRPG, GameLit, Progression Fantasy, Dungeon Core,
+Cultivation, Magical Academy, Harem, and Cyberpunk submissions, but the audited
+surface is likewise submission-oriented. Both remain candidates for a later
+reader-surface audit instead of being admitted on publisher identity alone.
+
 Current WebNR behavior
 ----------------------
-Selecting an item opens the corresponding public publisher catalog. WebNR does
-not call origin APIs, crawl catalog HTML, poll search or release pages, proxy
-responses, mirror metadata, cache publisher assets, automate accounts, or perform
-purchases. This starter adds no origin-site cookie, CORS, pagination, request-
-cadence, response-size, or rate-limit dependency to the WebNR reader path.
+Selecting an item opens the corresponding public publisher catalog or first-party
+discovery page. WebNR does not call origin APIs, crawl catalog HTML, poll search or
+release pages, proxy responses, mirror metadata, cache publisher assets, automate
+accounts, or perform purchases. This starter adds no origin-site cookie, CORS,
+pagination, request-cadence, response-size, or rate-limit dependency to the WebNR
+reader path.
 
 Audit boundary
 --------------
-The three included HTTPS catalog routes were rechecked on 2026-08-23 and were
+The six included HTTPS discovery routes were rechecked on 2026-08-24 and were
 publicly reachable without an account. Because the source makes no runtime
 requests to those origins beyond a reader choosing to follow a normal link,
 robots rules, automated-request cadence, pagination, CORS, response-size limits,
@@ -67,4 +93,4 @@ origin.
 
 Last verified
 -------------
-2026-08-23
+2026-08-24

--- a/public/sources/progression-litrpg-publisher-discovery-starter/search_index.yml
+++ b/public/sources/progression-litrpg-publisher-discovery-starter/search_index.yml
@@ -48,3 +48,53 @@ progression-litrpg-publisher-discovery/portal-books.md:
   categories:
     - Publisher discovery
   region: en
+
+progression-litrpg-publisher-discovery/wraithmarked-creative.md:
+  title: Wraithmarked Creative — Progression-Fantasy Series Discovery
+  author: Wraithmarked Creative
+  description: Wraithmarked Creative 的第一方系列目录集中列出 Arcane Ascension、Mother of Learning、Warformed 等 fantasy 与 progression-adjacent 系列。WebNR 仅保存官方集合页链接和自行撰写的发现标签，不复制商品、书籍、封面、价格、简介、库存或账户信息。
+  page_url: https://wraithmarked.com/collections
+  source: WebNR Progression & LitRPG Publisher Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Wraithmarked Creative
+    - Progression fantasy
+    - Fantasy
+    - Publisher catalog
+  categories:
+    - Publisher discovery
+  region: en
+
+progression-litrpg-publisher-discovery/shadow-alley-press.md:
+  title: Shadow Alley Press — LitRPG & Progression-Fantasy Library
+  author: Shadow Alley Press
+  description: Shadow Alley Press 的第一方 Library 提供其 fantasy 与 science-fiction 系列发现入口，当前书目包含 LitRPG、cultivation、isekai 与 progression 相关作品。WebNR 仅链接官方书库，不复制书籍简介、封面、价格、评论、零售链接、作者资料或正文。
+  page_url: https://shadowalleypress.com/library/
+  source: WebNR Progression & LitRPG Publisher Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Shadow Alley Press
+    - LitRPG
+    - Progression fantasy
+    - Cultivation
+    - Publisher catalog
+  categories:
+    - Publisher discovery
+  region: en
+
+progression-litrpg-publisher-discovery/timeless-wind-publishing.md:
+  title: Timeless Wind Publishing — Progression Fantasy & LitRPG Discovery
+  author: Timeless Wind Publishing
+  description: Timeless Wind Publishing 的第一方站点明确覆盖 progression fantasy、LitRPG、time loops、cultivation 与 system-apocalypse 等类型，并链接其当前出版作品。WebNR 仅保存官方站点链接和自行撰写的发现说明，不复制书籍简介、封面、价格、零售数据、作者资料或正文。
+  page_url: https://www.timelesswind.com/
+  source: WebNR Progression & LitRPG Publisher Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Timeless Wind Publishing
+    - LitRPG
+    - Progression fantasy
+    - Cultivation
+    - Publisher catalog
+  categories:
+    - Publisher discovery
+  region: en


### PR DESCRIPTION
## Outcome
Expand the existing progression/LitRPG publisher discovery starter with three newly audited first-party reader discovery routes: Wraithmarked Creative, Shadow Alley Press, and Timeless Wind Publishing.

## Evidence and scope
- Five new candidate families were screened for the 2026-08-24 source cycle: Wraithmarked Creative, Shadow Alley Press, Timeless Wind Publishing, Royal Guard Publishing, and The Legion Publishers.
- The first three expose stable public reader-facing discovery surfaces and were fully audited for the admitted WebNR capability.
- Royal Guard and The Legion Publishers remain deferred because the inspected first-party surfaces are primarily author/submission-oriented rather than stable reader catalogs.
- The admitted capability remains static link-only. No origin HTML, book metadata, prices, covers, reviews, accounts, or text are copied, crawled, polled, cached, or proxied.

## Blast radius and preserved behavior
Only `public/sources/progression-litrpg-publisher-discovery-starter/{search_index.yml,README.txt}` changes. Existing Aethon, Mountaindale, and Portal entries and source route remain intact. No application code, routing, canonical metadata, analytics, or unrelated source collections change.

## Validation and acceptance
Expected repository Quality checks must all succeed. Public acceptance after squash merge: the existing source route remains loadable and exposes all six link-only entries, while representative unrelated reader/docs routes and GA4 full-URL behavior remain unchanged.

## Risk and rollback
Low and reversible: the change adds only WebNR-authored labels and first-party HTTPS destination URLs to a static source fixture. Roll back the squash commit if source validation, build, or public source rendering regresses.