### PR TITLE
Publish progression fantasy and LitRPG recommendation method

### DIFF
--- a/docs/blog/posts/2026-08-24-progression-fantasy-litrpg-recommendation-method.md
+++ b/docs/blog/posts/2026-08-24-progression-fantasy-litrpg-recommendation-method.md
@@ -1,0 +1,380 @@
+---
+title: 2026 Progression Fantasy 与 LitRPG 推荐怎么找？从标签、社区到完结状态的选择方法
+date: 2026-08-24
+slug: progression-fantasy-litrpg-recommendation-method
+description: 面向 Progression Fantasy 与 LitRPG 读者的可复用推荐方法：用机制密度、成长路径、连载状态、格式平台、叙事质感与个人约束建立需求向量，再交叉核对平台标签、读者社区、专业目录和第一方出版信息。
+categories:
+  - Reader guides
+  - Recommendations
+  - Research
+---
+
+# 2026 Progression Fantasy 与 LitRPG 推荐怎么找？从标签、社区到完结状态的选择方法
+
+**直接答案：**寻找 Progression Fantasy 与 LitRPG 推荐时，先把自己的需求写成六个维度：**机制密度、成长路径、连载状态、阅读格式、叙事质感、个人约束**；随后用 Royal Road 一类平台标签生成候选，用 r/ProgressionFantasy 与 r/litrpg 一类读者社区寻找“相似口味的人”，再用出版社、作者页与作品原页核对版本、完结状态和当前可读入口。这样得到的是一组可解释的“适配推荐”，重点落在个人条件与证据链，而总榜只承担候选入口。[A1][A2][A5][A6][P2][P6][P10]
+
+[在 WebNR 添加 Progression & LitRPG Publisher Discovery Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fprogression-litrpg-publisher-discovery-starter){ .md-button .md-button--primary }
+
+## 摘要
+
+本文以 **2026 年 8 月 24 日**可公开访问的 Royal Road 搜索与榜单、Progression Fantasy 与 LitRPG 读者社区、类型目录、出版社目录、近期讨论，以及推荐系统、社会标签、在线书评和读者元数据研究为证据，回答一个非常具体的读者问题：**怎样稳定找到符合自己口味的 Progression Fantasy 与 LitRPG，而又能看清连载状态、平台差异与推荐偏差？**
+
+核心结论是一套“**六维需求向量 + 四层证据链**”。六维需求向量记录机制密度、成长路径、连载状态、阅读格式、叙事质感与个人约束；四层证据链依次使用平台结构化标签、社区自然语言经验、专业目录的交叉标签、第一方作品或出版信息。推荐系统研究长期强调准确率之外的多样性、情境、解释性与用户体验；社会标签研究说明读者自发词汇能够补充受控分类；Goodreads 与 Amazon 的比较研究又展示评价环境会改变读者表达。[A2][A4][A5][A6][A12][A13][A17][A18][A19] 对类型小说读者来说，这些研究共同指向一个实用原则：**推荐的价值来自“与你的阅读目标匹配”，并由多个独立来源共同支撑。**
+
+**关键词：** Progression Fantasy；LitRPG；Royal Road；r/ProgressionFantasy；r/litrpg；推荐系统；社会标签；完结状态；有声书；连载小说；读者社区
+
+## 研究问题、材料与方法
+
+本文研究的问题是：**当同一类作品同时存在 Web 连载、Kindle/纸书、有声书、出版社版本、社区口碑和多个标签体系时，读者怎样构建一条可复查的推荐路径？**
+
+材料分成四组。第一组是 Royal Road 的 Advanced Search、Rising Stars、Best Rated、Completed 与当前 Trending 页面，用于观察平台直接暴露的标签、状态、页数、更新时间和排序入口。[P2]-[P5][P23] 第二组是 r/ProgressionFantasy 与 r/litrpg 的近期公开讨论，用于观察读者实际提出推荐请求时会主动报告哪些偏好。[P6]-[P10][P24] 第三组是 ProgressionFantasy.co.uk、Ascendant Reads、LitRPG Toolkit 等类型目录，以及 Aethon、Mountaindale、Portal、Wraithmarked、Shadow Alley、Timeless Wind 等第一方出版或系列入口，用于交叉核对标签、格式与出版状态。[P11]-[P20] 第四组是推荐系统、社会标签、在线书评和游戏化叙事研究，用于解释为什么单一排行榜经常压缩掉真正决定阅读满意度的条件。[A1]-[A22]
+
+研究方法采用“候选生成—口味匹配—状态核验—时间核验”四步。平台标签负责候选生成；社区讨论负责口味匹配；第一方作品或出版社页面负责版本与状态核验；最后记录核验日期，为后续重查保留时间坐标。社区材料只承担“读者怎样表达偏好”与“某种推荐理由是否真实出现”这类观察性任务，作品身份、出版关系与可读入口交给第一方来源确认。[A16][A17][P6]-[P10]
+
+## 一、先把“想看什么”写成六维需求向量
+
+推荐系统研究从早期协同过滤一路发展到情境感知、用户体验、解释性、多样性与公平性，核心变化是把“给出一个高分项目”扩展成“在具体用户、具体场景和具体目标下提供有用选择”。[A1]-[A11] Progression Fantasy 与 LitRPG 特别适合这种思路，因为读者对“成长”二字内部的偏好差异很大。
+
+本文建议每次找书先写六个字段。
+
+### 1. 机制密度：你希望看到多少“系统”
+
+这一维记录读者对显式游戏机制的接受度。可以分成：
+
+- **高机制密度**：等级、属性、技能树、职业、任务、掉落、装备、系统提示持续参与叙事；
+- **中机制密度**：存在明确等级或能力框架，数字展示相对克制；
+- **低机制密度**：成长路径清晰，主要通过训练、境界、技巧、知识或资源呈现。
+
+这项区分直接解释了近期社区里反复出现的一类请求：读者喜欢成长与战斗，同时希望世界构建、角色关系和目标感占据更大比重；另一些读者明确寻找带成长感、同时把电子游戏界面式机制降到很低比例的作品。[P8][P9] “Progression Fantasy”这个标签本身也源于作者与读者寻找更精确类型语言的过程，Andrew Rowe 2019 年的类型概念说明把“角色力量与技能随时间增长”放在中心位置。[P1]
+
+### 2. 成长路径：你想看哪一种“变强”
+
+成长路径可以写成多选标签，例如：
+
+- cultivation / realm advancement；
+- level / class / skill build；
+- crafting / economy / settlement；
+- dungeon / tower / challenge ladder；
+- time loop / regression；
+- academy / training；
+- monster evolution；
+- kingdom building / leadership；
+- knowledge / research / magic-system mastery。
+
+Royal Road 当前 Advanced Search 已把许多这类信号放进标签体系；Rising Stars 与 Trending 页面也会同时展示 LitRPG、Progression、Cultivation、Time Loop、Crafting、Dungeon Crawler 等组合。[P2][P3][P23] 社会标签研究说明，自发标签能够补充正式分类体系，并把用户真正关心的主题词带进发现过程。[A12]-[A14][A19] 对读者而言，成长路径比宽泛的“Fantasy”标签更接近阅读体验。
+
+### 3. 连载状态：你愿意承担多少追更风险
+
+建议记录四类状态：
+
+- **completed**：作品页面显示完结；
+- **ongoing**：持续更新；
+- **book/arc complete**：当前卷或阶段完成，整体系列继续；
+- **edition transition**：Web 连载与商业电子书/有声书之间发生版本迁移。
+
+Royal Road 的搜索页允许直接设置 Completed，作品条目同时显示状态、章节与更新时间。[P2][P5] Best Rated 页面也大量包含已经完结的长篇。[P4] 对长篇类型小说来说，状态信息会显著改变推荐价值：一个偏好一次读完十卷的读者，与一个喜欢每天追更并参与评论区的读者，对同一作品会形成两套截然分开的满意度预期。
+
+### 4. 阅读格式：Web、电子书、有声书还是多格式
+
+Progression Fantasy 与 LitRPG 的发行链经常跨越 Royal Road、Kindle、Kindle Unlimited、有声书、纸书和出版社自有目录。Aethon 的当前目录把 GameLit/LitRPG 单列为类型，并同时收录 Progression Fantasy 作品；Mountaindale、Portal、Shadow Alley、Timeless Wind 等出版社也持续经营相关类型。[P15]-[P19] Wraithmarked 的系列集合则展示 Arcane Ascension、Mother of Learning、Warformed 等与 progression 读者高度重叠的系列。[P14]
+
+因此推荐卡里建议明确写“想读 Web 连载 / Kindle / 音频 / 纸书 / 任意格式”。音频用户还可以继续记录 narrator 偏好。社区推荐请求里，平台与格式本来就是读者常用的条件字段；2026 年 6 月一条 r/litrpg 推荐帖的自动提醒直接要求提问者说明自己使用 Audible、Royal Road、Kindle 等哪个平台。[P9]
+
+### 5. 叙事质感：你希望成长故事怎样“读起来”
+
+这一维建议用自然语言写，让多个描述共同保留读感：
+
+- 快节奏战斗 / 慢热探索；
+- 重世界构建 / 重角色关系；
+- 轻松 / 黑暗 / 温暖；
+- 单主角 / 群像；
+- 强情节 / slice of life；
+- 清晰目标 / 开放式漫游；
+- 强策略 / 强情绪 / 强幽默。
+
+近期 r/litrpg 的讨论里，有读者把“战斗依然重要、同时需要更多世界与角色时间”作为核心条件；r/ProgressionFantasy 的 tier list 讨论也会根据慢热、主题层次、角色复杂度等线索推断口味相似性。[P7][P8] 星级平均分只能覆盖其中一部分，社区自然语言与书评文本能保留更多细节。[A17][A18][A20]
+
+### 6. 个人约束：提前写出会直接决定弃书的条件
+
+个人约束常见于 romance 比例、harem、暴力强度、主角年龄、POV、性别视角、更新时间、篇幅、AI 内容标记、地区可用性等。Royal Road Advanced Search 当前已经提供类型、Additional Tags、Content Warnings、页数、评分、状态、排序和作品类型等字段。[P2] 这类约束越明确，社区回答越容易从“热门书单”进入真正的适配推荐。
+
+把六个字段合在一起，一条可直接使用的请求会长成这样：
+
+> 高成长感；中低系统密度；偏 cultivation 或 training；希望至少一卷完成；Web 或 Kindle 均可；重世界构建与角色关系；节奏中等；偏好单主角；希望 romance 占比较低。
+
+这种写法给推荐者提供了足够多的匹配坐标，也给自己留下了核对依据。
+
+## 二、四类入口各自解决一种问题
+
+### 第一层：Royal Road 一类平台解决“候选生成”
+
+Royal Road 目前为类型发现提供三种互补入口。**Advanced Search** 适合从零开始，用 genre、tag、status、page count、rating 等条件缩小集合；**Rising Stars / Trending** 适合观察近期增长与活跃作品；**Best Rated / Completed** 适合寻找已经积累大量反馈或已经完成的作品。[P2]-[P5][P23]
+
+这里的关键动作是“先筛选，再看榜”。例如，读者只接受完结 LitRPG，可以直接用 Completed + LitRPG；偏好 time loop、cultivation、crafting，也可以继续叠加标签。平台自身的标签与状态属于第一方结构化信息，适合作为候选生成器。
+
+推荐系统研究里，多样性与新颖性研究提醒我们，单纯沿排行榜头部浏览会反复遇到同一批高曝光项目。[A5][A6] 搜索过滤器的价值就在于先定义兴趣空间，再在空间内部排序。
+
+### 第二层：r/ProgressionFantasy 与 r/litrpg 解决“口味匹配”
+
+社区最强的信号来自“为什么这个人喜欢这本书”。近期公开讨论清楚展示了这种信息密度：
+
+- 有人寻找较少数值、较多世界构建与角色时间的 LitRPG / progression fantasy；[P8]
+- 有人明确寻找带成长元素、同时把电子游戏式机制降到较低比例的作品；[P9]
+- 有人把自己正在追的几十部 Royal Road Web 小说做成 tier list，评论者再从慢热、主题、人物复杂度推断相似口味；[P7]
+- r/ProgressionFantasy 的 Weekly Reading Roundup 让读者持续交流正在阅读的作品、短评和相邻推荐；[P6]
+- 2026 年 8 月还有社区成员把公开 tier lists 聚合成协同过滤式 LitRPG 推荐器，直接说明“相似读者”思路已经进入该社区的自发工具实践。[P10]
+
+协同过滤的经典思想正是从相似用户行为推导候选；用户体验研究又强调推荐理由与交互场景的重要性。[A1][A2] 对读者来说，社区的高价值字段是“我喜欢 A 的什么，也讨厌 B 的什么”。只要这个理由与自己的六维需求向量相似，这条推荐的解释力通常高于单纯“五星”。
+
+### 第三层：专业目录解决“交叉标签与长尾发现”
+
+ProgressionFantasy.co.uk 提供类型定义与大量细粒度标签；Ascendant Reads 的 Atlas 页面把 progression system、trope、genre、audio 等字段做成可检查的目录统计；LitRPG Toolkit 当前提供跨 Royal Road 与 Kindle 的大规模书目浏览与多条件过滤。[P11]-[P13]
+
+这些目录很适合做第二候选集。它们把平台特定标签重新组织成读者语言，也容易暴露长尾作品。社会标签与文学元数据研究说明，用户贡献词汇常能补充传统主题词表，尤其适合文学作品的“氛围、母题、关系、读感”这类检索需求。[A12][A13][A18][A19]
+
+使用目录时建议保留来源意识：查看“数据更新时间”“字段来源”“未知值怎样处理”“完成状态怎样定义”。Ascendant Reads 的 Atlas 当前明确说明其统计来自自身目录，未知字段保留为未知，并提醒数字会随目录更新。[P12] 这种边界声明本身就是高质量推荐资料的重要特征。
+
+### 第四层：出版社、作者与作品原页解决“版本和可用性核验”
+
+最后一层回答三个事实问题：**现在从哪里读、这一版是谁发布、系列处于什么状态。**
+
+Aethon 当前第一方目录明确提供 GameLit/LitRPG 分类，并展示 progression fantasy 作品；Mountaindale 的当前目录集中展示其 LitRPG 书目；Portal 公开书目覆盖 LitRPG、progression fantasy 与 cultivation；Shadow Alley 的 Library 与近期发行页包含 LitRPG、cultivation、isekai 等作品；Timeless Wind 的第一方站点直接列出 progression fantasy、LitRPG、time loop、cultivation、system apocalypse 等出版方向。[P15]-[P19] Wraithmarked 的系列集合适合核对其实际发行与收藏版本。[P14]
+
+第一方页面承担“当前状态”的最后确认。社区帖适合解释读感，目录适合检索，出版社与作品原页适合确认版本。把职责分开，推荐链就会稳定很多。
+
+## 三、把每条推荐写成一张“可解释卡片”
+
+本文建议保存七个字段：
+
+| 字段 | 记录内容 | 主要来源 |
+| --- | --- | --- |
+| 作品身份 | 标题、作者、系列 | 作品原页 / 出版社 |
+| 机制密度 | 高 / 中 / 低 + 一句理由 | 平台标签 + 读者讨论 |
+| 成长路径 | cultivation、skills、crafting、time loop 等 | 平台标签 + 目录 |
+| 当前状态 | completed / ongoing / book complete / 版本迁移 | 作品原页 |
+| 格式入口 | Web、ebook、audio、print | 第一方出版页 |
+| 口味证据 | 与哪类读者偏好相似、推荐理由是什么 | 社区讨论 |
+| 核验日期 | YYYY-MM-DD | 自己记录 |
+
+例如，一条“适合偏爱低数值、强世界构建、希望至少一卷完成的读者”的推荐，至少需要三类证据：平台或作者页显示作品的类型与状态；社区评论描述世界构建与机制密度；第一方出版信息确认当前可读格式。每一类证据只承担自己擅长的字段。
+
+解释性推荐研究强调透明度与信任之间存在紧密关系；推荐系统评价框架也要求把系统目标、数据、方法和指标一起考虑。[A6][A8][A15] 对个人找书而言，“为什么推荐给我”就是最实用的解释层。
+
+## 四、一个 15 分钟可重复的找书流程
+
+### 第 1—3 分钟：写需求
+
+写下六维需求向量，优先写三项最关键条件。例：低系统密度、完结优先、世界构建强。
+
+### 第 4—7 分钟：结构化筛选
+
+在 Royal Road Advanced Search 或一个专业目录里组合标签与状态，保存 5—10 个候选。[P2][P11]-[P13]
+
+### 第 8—11 分钟：社区匹配
+
+搜索“候选名 + subreddit”，再搜索自己的条件词，例如：
+
+- `site:reddit.com/r/ProgressionFantasy completed slow burn progression`
+- `site:reddit.com/r/litrpg low stats worldbuilding`
+- `site:reddit.com/r/litrpg audiobook crafting`
+
+关注评论里的比较句：喜欢 X 的人为什么喜欢 Y；弃掉某作品的人卡在哪个机制；读者怎样描述成长速度、角色关系、幽默、战斗比例。近期讨论已经显示这些变量会直接进入真实推荐请求。[P6]-[P10][P24]
+
+### 第 12—14 分钟：第一方核验
+
+打开作品原页、作者页或出版社页，确认状态、卷次、格式和当前入口。Web 连载与商业版并行时，把两者分别记录。
+
+### 第 15 分钟：做三选一
+
+给候选写一句“匹配理由”，再从三个不同方向各留一个：
+
+1. **最贴合**：六维匹配度最高；
+2. **相邻探索**：保留主要偏好，同时改变一个维度；
+3. **长尾候选**：热度较低，解释证据仍然完整。
+
+这种三选一结构把准确性、多样性和新颖性同时带进个人决策。[A5][A6]
+
+## 五、为什么“社区最热门”会漏掉你的最佳下一本
+
+### 1. 热度带来头部重复
+
+推荐系统里的 popularity bias 会让高曝光项目继续获得更多曝光；多样性研究因此把 novelty 与 diversity 作为独立目标。[A5][A6][A9][A10] 类型社区里也存在类似结构：新读者频繁提出相近问题，热门系列持续进入回答，长尾作品需要更细的条件才能浮现。[P7][P24]
+
+应对方式很简单：先筛选，再排行；每次至少加入一个“相邻探索”与一个“长尾候选”。
+
+### 2. 同一个评分在不同平台里含义会变化
+
+Dimitrov 等人比较 Goodreads 与 Amazon 的同类书评后发现，评论环境与商业语境会改变评价行为。[A17] Trott 与 Naik 对 Goodreads 的讨论也强调读者自发语言在 readers’ advisory 中的价值。[A18] 因此星级适合做辅助信号，具体评论理由更适合做口味匹配。
+
+### 3. 标签很强，同时带着社区语境
+
+folksonomy 研究表明社会标签能够提升检索和发现，同时也会形成自己的词汇习惯与语义结构。[A12]-[A14] Progression Fantasy 的标签生态尤其活跃：LitRPG、GameLit、cultivation、system apocalypse、time loop、regression、dungeon core、crafting 等词在不同站点存在粒度差异。[P2][P11][P12]
+
+应对方式是给每个标签配一个自己的短定义。例如“low stats = 系统存在，正文很少展示数字面板”。这样跨平台时依然能保持一致。
+
+### 4. 连载状态具有时间性
+
+Web 小说会更新、完结、迁移版本、下架章节或进入商业出版阶段。Royal Road 当前页面直接显示更新时间与状态，部分作品简介还会说明卷次完成、Amazon/Audible 版本等信息。[P3]-[P5] 推荐卡保留核验日期，就能把“当时真实”与“现在真实”分开。
+
+### 5. 社区样本反映参与讨论者的表达
+
+社交数据研究持续提醒研究者关注自选择、平台人口结构、可见性和采集边界。[A16] Reddit 公开讨论适合观察活跃社区成员怎样表达偏好，适合给个人找书提供丰富解释。它们承担“口味语料”的角色，适合描述参与讨论者表达出的阅读需求。
+
+## 六、反例与边界：什么时候另一种方法更合适
+
+有几种阅读任务适合更直接的入口。
+
+**新入门读者**希望先建立类型坐标时，可以从作者提出的 progression fantasy 定义、Royal Road Best Rated、出版社代表目录开始，先读一两部典型作品，再细化六维向量。[P1][P4][P15]
+
+**音频优先读者**的约束通常集中在 narrator、时长、系列音频进度和地区可用性。此时第一方出版社与音频零售页应提前到第二步，社区用于判断 narration 风格与系列体验。
+
+**追更型读者**关注更新频率和当前活跃度。Rising Stars、Trending、Latest Updates 这类时间敏感入口更有价值。[P3][P23]
+
+**研究型读者**关注类型边界与媒介形式。LitRPG 把游戏机制直接嵌入小说叙事，相关研究已经从游戏与文学的跨媒介关系、角色能动性和身份等角度展开。[A21][A22] 这类读者可以把“机制如何进入叙事”本身设为搜索维度。
+
+这些路径说明推荐方法应随任务切换。推荐系统评价研究把场景、目标与用户体验放在同一框架中，个人阅读选择也适用相同思想。[A2][A4][A6]
+
+## 七、原创综合：把推荐可信度拆成四个可检查因素
+
+综合平台结构、社区语言与推荐系统研究，本文提出一个面向类型小说的“**四因素推荐可信度**”框架：
+
+**推荐可信度 = 口味贴合 × 证据多样性 × 信息新鲜度 × 状态确定性**
+
+这里的乘法是概念表达，用来提醒读者四项中任何一项很弱时都值得继续核验。
+
+### 口味贴合
+
+候选与六维需求向量重合多少。最重要的是你的前三项硬条件。
+
+### 证据多样性
+
+同一判断是否由不同类型来源支持。平台标签、社区评论、专业目录、第一方出版页分别承担不同字段时，证据结构最清晰。
+
+### 信息新鲜度
+
+更新时间、版本与可读入口距离今天有多近。推荐帖可以长期保留读感价值，状态字段则需要重新核对。
+
+### 状态确定性
+
+completed、ongoing、卷完成、Web 版迁移、音频进度等字段是否有第一方页面支撑。
+
+这套框架带来一个很实用的排序变化：**一部热度中等、与你高度贴合、状态明确、多个来源都能解释其特点的作品，常常比“社区总榜第一名”更适合作为你的下一本。** 推荐从“谁最有名”变成“哪一部最适合当前这次阅读”。
+
+## 八、WebNR 在这条发现链里适合做什么
+
+WebNR 的价值适合放在“来源导航与证据保留”一侧。当前 Progression & LitRPG Publisher Discovery Starter 已收录 Aethon Books、Mountaindale Press、Portal Books，并在 2026 年 8 月 24 日增加 Wraithmarked Creative、Shadow Alley Press 与 Timeless Wind Publishing 的第一方发现入口。[P14]-[P19]
+
+这些入口采用 link-only 方式：WebNR 保存第一方目标 URL 与自行撰写的发现标签，书籍简介、封面、价格、评分、零售数据、账户状态和正文继续留在原站。这样，读者可以把 WebNR 当作一张稳定的“去哪里核验”地图，再回到第一方页面完成版本确认。
+
+对推荐方法来说，这也对应本文的最后一层证据：平台和社区负责发现与解释，第一方来源负责当前事实。
+
+## 结论
+
+Progression Fantasy 与 LitRPG 的推荐质量，取决于读者能否把“我想看一个好看的”转换成一组可检查条件。最实用的做法是：
+
+1. 用**机制密度、成长路径、连载状态、阅读格式、叙事质感、个人约束**建立六维需求向量；
+2. 用 Royal Road 一类平台的标签与状态生成候选；
+3. 用 r/ProgressionFantasy、r/litrpg 等社区寻找口味相似与具体推荐理由；
+4. 用专业目录扩展长尾与交叉标签；
+5. 用作品原页、作者页、出版社页确认当前版本与可读入口；
+6. 保存核验日期，并用“口味贴合、证据多样性、信息新鲜度、状态确定性”检查每条推荐。
+
+这套方法把排行榜转化成搜索入口，把社区口碑转化成解释证据，把出版社页面转化成状态锚点。最终得到的是一套可复用、可更新、可说明理由的个人推荐系统。
+
+## 参考文献
+
+### 学术研究
+
+[A1] Resnick, P.; Varian, H. R. (1997). **Recommender Systems.** *Communications of the ACM*, 40(3). https://doi.org/10.1145/245108.245121
+
+[A2] Konstan, J. A.; Riedl, J. (2012). **Recommender systems: from algorithms to user experience.** *User Modeling and User-Adapted Interaction*, 22, 101–123. https://doi.org/10.1007/s11257-011-9112-x
+
+[A3] Lü, L.; Medo, M.; Yeung, C. H.; Zhang, Y.-C.; Zhang, Z.-K.; Zhou, T. (2012). **Recommender systems.** *Physics Reports*, 519(1), 1–49. https://arxiv.org/abs/1202.1112
+
+[A4] Adomavicius, G.; Mobasher, B.; Ricci, F.; Tuzhilin, A. (2011). **Context-Aware Recommender Systems.** *AI Magazine*, 32(3). https://ojs.aaai.org/index.php/aimagazine/article/view/2364
+
+[A5] Vargas, S.; Castells, P. (2011). **Rank and relevance in novelty and diversity metrics for recommender systems.** *Proceedings of RecSys 2011*. https://doi.org/10.1145/2043932.2043955
+
+[A6] Zangerle, E.; Bauer, C. (2022). **Evaluating Recommender Systems: Survey and Framework.** *ACM Computing Surveys*, 55(8), Article 170. https://doi.org/10.1145/3556536
+
+[A7] Silveira, T.; Zhang, M.; Lin, X.; Liu, Y.; Ma, S. (2019). **How good your recommender system is? A survey on evaluations in recommendation.** *International Journal of Machine Learning and Cybernetics*. https://doi.org/10.1007/s13042-017-0762-9
+
+[A8] Zhang, Y.; Chen, X. (2020). **Explainable Recommendation: A Survey and New Perspectives.** *Foundations and Trends in Information Retrieval*, 14(1). https://arxiv.org/abs/1804.11192
+
+[A9] Milano, S.; Taddeo, M.; Floridi, L. (2020). **Recommender systems and their ethical challenges.** *AI & Society*, 35, 957–967. https://doi.org/10.1007/s00146-020-00950-y
+
+[A10] Wang, Y.; Ma, W.; Zhang, M.; Liu, Y.; Ma, S. (2023). **A Survey on the Fairness of Recommender Systems.** *ACM Transactions on Information Systems*. https://doi.org/10.1145/3547333
+
+[A11] Schedl, M.; Zamani, H.; Chen, C.-W.; Deldjoo, Y.; Elahi, M. (2018). **Current challenges and visions in music recommender systems research.** *International Journal of Multimedia Information Retrieval*, 7, 95–116. https://doi.org/10.1007/s13735-018-0154-2
+
+[A12] Hotho, A.; Jäschke, R.; Schmitz, C.; Stumme, G. (2006). **Information Retrieval in Folksonomies: Search and Ranking.** *ESWC 2006*. https://link.springer.com/chapter/10.1007/11762256_31
+
+[A13] Jäschke, R.; Marinho, L. B.; Hotho, A.; Schmidt-Thieme, L.; Stumme, G. (2007). **Tag Recommendations in Folksonomies.** *PKDD 2007*. https://link.springer.com/chapter/10.1007/978-3-540-74976-9_52
+
+[A14] Mika, P. (2005). **Ontologies Are Us: A Unified Model of Social Networks and Semantics.** *ISWC 2005*. https://link.springer.com/chapter/10.1007/11574620_38
+
+[A15] Cramer, H.; Evers, V.; Ramlal, S.; van Someren, M.; Rutledge, L.; Stash, N.; Aroyo, L.; Wielinga, B. (2008). **The effects of transparency on trust in and acceptance of a content-based art recommender.** *User Modeling and User-Adapted Interaction*. https://doi.org/10.1007/s11257-008-9051-3
+
+[A16] Olteanu, A.; Castillo, C.; Diaz, F.; Kıcıman, E. (2019). **Social Data: Biases, Methodological Pitfalls, and Ethical Boundaries.** *Frontiers in Big Data*, 2:13. https://doi.org/10.3389/fdata.2019.00013
+
+[A17] Dimitrov, S.; Zamal, F. A.; Piper, A.; Ruths, D. (2015). **Goodreads versus Amazon: The Effect of Decoupling Book Reviewing and Book Selling.** *Proceedings of ICWSM 2015*. https://ojs.aaai.org/index.php/ICWSM/article/view/14662
+
+[A18] Trott, B.; Naik, Y. (2012). **Finding Good Reads on Goodreads: Readers Take RA into Their Own Hands.** *Reference & User Services Quarterly*, 51(4), 319–323. https://doi.org/10.5860/rusq.51n4.319
+
+[A19] DeZelar-Tiedman, C. (2011). **Exploring User-Contributed Metadata's Potential to Enhance Access to Literary Works: Social Tagging in Academic Library Catalogs.** *Library Resources & Technical Services*, 55(4), 221–233. https://doi.org/10.5860/lrts.55n4.221
+
+[A20] Shahsavari, S.; Ebrahimzadeh, E.; Shahbazi, B.; Falahi, M.; Holur, P.; Bandari, R.; Tangherlini, T. R.; Roychowdhury, V. (2020). **An Automated Pipeline for Character and Relationship Extraction from Readers' Literary Book Reviews on Goodreads.com.** *WebSci 2020*. https://doi.org/10.1145/3394231.3397918
+
+[A21] Wenig, N. (2024). **[New self obtained - level up!]: the impact of ludic elements on the agency and identity of LitRPG protagonists.** University of Vienna Master's thesis. https://doi.org/10.25365/thesis.77524
+
+[A22] Caracciolo, M. (2023). **Remediating Video Games in Contemporary Fiction: Literary Form and Intermedial Transfer.** https://biblio.ugent.be/publication/8763602
+
+### 平台、社区、目录与第一方来源
+
+[P1] Andrew Rowe. **Progression Fantasy – A New Subgenre Concept.** 2019-02-26. https://andrewkrowe.wordpress.com/2019/02/26/progression-fantasy-a-new-subgenre-concept/
+
+[P2] Royal Road. **Advanced Search.** Accessed 2026-08-24. https://www.royalroad.com/fictions/search?advanced=True&globalFilters=true
+
+[P3] Royal Road. **Rising Stars.** Accessed 2026-08-24. https://www.royalroad.com/fictions/rising-stars
+
+[P4] Royal Road. **Best Rated.** Accessed 2026-08-24. https://www.royalroad.com/fictions/best-rated
+
+[P5] Royal Road. **Completed LitRPG search example.** Accessed 2026-08-24. https://www.royalroad.com/fictions/search?globalFilters=true&status=COMPLETED&tagsAdd=litrpg
+
+[P6] r/ProgressionFantasy. **New Weekly Reading Roundup.** 2026-08-21. https://www.reddit.com/r/ProgressionFantasy/comments/1vuee6f/new_weekly_reading_roundup/
+
+[P7] r/ProgressionFantasy. **Updated tierlist from all the (progression fantasy) webnovels I am reading at RR, recommendations welcome!** 2026-08-20. https://www.reddit.com/r/ProgressionFantasy/comments/1vtcvmn/updated_tierlist_from_all_the_progression_fantasy/
+
+[P8] r/litrpg. **I want litrpg/progression fantasy… just a little less “number go brrr”.** 2026-08-01. https://www.reddit.com/r/litrpg/comments/1vc8htj/i_want_litrpgprogression_fantasy_just_a_little/
+
+[P9] r/litrpg. **Anyone have any progression fantasy … recommendations that AREN'T a video game mechanic lit RPG?** 2026-06-10. https://www.reddit.com/r/litrpg/comments/1u2g6wl/anyone_have_any_progression_fantasy_or_fantasy/
+
+[P10] r/litrpg. **r/LitRPG Specific Recommender System.** 2026-08-01. https://www.reddit.com/r/litrpg/comments/1vcrveo/rlitrpg_specific_recommender_system/
+
+[P11] Progression Fantasy & LitRPG Database. **Definitions.** Accessed 2026-08-24. https://progressionfantasy.co.uk/definitions/
+
+[P12] Ascendant Reads. **Progression Fantasy Atlas Data.** Updated 2026-08-20; accessed 2026-08-24. https://ascendantreads.com/atlas-data
+
+[P13] LitRPG Toolkit. **Browse books.** Accessed 2026-08-24. https://litrpgtoolkit.com/books
+
+[P14] Wraithmarked Creative. **Collections.** Accessed 2026-08-24. https://wraithmarked.com/collections
+
+[P15] Aethon Books. **Our Catalog.** Accessed 2026-08-24. https://aethonbooks.com/catalog/
+
+[P16] Mountaindale Press. **Catalog.** Accessed 2026-08-24. https://www.mountaindalepress.store/pages/catalog
+
+[P17] Portal Books. **Browse Our Books.** Accessed 2026-08-24. https://portal-books.com/our-books/
+
+[P18] Shadow Alley Press. **Library.** Accessed 2026-08-24. https://shadowalleypress.com/library/
+
+[P19] Timeless Wind Publishing. **Home / catalog discovery.** Accessed 2026-08-24. https://www.timelesswind.com/
+
+[P20] Podium Entertainment. **Browse Titles / LitRPG & GameLit genre entry.** Accessed 2026-08-24. https://podiumentertainment.com/titles
+
+[P21] Royal Guard Publishing. **Publisher home and current eBook/audiobook discovery links.** Accessed 2026-08-24. https://royalguardpublishing.com/
+
+[P22] The Legion Publishers. **Contact and Submissions.** Accessed 2026-08-24. https://www.legionpublishers.com/contact-and-submissions
+
+[P23] Royal Road. **Trending.** Accessed 2026-08-24. https://www.royalroad.com/fictions/trending?genre=fantasy
+
+[P24] r/ProgressionFantasy. **What qualifies as progression fantasy?** 2026-04-02. https://www.reddit.com/r/ProgressionFantasy/comments/1sa9kur/what_qualifies_as_progression_fantasy/


### PR DESCRIPTION
## Outcome
Publish the 2026-08-24 research-heavy reader guide answering where and how readers can find progression fantasy and LitRPG recommendations.

## Thesis and evidence
The guide turns recommendation seeking into a reusable method: a six-dimensional reader demand vector (mechanism density, progression path, serialization status, format, narrative texture, personal constraints) plus a four-layer evidence chain spanning platform tags, reader communities, specialist directories, and first-party work/publisher pages.

Research used multiple public-web rounds and Sider Scholar across recommendation systems, folksonomies, book-review environments, LitRPG/game-literature research, current Royal Road discovery surfaces, r/ProgressionFantasy and r/litrpg discussions, specialist directories, and first-party publisher pages. The article contains 22 academic references and 24 platform/community/first-party references, exceeds 10,000 Chinese main-text characters, includes counterexamples/boundaries and an original four-factor recommendation-confidence synthesis.

## Language review
Completed a literal negation-pattern scan over author-written prose and a separate semantic review. The research question, thesis, evidence, counterevidence, examples, synthesis, and practical workflow remain explicit and concrete.

## Blast radius and preserved behavior
Adds one MkDocs blog post only. Existing articles, routes, canonical ownership, reader application, source collections, analytics (`G-DGH8HNQKE4`, full-URL reporting), navigation, and unrelated copy remain unchanged.

## Validation and public acceptance
All expected Quality jobs must reach successful terminal conclusions. After squash merge, verify the exact canonical documentation deployment and public article, including rendered title/body/references, canonical URL, sitemap/RSS discovery, GA4 runtime contract, and a representative unaffected article/reader route.

## Risk and rollback
Low, editorial-only and fully reversible. Roll back the squash commit if strict documentation build, link/output validation, language/content review, or exact public rendering fails.