### PR TITLE
Add fanfiction discovery starter

### DIFF
--- a/public/sources/fanfiction-discovery-starter/README.txt
+++ b/public/sources/fanfiction-discovery-starter/README.txt
@@ -1,0 +1,99 @@
+Fanfiction Discovery Starter
+============================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/fanfiction-discovery-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Ffanfiction-discovery-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small link-only directory for readers looking
+for fan fiction and transformative serial fiction. It points to first-party
+search or browse surfaces while leaving work metadata, fandom ownership,
+accounts, ratings, comments, downloads, and story text at the origin.
+
+Included discovery routes
+-------------------------
+- FanFiction.Net — first-party story and crossover search across its fandom archive
+- Fimfiction — first-party story browse and search for My Little Pony fanfiction
+- Scribble Hub — first-party Fanfiction genre directory for serialized works hosted on Scribble Hub
+
+Content and rights boundary
+---------------------------
+The committed index contains only first-party destination URLs plus short
+WebNR-authored descriptions and discovery labels. It does not copy story titles,
+summaries, covers, author profiles, fandom metadata, ratings, comments, bookmarks,
+release history, downloadable files, account data, or story text from any origin.
+
+FanFiction.Net's current public Terms of Service restrict redistribution and
+automated access beyond ordinary browser-like use, and its current robots policy
+also carries explicit crawler controls. This starter therefore performs no
+FanFiction.Net crawling, search polling, offline reading, scraping, or mirroring;
+it only lets a reader choose to open the normal first-party search page.
+
+Fimfiction exposes both a public story browser and an official developer API. Its
+API terms require responsible resource use, rate-limit compliance, appropriate
+caching, no excessive polling, and no replication of the site's core
+functionality. The existence of that API is not treated as blanket permission to
+mirror its catalog. This starter deliberately stays link-only and uses no API
+credentials, OAuth state, background polling, download endpoints, or copied story
+metadata. A richer adapter would require its own capability-limited design,
+current API/rights review, request bounds, deletion semantics, and versioned
+fixtures.
+
+Scribble Hub exposes a public Series Finder and a first-party Fanfiction genre.
+Its Terms of Service, last observed updated 2026-06-29, describe user-posted works
+as User Content and grant Scribble Hub service-specific hosting/display rights;
+WebNR does not infer a redistribution license from that relationship. The current
+integration therefore links the public Fanfiction directory without copying or
+polling user submissions.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the corresponding first-party discovery page. WebNR does
+not call origin APIs, crawl catalog HTML, poll rankings or updates, proxy
+responses, mirror metadata, cache origin assets, automate accounts, submit forms,
+perform downloads, or attempt to bypass age, login, payment, captcha, robots,
+rate-limit, or other access controls.
+
+Because the admitted capability is static link-only, the WebNR reader path adds
+no origin-site CORS, cookie, login, pagination, request-cadence, response-size,
+encoding, timeout, WebView, or Bridge dependency. Any limits or account rules a
+reader encounters after following a normal link remain those of the origin.
+
+Audit boundary
+--------------
+The three included HTTPS discovery routes were checked through normal public web
+access on 2026-08-25. FanFiction.Net's search surface did not require an account
+for the audited reader path. Fimfiction's public Stories page rendered a browse
+and filter surface without requiring an account, while also indicating that some
+site functionality benefits from JavaScript. Scribble Hub's Series Finder and
+Fanfiction genre were publicly discoverable without an account in the audited
+path.
+
+The committed search index is the versioned fixture for this static link-only
+capability. A richer adapter for any origin would require a separate audit of an
+explicitly permitted machine interface, current terms and robots behavior,
+stable work/edition identity, pagination, request cadence, rate limits, timeouts
+and backoff, provenance, attribution, update/deletion semantics, regional and
+age/access boundaries, maximum response size, and representative versioned
+fixtures.
+
+Candidate boundary
+------------------
+Archive of Our Own (AO3) remains a high-value candidate for the scheduled
+fanfiction ecosystem work, but no source capability was admitted in this cycle
+because the operating environment did not provide sufficiently current
+first-party machine-access and policy evidence for a complete source audit.
+Twisting the Hellmouth was also screened but its first-party reader surface was
+not reliably accessible from the operating environment during this cycle. Neither
+candidate is treated as failed, licensed, or safe for automated ingestion by
+assumption; both remain deferred for a later evidence-complete audit.
+
+Last verified
+-------------
+2026-08-25

--- a/public/sources/fanfiction-discovery-starter/search_index.yml
+++ b/public/sources/fanfiction-discovery-starter/search_index.yml
@@ -1,0 +1,47 @@
+fanfiction-discovery/fanfiction-net-search.md:
+  title: FanFiction.Net — Story & Crossover Search
+  author: FanFiction.Net
+  description: FanFiction.Net 的第一方公开搜索入口，可按 fandom、标题/简介关键词以及普通或 crossover 作品寻找同人小说。WebNR 仅保存官方搜索链接和自行撰写的发现说明，不抓取、复制、缓存或重发用户投稿、作者资料、评论、收藏数据或正文。
+  page_url: https://www.fanfiction.net/search/?ready=1
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - FanFiction.Net
+    - Fan fiction
+    - Crossover
+    - Fandom search
+  categories:
+    - Fanfiction discovery
+  region: en
+
+fanfiction-discovery/fimfiction-stories.md:
+  title: Fimfiction — My Little Pony Fanfiction Browse
+  author: Fimfiction
+  description: Fimfiction 的第一方 Stories 目录可按标签、题材、完成状态、篇幅、更新时间与排序方式发现 My Little Pony 同人小说。WebNR 当前只链接官方目录，不调用其 API，也不复制故事元数据、下载文件、封面、评论、评分、账户数据或正文。
+  page_url: https://www.fimfiction.net/stories
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Fimfiction
+    - Fan fiction
+    - My Little Pony
+    - Story discovery
+  categories:
+    - Fanfiction discovery
+  region: en
+
+fanfiction-discovery/scribble-hub-fanfiction.md:
+  title: Scribble Hub — Fanfiction Genre
+  author: Scribble Hub
+  description: Scribble Hub 的第一方 Fanfiction 题材目录，为已在 Scribble Hub 连载的同人作品提供按章节、更新、热度、评分、读者与状态等维度的发现入口。WebNR 仅保存官方题材页链接，不复制用户作品、简介、封面、评分、评论、作者资料或正文。
+  page_url: https://www.scribblehub.com/genre/fanfiction/
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Scribble Hub
+    - Fan fiction
+    - Serialized fiction
+    - Genre discovery
+  categories:
+    - Fanfiction discovery
+  region: en


### PR DESCRIPTION
## Outcome

Add a conservative WebNR-maintained fanfiction discovery starter with three audited first-party reader routes: FanFiction.Net search, Fimfiction story browse, and Scribble Hub's Fanfiction genre.

## Evidence and scope

- FanFiction.Net exposes a public search surface; its current Terms of Service and robots policy constrain automated access and redistribution, so the admitted capability is static link-only.
- Fimfiction exposes a public story browser and an official API whose terms require responsible use, rate-limit compliance, caching, and avoidance of replicating core site functionality. This change does not use the API or any credentials.
- Scribble Hub exposes a public Series Finder and Fanfiction genre; its Terms of Service were observed updated 2026-06-29 and do not provide WebNR a general redistribution license for user submissions.
- AO3 and Twisting the Hellmouth were screened but remain deferred because this cycle did not obtain evidence-complete first-party machine-access/policy and reader-surface verification respectively.

The diff is limited to a new `public/sources/fanfiction-discovery-starter/` static fixture. It does not change application code, analytics, canonical ownership, existing source definitions, or origin-site request behavior.

## Preserved behavior

WebNR stores only first-party destination URLs plus WebNR-authored labels/descriptions. It does not crawl, poll, proxy, mirror, download, or copy origin story metadata/content and does not add cookies, login state, CORS, WebView, Bridge, API credentials, or background requests.

## Validation

Expected repository Quality workflow: Web quality, Documentation quality, Production evidence, and Chromium user journeys. Final review will be restarted from the operating contract only after every expected check succeeds.

## Risk and rollback

Risk is limited to an incorrect or stale static discovery link/description. Rollback is the squash commit that precedes this PR; removal of this isolated source directory restores the previous behavior without migration or user-data impact.

## Deployment and acceptance

This is rendered/static application output. After squash merge, the application deployment must attribute `https://app.webnovel.win/build.json` to the exact squash commit, `https://app.webnovel.win/sources/fanfiction-discovery-starter/search_index.yml` must expose all three link-only routes, and a representative existing source route must remain intact. Existing GA4 full-URL behavior and the documentation/canonical production identities must remain unchanged.