### PR TITLE
Expand fanfiction discovery and publish research guide

### DIFF
--- a/docs/blog/posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md
+++ b/docs/blog/posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md
@@ -11,48 +11,44 @@ categories:
 
 # 2026 同人小说与变形创作怎么找？AO3 标签、书签、合集、社区与本地阅读路线
 
-**直接答案：**寻找同人小说时，把“排行榜找高分作品”换成一条五层路线通常更有效：**先用 fandom / relationship / character / additional tags 表达内容语义，再用完结状态、字数、语言与更新时间表达阅读成本；接着沿作者、公开书签、推荐、合集与社区讨论扩展候选；随后去独立档案补齐 AO3 之外的生态；最后只把自己有权保存的文本或下载文件带进本地阅读器，并保留原始链接与来源信息。** AO3 更接近一套由用户标签与 tag wrangling 共同维护的档案检索系统，而不是替读者自动决定“你下一篇应该读什么”的个性化推荐器。[A10][A14][A15][A16][P3][P4]
+**直接答案：**寻找同人小说时，可以把“看总榜挑高分”换成一条五层路线：**先用 fandom / relationship / character / additional tags 表达内容语义，再用完结状态、字数、语言、更新时间与 warnings 表达阅读成本；接着沿作者、公开书签、推荐、合集与社区讨论扩展候选；随后去独立档案补齐 AO3 之外的生态；最后把自己有权保存的文本或下载文件带进本地阅读器，并保留原始链接与来源信息。** AO3 更接近一套由用户标签与 tag wrangling 共同维护的档案检索系统，而个性化推荐通常来自读者和作者组成的策展网络。[A10][A14][A15][A16][P3][P4]
 
 [在 WebNR 添加 Fanfiction Discovery Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Ffanfiction-discovery-starter){ .md-button .md-button--primary }
 
 ## 摘要
 
-本文以 **2026 年 8 月 26 日**仍可公开核验的 AO3 搜索、标签、书签、合集、订阅与 Atom feed 说明，OTW Open Doors 的保存实践，FanFiction.Net、Fimfiction、Scribble Hub、SquidgeWorld、fanfiction.lol、Sunset 等第一方发现入口，以及近期读者社区讨论与 fan studies、信息组织、数字阅读研究为材料，回答三个问题：**读者怎样更稳定地找到真正合口味的同人小说；AO3 的标签、书签、合集与社区推荐分别解决什么问题；本地阅读怎样接在发现链路之后，同时保持来源和作者控制边界清晰。**[A1]-[A24][P1]-[P27]
+本文以 **2026 年 8 月 26 日**仍可公开核验的 AO3 搜索、标签、书签、合集、订阅与 Atom feed 说明，OTW Open Doors 的保存实践，FanFiction.Net、Fimfiction、Scribble Hub、SquidgeWorld、fanfiction.lol、Sunset 等第一方发现入口，以及近期读者社区讨论与 fan studies、信息组织、数字阅读研究为材料，回答三个读者问题：**怎样更稳定地找到真正合口味的同人小说；AO3 的标签、书签、合集与社区推荐分别解决什么问题；本地阅读怎样接在发现链路之后，同时保持来源与作者控制边界清晰。**[A1]-[A24][P1]-[P27]
 
-本文提出“**双轴查询 + 五层发现 + 三种时间语义**”框架。双轴查询把“作品讲什么”与“我愿意投入怎样的阅读成本”分开；五层发现依次是档案检索、二阶人工策展、作者/读者网络、跨档案补集、本地个人图书馆；三种时间语义分别是“新作品出现”“连载章节更新”“档案/标签关系变化”。这个框架的目标并非制造一个新的统一排名，而是让读者能够解释自己为什么看到某篇作品、为什么继续沿某条路径扩展，以及什么时候应该回到第一方页面重新核验。[A2][A9][A12][A17][P3][P5]
+本文提出“**双轴查询 + 五层发现 + 三种时间语义**”框架。双轴查询把“作品讲什么”与“我愿意投入怎样的阅读成本”分开；五层发现依次是档案检索、二阶人工策展、作者/读者网络、跨档案补集、本地个人图书馆；三种时间语义分别是“新作品出现”“连载章节更新”“档案或标签关系变化”。核心目标是让读者能解释自己为什么看到某篇作品、为什么继续沿某条路径扩展，以及何时需要回到第一方页面重新核验。[A2][A9][A12][A17][P3][P5]
 
 **关键词：** AO3；Archive of Our Own；fanfiction；同人小说；transformative works；tag wrangling；folksonomy；bookmarks；collections；Atom feed；Open Doors；本地阅读
 
 ## 一、先区分“检索”与“推荐”
 
-很多同人阅读挫败来自一个概念混用：读者把档案检索界面当成推荐系统，又把社区里一句“这篇神作”当成稳定可复用的检索规则。两者承担的工作其实不同。
+AO3 的 Work Search、tag browsing 与过滤器让用户主动指定 fandom、关系、角色、附加标签、分级、Archive Warnings、语言、字数、完结状态、发布日期等条件。[P3][P4] 关于 AO3 标签结构的研究很早就注意到，这套系统的价值来自用户生成词汇、canonical tags 与人工 tag wrangling 的组合；后续知识组织研究则把它放进 folksonomy、受控词汇与分类后果的更广背景中。[A14][A15][A16] 因此，一个更准确的理解是：**AO3 帮你把一个巨大档案切成“符合一组可声明条件的候选集”。**
 
-AO3 的 Work Search、tag browsing 与过滤器让用户主动指定 fandom、关系、角色、附加标签、分级、Archive Warnings、语言、字数、完结状态、发布日期等条件。[P3][P4] 关于 AO3 标签结构的早期研究已经注意到，这套系统的价值来自用户生成词汇、canonical tags 与人工 tag wrangling 的组合；后续知识组织研究则把这类问题放进 folksonomy、受控词汇与分类后果的更广背景中。[A14][A15][A16] 因此，一个更准确的理解是：**AO3 帮你把一个巨大档案切成“符合一组可声明条件的候选集”。**
+推荐解决的是另一个问题：候选很多、偏好只表达了一部分时，哪个更值得先读。在同人生态里，这一层经常由作者关系、公开书签、rec 标记、合集、Tumblr/Reddit/Discord 等社区讨论、朋友之间的 fic rec 承担。fan-based affinity spaces 与 collective literacies 研究长期说明，参与式社群会围绕创作、反馈、身份与知识分享形成非正式学习和策展网络。[A1][A2][A3][A6] 对读者来说，这些网络补足了结构化字段里很难写清的“为什么这篇适合某种口味”。
 
-推荐系统解决的是另一个问题：在候选很多、用户偏好只表达了一部分时，系统或人需要判断“哪个更值得先读”。在同人生态里，这一层经常由作者关系、公开书签、rec 标记、合集、Tumblr/Reddit/Discord 等社区讨论、朋友之间的 fic rec 承担。fan-based affinity spaces 与 collective literacies 研究长期说明，参与式社群会围绕创作、反馈、身份与知识分享形成非正式学习和策展网络。[A1][A2][A3][A6] 对读者来说，这些网络的价值正是补足结构化字段里没有写出的“为什么这篇适合某种口味”。
-
-于是第一条实用原则是：**先让检索系统做它擅长的集合缩减，再让人际策展做细腻判断。** 这样既避免把 kudos、hits 或 bookmarks 当成唯一质量刻度，也避免完全依赖零散口碑而失去可复查性。
+所以第一条实用原则是：**先让档案检索做集合缩减，再让人际策展做细腻判断。** 这样既能利用 kudos、hits、bookmarks 等社会信号，也能继续保留更具体的个人条件。
 
 ## 二、双轴查询：内容语义与阅读成本分开写
 
-一个可重复使用的 AO3 查询最好同时包含两条轴。
+### 1. 内容语义轴
 
-### 1. 内容语义轴：我究竟想读什么
+这条轴可以从四类标签逐层表达：
 
-这一轴可以从四类标签逐层表达：
-
-- **Fandom**：作品属于哪个原作、系列或跨 fandom 组合；
+- **Fandom**：原作、系列或 crossover 范围；
 - **Relationship**：想看的关系组合；
-- **Character**：想把哪些角色放在中心；
+- **Character**：希望放在中心的角色；
 - **Additional Tags**：trope、AU、情绪、剧情机制、身份主题、叙事形式、内容提示等。
 
-Tag Search 与 Tags FAQ 说明 canonical tags 会把同义或相关用户标签连接到可浏览的标准入口；tag wrangling 仍是持续进行的维护工作。[P4][P11] 这意味着标签体系是一个活的知识组织层，而不是一次性写死的目录树。2026 年 AO3 对 “No Fandom” Additional Tags 的持续更新正好展示了这种维护性：某些标签与 fandom 的关系会随规则和使用变化被重新整理。[P11]
+Tags FAQ 说明 canonical tags 会把相关用户标签连接到可浏览入口，tag wrangling 仍是持续维护工作。[P4] 2026 年 AO3 对 “No Fandom” Additional Tags 的持续更新也展示了这种动态性：某些标签与 fandom 的关系会随规则和使用变化被重新整理。[P11]
 
-这也解释了为什么标签数量多并不必然等于检索质量高。标签既可能非常精确，也可能把语义写得很私人、很幽默，或者处在 wrangling 尚未稳定的阶段。关于 fan-generated metadata 的研究提醒我们：用户标签既是分类材料，也是社群实践；“genre”“trope”“identity”之间的边界经常由使用情境塑造。[A11][A13][A16] 实际搜索时，建议把最关键的 2–4 个语义条件放在主查询里，再用 summary 与作者说明确认剩余细节。
+标签既是分类材料，也是社群实践。关于 fan-generated metadata 的研究指出，genre、trope、identity 等边界会被具体使用情境塑造。[A11][A13][A16] 实际搜索时，可以把最关键的 2–4 个语义条件放在主查询里，再用 summary、notes 与作者其他作品确认剩余细节。
 
-### 2. 阅读成本轴：我愿意怎样读
+### 2. 阅读成本轴
 
-第二轴描述的不是故事主题，而是一次阅读承诺：
+第二条轴描述一次阅读承诺：
 
 - completed / work in progress；
 - 最小与最大字数；
@@ -63,117 +59,111 @@ Tag Search 与 Tags FAQ 说明 canonical tags 会把同义或相关用户标签�
 - 分级与 Archive Warnings；
 - 需要登录才能查看的作品是否进入候选。
 
-这条轴很重要，因为同一个 trope 在 3,000 字 one-shot 与 400,000 字长篇里的体验差异极大。把“我想看 slow burn”与“我只想今晚读完”同时写进查询，会比单独按 kudos 排序更接近真实需求。
+同一个 trope 在 3,000 字 one-shot 与 400,000 字长篇里的体验差异很大。把“我想看 slow burn”与“我今晚只想读完一篇”同时表达，会比单独按 kudos 排序更接近真实需求。
 
-AO3 的 Terms FAQ 还提醒读者，Archive Warnings 采用一个刻意精简的强制体系，Additional Tags、summary 与 bookmark 信息承担额外补充角色。[P2] 因此对内容敏感的读者，可以把 warnings、排除标签、summary 与公开书签视为多层筛选，而不是把任意单一字段当成完整内容描述。
+AO3 的 Terms FAQ 还说明 Archive Warnings 采用一个刻意精简的强制体系，Additional Tags、summary 与 bookmark 信息承担额外补充角色。[P2] 对内容敏感的读者，可以把 warnings、排除标签、summary 与公开书签视为多层筛选。
 
-## 三、排序不是答案：把 kudos、hits、bookmarks 当成“导航信号”
+## 三、排序是导航信号，而不是口味本身
 
-在大型 fandom 中，按 kudos 或 bookmarks 排序确实非常省时间。它会迅速把很多读者曾经互动过的作品推到前面，作为第一次进入 fandom 的候选生成器很有效。近期 r/AO3 讨论里，读者也持续把 kudos、bookmark、作者主页与别人的公开书签组合使用。[P23]-[P27]
+在大型 fandom 中，按 kudos 或 bookmarks 排序非常省时间。它会迅速把很多读者曾经互动过的作品推到前面，作为第一次进入 fandom 的候选生成器很有效。近期 r/AO3 讨论里，读者也持续把 kudos、bookmark、作者主页与别人的公开书签组合使用。[P23]-[P27]
 
-问题在于，这些数字混合了作品质量之外的因素：发布时间早晚、fandom 规模、ship 热度、作者既有读者群、更新时间策略、作品是否跨平台传播，以及读者是否习惯公开互动。Lauren Moore 对 AO3 发布趋势的分析与数字阅读研究都提醒我们，平台上的可见度指标需要放进时间和社群背景理解。[A9][A19] 因此“kudos 高 = 更适合我”是一个过于压缩的假设。
+这些数字同时混合了发布时间、fandom 规模、ship 热度、作者既有读者群、更新时间策略和跨平台传播。Lauren Moore 对 AO3 发布趋势的分析与数字阅读研究都提醒我们，可见度指标需要放进时间和社群背景理解。[A9][A19]
 
 一个实用做法是采用 **两轮排序**：
 
 1. 第一轮用 kudos / bookmarks / hits 快速看 fandom 的“公共记忆”；
 2. 第二轮切回 date updated、word count、complete status 或更具体标签，主动寻找进入时间较晚、体量较小、或者属于小众 pairing 的作品。
 
-这种切换等于同时利用“社会证明”和“长尾探索”。它也能解释为什么社区里常有人说：高 kudos 页面很方便，但真正让自己惊喜的作品往往来自作者书签、较新条目、冷门 tag 或朋友推荐。[P23]-[P27]
+这种切换同时利用“社会证明”和“长尾探索”，也解释了为什么社区里常有人把作者书签、较新条目、冷门 tag 或朋友推荐当成第二层入口。[P23]-[P27]
 
-## 四、书签是“二阶元数据”：它保存读者怎么看一篇作品
+## 四、书签是“二阶元数据”
 
-AO3 的 Bookmarks 特别值得单独理解。作品页上的 creator tags 描述作者选择公开的作品信息；公开 bookmark 可以附加另一个读者自己的 tags、notes 与 recommendation 状态。也就是说，书签形成了一层**作品之外的读者策展元数据**。[P7]
+作品页上的 creator tags 描述作者选择公开的作品信息；公开 bookmark 可以附加另一个读者自己的 tags、notes 与 recommendation 状态。于是，书签形成了一层**作品之外的读者策展元数据**。[P7]
 
-这层元数据有三种用途。
+第一种用途是**个人阅读记忆**。读者会用 bookmark note 记录读到哪一章、想重读的原因、情绪关键词，或者建立 “To Read”“Favorites”“Research” 一类个人标签。近期 r/AO3 讨论清楚显示，同一个 bookmarks 功能在不同用户手里有多种语义：有人只收藏最喜欢的作品，有人把它当阅读历史，有人配合 subscriptions 追更。[P23][P25]
 
-第一种是**个人阅读记忆**。读者会用 bookmark note 记录读到哪一章、想重读的原因、情绪关键词，或者给自己建立 “To Read”“Favorites”“Research” 一类个人标签。近期 r/AO3 的讨论清楚显示，同一个 bookmarks 功能在不同用户手里有完全不同的语义：有人只收藏最喜欢的作品，有人把它当阅读历史，有人配合订阅追更，也有人给自己的 bookmark 建立私有标签体系。[P23][P24][P25]
+第二种用途是**公开推荐网络**。如果一个作者或读者的口味与你高度重合，他们公开 bookmarks 的边际价值可能高于整个 fandom 的全站排序。你已经知道这个人喜欢什么，因此浏览其 bookmarks 相当于把“相似用户”人工引入推荐过程。这与 affinity spaces、fan information behaviour、collective literacies 的研究很一致。[A2][A3][A12]
 
-第二种是**公开推荐网络**。如果一个作者或读者的口味与你高度重合，他们公开 bookmarks 的边际价值可能比整个 fandom 的全站排序更高。你已经知道这个人喜欢什么，因此浏览其 bookmarks 相当于把“相似用户”人工引入推荐过程。这与 affinity spaces、fan information behaviour、collective literacies 的研究非常一致：社群成员通过共享资源、评价与路径构成可学习的知识网络。[A2][A3][A12]
+第三种用途是**补充风险信息**。AO3 Terms FAQ 明确建议，想进一步判断作品内容的读者可以参考其他用户用于组织作品的 bookmarks。[P2] WebNR 的发现目录只链接第一方入口，个人 bookmark 数据继续留在来源站点。
 
-第三种是**补充风险信息**。AO3 官方 Terms FAQ 明确提到，想进一步判断作品内容的读者可以参考其他用户用于组织作品的 bookmarks。[P2] 这里需要尊重一个边界：公开 bookmark note 是公开文本，私人 bookmark 则属于用户自己的阅读管理空间；WebNR 的发现目录只链接第一方入口，不复制这些个人策展数据。
+## 五、合集与书签承担不同工作
 
-## 五、合集与书签不是同一个东西
+AO3 collections 还包含 challenge、exchange、anonymous/unrevealed 等社区协作语义，维护者与作者之间存在专门工作流。[P6] 近期社区问题也反复出现“private collection 和 private bookmark 行为为什么不同”的困惑。[P24]
 
-新用户经常把 collections 理解成“我的私人歌单”。AO3 的 collections 实际上还有 challenge、exchange、anonymous/unrevealed 等社区协作语义，维护者与作者之间存在更复杂的权限关系。[P6] 近期社区问题也反复出现“为什么 private collection 和 private bookmark 行为不同”的困惑。[P24]
-
-读者可以把两者这样区分：
+可以这样记：
 
 - **Bookmarks** 更适合“我如何保存、标注、推荐这篇作品”；
 - **Collections** 更适合“这些作品为什么在一个活动、主题、交换、策展项目里被组织到一起”。
 
-于是，合集的推荐价值来自“策展上下文”。一个高质量 exchange collection、fandom challenge 或主题项目，往往给你提供一组共享约束下的作品；而个人 bookmark 则更像读者品味轨迹。两种入口同时使用，会比只按数字排序更接近图书馆目录 + 书友推荐的组合。
+合集的推荐价值来自“策展上下文”。一个 exchange collection、fandom challenge 或主题项目，能提供一组共享约束下的作品；个人 bookmark 更像读者品味轨迹。两者同时使用，接近“图书馆目录 + 书友推荐”的组合。
 
-Sunset 当前公开 collections 页面也能看到相似的组织方式：2026 年仍有 prompt meme、seasonal challenge 与 fandom-oriented collection 在活动。[P19] 这说明 OTW-Archive 风格的 archive software 可以承载相似的集合机制，但每个独立站点仍拥有自己的治理、社区与内容范围。
+Sunset 当前公开 collections 页面也能看到相似组织方式：2026 年仍有 prompt meme、seasonal challenge 与 fandom-oriented collection 在活动。[P19] 这说明 OTW-Archive 风格的软件可以承载相似集合机制，而每个独立站点仍拥有自己的治理与内容范围。
 
-## 六、作者页、公开书签与社区：把发现过程变成一张“人际图”
+## 六、把发现过程变成一张人际图
 
-当你读到一篇真正喜欢的作品时，下一步往往不是返回总榜，而是沿着它的社会关系走：
+当你读到一篇真正喜欢的作品时，下一步常常可以沿社会关系走：
 
-**作品 → 作者 → 作者的其他作品 → 作者公开书签 → 同一 pairing/tag 下常出现的其他作者 → collection / challenge → 社区讨论。**
+**作品 → 作者 → 作者的其他作品 → 作者公开书签 → 同一 pairing/tag 下常出现的其他作者 → collection/challenge → 社区讨论。**
 
-这条路径的优势是上下文越来越丰富。第一篇作品给出一个偏好样本；作者的其他作品告诉你这个样本是否代表其稳定风格；书签暴露作者作为读者的口味；collection 揭示参与的社群项目；论坛、Reddit、Tumblr 或 Discord 讨论再补充自然语言评价。
+这条路径的上下文会逐层增加。第一篇作品给出一个偏好样本；作者的其他作品告诉你这个样本是否代表其稳定风格；书签暴露作者作为读者的口味；collection 揭示参与的社群项目；论坛、Reddit、Tumblr 或 Discord 讨论再补充自然语言评价。
 
-fan studies 与数字素养研究长期观察到，fanfiction communities 同时是写作、阅读、反馈、学习与身份协商空间。[A1][A3][A6][A7][A17] Price 对 fan communities 的信息行为研究也把“找信息”放在 serious leisure 与社群实践中理解。[A12] 对实际读者来说，这意味着推荐本身就是一种分布式信息检索：每个可靠的人际节点都在替你缩小搜索空间。
+fan studies 与数字素养研究长期观察到，fanfiction communities 同时是写作、阅读、反馈、学习与身份协商空间。[A1][A3][A6][A7][A17] Price 对 fan communities 的信息行为研究也把“找信息”放在 serious leisure 与社群实践中理解。[A12]
 
-社区材料需要保持证据边界。Reddit 上十几个高赞回复可以证明“有人这样找 fic”，却无法直接推出“多数 AO3 用户都这样找”。本文使用社区帖子来观察策略、困惑和术语，只把 AO3 功能、政策和接口事实交给第一方 FAQ、TOS 与代码仓库确认。[P1]-[P8][P23]-[P27]
+社区材料需要明确证据等级。Reddit 上的讨论可以证明“有人这样找 fic”，却不适合直接推导总体比例。本文使用社区帖子观察策略、困惑和术语，把 AO3 功能、政策和接口事实交给第一方 FAQ、TOS 与代码仓库确认。[P1]-[P8][P23]-[P27]
 
-## 七、AO3 之外：同人生态本来就是多档案的
-
-AO3 的规模和标签工具让它成为很多读者的默认入口，但同人历史一直包含多个 archive、论坛、作者站、专题社区和平台。把 AO3 当成完整宇宙，会错过不同媒介、不同年代与不同社区治理下形成的作品。
+## 七、AO3 之外：同人生态一直是多档案的
 
 ### FanFiction.Net
 
-FanFiction.Net 仍公开提供 Story / Writer / Forum / Community 搜索与 fandom、crossover 浏览入口。[P20] 对一些老 fandom 来说，它保留了与 AO3 不同的历史层。WebNR 当前只把第一方搜索页作为发现入口，因为当前公开条款与 crawler policy 对自动化和再分发有明确约束；发现动作留在正常浏览路径里。
+FanFiction.Net 仍公开提供 Story / Writer / Forum / Community 搜索与 fandom、crossover 浏览入口。[P20] 对一些老 fandom 来说，它保留了与 AO3 不同的历史层。WebNR 当前只把第一方搜索页作为发现入口，因为来源的公开条款与 crawler policy 对自动化和再分发设有来源侧约束。
 
 ### Fimfiction
 
-Fimfiction 是 My Little Pony 同人生态里非常强的专门化 archive。它当前公开的 Story Search 文档支持标签、布尔表达式、标题/描述字段、字数、views、rating、likes、发布时间、更新时间与完成状态等查询。[P21] 它同时拥有官方 API，因此比多数大型同人站更适合未来做经过限流、缓存和删除语义审计的机器接口。WebNR 当前仍采用第一方链接，后续 richer adapter 的升级条件已经明确：调用边界、身份、分页、缓存、删除、超时与版本化 fixtures 都要先进入测试合同。
+Fimfiction 是 My Little Pony 同人生态里的专门化 archive。它当前公开的 Story Search 文档支持标签、布尔表达式、标题/描述字段、字数、views、rating、likes、发布时间、更新时间与完成状态等查询。[P21] 它同时拥有官方 API，因此比多数大型同人站更适合未来做经过限流、缓存和删除语义审计的机器接口。WebNR 当前仍采用第一方链接，下一步 richer adapter 的升级条件包括调用边界、身份、分页、缓存、删除、超时与版本化 fixtures。
 
 ### Scribble Hub
 
-Scribble Hub 的 Series Finder 与 Genre 体系把 Fanfiction 和 LitRPG、Isekai、Romance、Girls Love 等连载小说标签放在同一发现空间里。[P22] 这类平台对“同人 + 原创 Web serial”交叉读者尤其有价值。它也说明同人发现并不总围绕传统 archive 组织，有时会嵌在一个更广的连载平台里。
+Scribble Hub 的 Series Finder 与 Genre 体系把 Fanfiction 和 LitRPG、Isekai、Romance、Girls Love 等连载小说标签放在同一发现空间里。[P22] 这类平台对“同人 + 原创 Web serial”交叉读者很有价值，也说明同人发现有时嵌在更广的连载平台里。
 
 ### SquidgeWorld
 
-SquidgeWorld 提供 OTW-Archive 风格的公开 Work Search，能够按 fandom、relationships、additional tags、completion、word count、language、ratings、warnings 与互动统计过滤。[P12][P13] Squidge.org 对用户数据所有权和站点托管边界有自己的条款；当前还明确限制面向 AI / machine-learning dataset 的 scraping/aggregation。WebNR 因此只提供第一方搜索链接，保留每个独立 archive 的政策自主性。
+SquidgeWorld 提供 OTW-Archive 风格的公开 Work Search，可以按 fandom、relationships、additional tags、completion、word count、language、ratings、warnings 与互动统计过滤。[P12][P13] Squidge.org 对用户数据所有权和站点托管边界有自己的政策。WebNR 当前只提供第一方搜索链接，保留独立 archive 的政策自主性。
 
 ### fanfiction.lol
 
-fanfiction.lol 是一个规模较小、仍主动开发的独立 archive，公开 Fandoms 目录。[P14][P15] 它在站点上直接提醒用户功能与数据稳定性仍可能变化。对读者来说，这种小型 archive 的价值常在于社区密度和新实验；同时，发现系统应该把稳定性信息显式暴露，而不是把所有来源伪装成同一成熟度。
+fanfiction.lol 是一个规模较小、仍主动开发的独立 archive，公开 Fandoms 目录。[P14][P15] 站点直接提示功能与数据稳定性仍可能变化，并在 2026-08-18 生效的 Content Policy 里说明其当前内容和治理边界。[P16] 对读者来说，小型 archive 的价值常在于社区密度和新实验；发现系统则需要把成熟度与稳定性信息显式暴露。
 
 ### Sunset
 
-Sunset 自我描述为 fan-created、fan-run、nonprofit、noncommercial 的 transformative fanworks archive，聚焦 F/F、F/NB 与 NB/NB。[P17] 2026 年 8 月仍有新的站点更新与 active collections。[P19] 它说明独立 archive 可以把某个社群的内容范围与价值观做成第一层组织结构。WebNR 当前把其第一方首页作为专门化发现入口，作品与合集数据继续由 Sunset 自己维护。
+Sunset 自我描述为 fan-created、fan-run、nonprofit、noncommercial 的 transformative fanworks archive，聚焦 F/F、F/NB 与 NB/NB。[P17] 2026 年 8 月仍有新的站点更新与 active collections。[P19] WebNR 当前把其第一方首页作为专门化发现入口，作品与合集数据继续由 Sunset 自己维护。[P18]
 
 ### 历史保存与迁移
 
-Ad Astra 的 legacy archive 公开说明旧站会作为 read-only snapshot 保留，而当前主站在本次自动化环境中启用了 Anubis anti-bot challenge。[P26] 这种情况提醒我们：**“旧站可读”“新站活跃”“机器可抓取”是三个不同事实。** 一个可靠发现目录应该分别记录，而不是看到一个 200 页面就假设整个来源可以长期自动同步。
+Ad Astra 的 legacy archive 公开说明旧站作为 read-only snapshot 保留，而当前主站在本次自动化环境中启用了 Anubis anti-bot challenge。[P26] 这说明“旧站可读”“新站活跃”“机器接口可用”是需要分别记录的事实。可靠发现目录应该逐项核验，而不是把普通页面访问自动扩展成批量同步能力。
 
-## 八、Open Doors 给“保存”划出更清楚的治理边界
+## 八、Open Doors 展示了保存所需的治理层
 
-OTW Open Doors 的意义不仅是保存旧 fan archives，它还展示了一套比“把网页全抓下来”复杂得多的迁移伦理：联系 archivists、向创作者说明迁移、保留作者身份、提供 claim / orphan / delete 等控制路径，并在具体 archive 项目里记录来源历史。[P9][P10]
+OTW Open Doors 展示了一套比“批量下载网页”更完整的 archive migration 实践：联系 archivists、向创作者说明迁移、保留作者身份，并提供 claim / orphan / delete 等控制路径。[P9][P10]
 
-这对 WebNR 很重要。一个本地阅读器最适合承担的是**读者个人控制层**：用户已经合法获得的 TXT、下载文件、自己拥有的文本或明确允许保存的内容，可以在本地建立阅读进度、主题与离线体验。平台级 archive preservation 则涉及作者权利、账户、删除、归属、公开传播和长期治理，不能因为技术上能下载就被降格成普通缓存问题。
+这对 WebNR 很重要。一个本地阅读器最适合承担的是**读者个人控制层**：用户已经合法获得的 TXT、下载文件、自己拥有的文本或明确允许保存的内容，可以在本地建立阅读进度、主题与离线体验。平台级 archive preservation 则同时涉及作者权利、账户、删除、归属、公开传播和长期治理。
 
-Jacobs 与 Lowe 关于 fanbinding 的案例、Pilati 等关于 fanfiction forums 作为 digital heritage communities 的研究，也说明“保存”同时具有物质、社群与文化层面。[A17][A24] 对发现产品而言，最稳健的设计是保留来源 URL、作品身份和 provenance，让个人保存与公共再分发保持区分。
+Jacobs 与 Lowe 关于 fanbinding 的案例、Pilati 等关于 fanfiction forums 作为 digital heritage communities 的研究，也说明“保存”同时具有物质、社群与文化层面。[A17][A24] 对发现产品而言，保留来源 URL、作品身份和 provenance，可以让个人保存与公共再分发维持清晰区分。
 
-## 九、Atom feed 的真实用途：关注“新出现”，而不是替代整个 AO3
+## 九、AO3 Atom feed 的真实用途：关注“新出现”
 
-AO3 官方 Subscriptions and Feeds FAQ 提供了一个很有价值、又经常被忽略的机器入口：多数 canonical tag 和 metatag 可以订阅 Atom feed，relationship / character tag 也可用；freeform 非 canonical tag 则没有相同保证。[P5] 官方还明确说这些 feeds 可以放进个人 feed reader，也可以 syndicate 到其他网站。
+AO3 官方 Subscriptions and Feeds FAQ 提供了一个很有价值的机器入口：多数 canonical tag 和 metatag 可以订阅 Atom feed，relationship / character tag 也可用。[P5] 官方还明确说明这些 feeds 可以放进个人 feed reader，也可以 syndicate 到其他网站。
 
-但这里有一个关键时间语义：**feed 在 work 原始发布时加入条目，后续 chapter update 不会把同一作品当成新 feed item 重新推送。**[P5] 因此 Atom 更适合回答“这个 canonical tag 最近有什么新作品”，而不是“我追的 WIP 刚更新了哪一章”。章节更新仍应使用 AO3 subscription 或回到作品/作者层。
+这里有一个关键时间语义：**feed 在 work 原始发布时加入条目，后续 chapter update 不会把同一作品当成新 feed item 重新推送。**[P5] 因此 Atom 更适合回答“这个 canonical tag 最近有什么新作品”，章节更新则更适合使用 AO3 subscription 或回到作品/作者层。
 
-这一区别可以概括成三种时间语义：
+可以把时间问题分成三类：
 
 1. **new-work time**：一个 tag 下出现新 work；Atom 很合适；
 2. **update time**：已有 work 新增章节；subscription / work page 更合适；
-3. **taxonomy time**：canonical relation、wrangling 或 archive policy 变化；需要重新核验 FAQ/news，而不是从旧 feed 推断。
+3. **taxonomy time**：canonical relation、wrangling 或 archive policy 变化；需要重新核验 FAQ/news。[P4][P5][P11]
 
-OTW-Archive 官方代码仓库目前仍明确说明“there is currently no API for OTW-Archive”。[P8] 所以，把 AO3 Atom feed 说成“AO3 API”并不准确。WebNR 当前的 repository loader 读取 `search_index.yml`，也没有通用 Atom parser。今天把 AO3 从 defer 升级为第一方 discovery route 是基于最新政策和接口证据；把 canonical-tag feed 升级成动态来源，则还需要浏览器传输/CORS、feed identity、response bounds、截断/分页、更新时间、失败重试和版本化 fixtures 的工程验证。
+OTW-Archive 官方代码仓库目前明确说明“there is currently no API for OTW-Archive”。[P8] 因此 AO3 Atom feed 与“AO3 通用 API”是两个概念。WebNR 当前 repository loader 读取 `search_index.yml`，还没有通用 Atom parser。今天把 AO3 从 defer 升级为第一方 discovery route，是基于最新政策与接口证据；把 canonical-tag feed 升级成动态来源，则还需要浏览器传输/CORS、feed identity、response bounds、截断/分页、更新时间、失败重试和版本化 fixtures 的工程验证。
 
 ## 十、一条可以直接照做的 20 分钟找文流程
-
-当你面对一个陌生 fandom，可以按下面顺序操作。
 
 **第 1–3 分钟：定义双轴。** 写下 fandom / ship / character / trope，再写 complete 状态、字数、语言、warnings、更新时间等阅读成本。
 
@@ -181,39 +171,37 @@ OTW-Archive 官方代码仓库目前仍明确说明“there is currently no API 
 
 **第 8–11 分钟：沿人际图扩展。** 选 2–3 篇真正喜欢的作品，打开作者其他作品与公开 bookmarks；观察哪些作者、tags、collections 反复出现。
 
-**第 12–15 分钟：去社区找“为什么”。** 用具体需求提问或搜索现有 Reddit/Tumblr/Discord 讨论，例如“30k–100k、completed、某 pairing、偏角色研究、低 angst”。自然语言条件越具体，社区推荐越有信息量。
+**第 12–15 分钟：去社区找“为什么”。** 用具体需求搜索既有 Reddit/Tumblr/Discord 讨论，例如“30k–100k、completed、某 pairing、偏角色研究、低 angst”。自然语言条件越具体，社区推荐越有信息量。
 
 **第 16–18 分钟：跨 archive 补集。** 老 fandom 看 FanFiction.Net；MLP 看 Fimfiction；Web serial 交叉口看 Scribble Hub；多 fandom 独立 archive 看 SquidgeWorld；专门化 queer/femslash archive 看 Sunset；同时记录每个平台的成熟度与治理差异。
 
 **第 19–20 分钟：建立个人阅读队列。** 把第一方链接保存下来；对来源明确允许下载或由你合法拥有的文件，再导入 WebNR 等本地阅读器。保留原始 URL、作者与来源备注，后续遇到版本变化时还能回到源站复查。
 
-这个流程的优势是每一步都能解释：AO3 提供结构化候选，人际网络提供口味相似性，社区提供自然语言理由，独立 archive 提供生态覆盖，本地阅读器提供个人控制。
-
-## 十一、几个容易踩的坑
+## 十一、五个常见判断误区
 
 ### 1. 把高热度当成稳定质量排序
 
-热度是有用信号，同时包含暴露量和时间效应。更稳妥的方式是把它作为第一轮入口，再用窄标签、更新时间与人际策展做第二轮。
+热度包含暴露量和时间效应。更稳妥的方式是把它作为第一轮入口，再用窄标签、更新时间与人际策展做第二轮。[A9][A19]
 
-### 2. 把 tags 当成作者承诺书
+### 2. 把 tags 当成完整内容承诺
 
 AO3 的 mandatory warnings 与 additional tags 承担的责任层级不同；用户标签还会随 wrangling 发生 canonical 关系变化。[P2][P4][P11] 对重要内容约束，summary、notes、warnings 与公开 bookmarks 可以交叉参考。
 
 ### 3. 把 collections 当私人文件夹
 
-Collections 带有策展、挑战、匿名/未公开等 archive 工作流；个人整理优先用 bookmarks 和 bookmark tags 更清晰。[P6][P7][P24]
+Collections 带有策展、挑战、匿名/未公开等 archive 工作流；个人整理通常更适合用 bookmarks 与 bookmark tags。[P6][P7][P24]
 
 ### 4. 把“有 feed”理解成“有完整 API”
 
-AO3 canonical tag Atom feed 是一个公开且官方说明的 syndication surface；OTW-Archive 代码仓库同时明确当前没有通用 API。[P5][P8] 两个事实可以同时成立。
+AO3 canonical-tag Atom feed 是官方说明的 syndication surface；OTW-Archive 代码仓库同时明确当前没有通用 API。[P5][P8] 两个事实可以同时成立。
 
-### 5. 把“可打开网页”理解成“适合自动抓取”
+### 5. 把“可打开网页”直接扩展成“适合自动抓取”
 
-来源接入需要把普通浏览、API/feed、批量抓取、再分发、账户自动化分别审计。FanFiction.Net、Fimfiction、SquidgeWorld、AO3 的政策和接口条件都不同。WebNR 的当前 Fanfiction Discovery Starter 选择窄的 link-only 能力，是为了只声明已经有第一方证据和运行时验证的行为；下一步会优先把 Fimfiction official API 与 AO3 canonical-tag Atom 作为机器接口候选分别做 capability-limited adapter，而不是把 link-only 当成永久终点。
+来源接入需要把普通浏览、API/feed、批量抓取、再分发、账户自动化分别审计。FanFiction.Net、Fimfiction、SquidgeWorld、AO3 的政策与接口条件都不同。WebNR 当前 Fanfiction Discovery Starter 选择窄的 link-only 能力，是为了只声明已经有第一方证据和运行时验证的行为；下一步优先把 Fimfiction official API 与 AO3 canonical-tag Atom 作为机器接口候选分别做 capability-limited adapter，而 link-only 只是当前能力层级。
 
-## 十二、结论：同人发现的核心是“可解释的路径”，不是一个万能榜
+## 十二、结论：核心是可解释的发现路径
 
-同人小说生态很难被压进单一推荐分数，因为作品本身、标签体系、读者社群、作者关系、archive 治理与平台历史共同决定了“你会在哪里遇到一篇作品”。AO3 的强项是可组合的档案检索与标签治理；公开书签和合集提供二阶策展；社区讨论提供自然语言理由；独立 archive 保存不同社群与年代；本地阅读器则把最后一公里交回读者。
+同人小说生态很难被压进单一推荐分数，因为作品本身、标签体系、读者社群、作者关系、archive 治理与平台历史共同决定“你会在哪里遇到一篇作品”。AO3 的强项是可组合档案检索与标签治理；公开书签和合集提供二阶策展；社区讨论提供自然语言理由；独立 archive 保存不同社群与年代；本地阅读器则把最后一公里交回读者。
 
 如果只保留一句操作原则，可以记住：**先用标签说清“我要什么”，再用状态说清“我愿意怎么读”，随后沿人际策展找相似口味，跨 archive 补齐生态，最后把个人有权保存的文件带回本地。**
 
@@ -225,7 +213,7 @@ AO3 canonical tag Atom feed 是一个公开且官方说明的 syndication surfac
 
 [A2] Jayne C. Lammers, Jen Scott Curwood, Alecia Marie Magnifico. *Toward an Affinity Space Methodology: Considerations for Literacy Research*. http://hdl.handle.net/1802/27489
 
-[A3] Henry Jenkins. *‘Art Happens not in Isolation, But in Community’: The Collective Literacies of Media Fandom*. https://www.sciendo.com/pdf/10.5334/csci.125
+[A3] Henry Jenkins. *“Art Happens not in Isolation, But in Community”: The Collective Literacies of Media Fandom*. https://www.sciendo.com/pdf/10.5334/csci.125
 
 [A4] Kathy A. Mills. *A Review of the “Digital Turn” in the New Literacy Studies*. https://eprints.qut.edu.au/32979/1/32979.pdf
 
@@ -291,7 +279,7 @@ AO3 canonical tag Atom feed 是一个公开且官方说明的 syndication surfac
 
 [P10] Organization for Transformative Works, Open Doors. *Online Archives*. https://opendoors.transformativeworks.org/en/online-archives/
 
-[P11] Archive of Our Own. *Updates to “No Fandom” Additional Tags*（2026 年持续更新系列）. https://archiveofourown.org/admin_posts
+[P11] Archive of Our Own. *Admin/news posts on tag wrangling and “No Fandom” changes*. https://archiveofourown.org/admin_posts
 
 [P12] SquidgeWorld Archive. *Home*. https://squidgeworld.org/
 
@@ -301,7 +289,7 @@ AO3 canonical tag Atom feed 是一个公开且官方说明的 syndication surfac
 
 [P15] fanfiction.lol. *Fandoms*. https://fanfiction.lol/media
 
-[P16] fanfiction.lol. *Content Policy*. https://fanfiction.lol/content_policy
+[P16] fanfiction.lol. *Content Policy*. https://fanfiction.lol/content
 
 [P17] Sunset. *Home*. https://sunset.femslash.club/
 

--- a/docs/blog/posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md
+++ b/docs/blog/posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md
@@ -1,0 +1,330 @@
+---
+title: 2026 同人小说与变形创作怎么找？AO3 标签、书签、合集、社区与本地阅读路线
+date: 2026-08-26
+slug: fanfiction-transformative-serial-discovery-guide
+description: 面向同人小说与变形创作读者的研究型发现指南：把 AO3 的 fandom、关系、角色、附加标签、书签与合集拆成不同检索层，再结合独立档案、社区推荐和本地阅读建立可复查的发现路径。
+categories:
+  - Reader guides
+  - Research
+  - Fanfiction
+---
+
+# 2026 同人小说与变形创作怎么找？AO3 标签、书签、合集、社区与本地阅读路线
+
+**直接答案：**寻找同人小说时，把“排行榜找高分作品”换成一条五层路线通常更有效：**先用 fandom / relationship / character / additional tags 表达内容语义，再用完结状态、字数、语言与更新时间表达阅读成本；接着沿作者、公开书签、推荐、合集与社区讨论扩展候选；随后去独立档案补齐 AO3 之外的生态；最后只把自己有权保存的文本或下载文件带进本地阅读器，并保留原始链接与来源信息。** AO3 更接近一套由用户标签与 tag wrangling 共同维护的档案检索系统，而不是替读者自动决定“你下一篇应该读什么”的个性化推荐器。[A10][A14][A15][A16][P3][P4]
+
+[在 WebNR 添加 Fanfiction Discovery Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Ffanfiction-discovery-starter){ .md-button .md-button--primary }
+
+## 摘要
+
+本文以 **2026 年 8 月 26 日**仍可公开核验的 AO3 搜索、标签、书签、合集、订阅与 Atom feed 说明，OTW Open Doors 的保存实践，FanFiction.Net、Fimfiction、Scribble Hub、SquidgeWorld、fanfiction.lol、Sunset 等第一方发现入口，以及近期读者社区讨论与 fan studies、信息组织、数字阅读研究为材料，回答三个问题：**读者怎样更稳定地找到真正合口味的同人小说；AO3 的标签、书签、合集与社区推荐分别解决什么问题；本地阅读怎样接在发现链路之后，同时保持来源和作者控制边界清晰。**[A1]-[A24][P1]-[P27]
+
+本文提出“**双轴查询 + 五层发现 + 三种时间语义**”框架。双轴查询把“作品讲什么”与“我愿意投入怎样的阅读成本”分开；五层发现依次是档案检索、二阶人工策展、作者/读者网络、跨档案补集、本地个人图书馆；三种时间语义分别是“新作品出现”“连载章节更新”“档案/标签关系变化”。这个框架的目标并非制造一个新的统一排名，而是让读者能够解释自己为什么看到某篇作品、为什么继续沿某条路径扩展，以及什么时候应该回到第一方页面重新核验。[A2][A9][A12][A17][P3][P5]
+
+**关键词：** AO3；Archive of Our Own；fanfiction；同人小说；transformative works；tag wrangling；folksonomy；bookmarks；collections；Atom feed；Open Doors；本地阅读
+
+## 一、先区分“检索”与“推荐”
+
+很多同人阅读挫败来自一个概念混用：读者把档案检索界面当成推荐系统，又把社区里一句“这篇神作”当成稳定可复用的检索规则。两者承担的工作其实不同。
+
+AO3 的 Work Search、tag browsing 与过滤器让用户主动指定 fandom、关系、角色、附加标签、分级、Archive Warnings、语言、字数、完结状态、发布日期等条件。[P3][P4] 关于 AO3 标签结构的早期研究已经注意到，这套系统的价值来自用户生成词汇、canonical tags 与人工 tag wrangling 的组合；后续知识组织研究则把这类问题放进 folksonomy、受控词汇与分类后果的更广背景中。[A14][A15][A16] 因此，一个更准确的理解是：**AO3 帮你把一个巨大档案切成“符合一组可声明条件的候选集”。**
+
+推荐系统解决的是另一个问题：在候选很多、用户偏好只表达了一部分时，系统或人需要判断“哪个更值得先读”。在同人生态里，这一层经常由作者关系、公开书签、rec 标记、合集、Tumblr/Reddit/Discord 等社区讨论、朋友之间的 fic rec 承担。fan-based affinity spaces 与 collective literacies 研究长期说明，参与式社群会围绕创作、反馈、身份与知识分享形成非正式学习和策展网络。[A1][A2][A3][A6] 对读者来说，这些网络的价值正是补足结构化字段里没有写出的“为什么这篇适合某种口味”。
+
+于是第一条实用原则是：**先让检索系统做它擅长的集合缩减，再让人际策展做细腻判断。** 这样既避免把 kudos、hits 或 bookmarks 当成唯一质量刻度，也避免完全依赖零散口碑而失去可复查性。
+
+## 二、双轴查询：内容语义与阅读成本分开写
+
+一个可重复使用的 AO3 查询最好同时包含两条轴。
+
+### 1. 内容语义轴：我究竟想读什么
+
+这一轴可以从四类标签逐层表达：
+
+- **Fandom**：作品属于哪个原作、系列或跨 fandom 组合；
+- **Relationship**：想看的关系组合；
+- **Character**：想把哪些角色放在中心；
+- **Additional Tags**：trope、AU、情绪、剧情机制、身份主题、叙事形式、内容提示等。
+
+Tag Search 与 Tags FAQ 说明 canonical tags 会把同义或相关用户标签连接到可浏览的标准入口；tag wrangling 仍是持续进行的维护工作。[P4][P11] 这意味着标签体系是一个活的知识组织层，而不是一次性写死的目录树。2026 年 AO3 对 “No Fandom” Additional Tags 的持续更新正好展示了这种维护性：某些标签与 fandom 的关系会随规则和使用变化被重新整理。[P11]
+
+这也解释了为什么标签数量多并不必然等于检索质量高。标签既可能非常精确，也可能把语义写得很私人、很幽默，或者处在 wrangling 尚未稳定的阶段。关于 fan-generated metadata 的研究提醒我们：用户标签既是分类材料，也是社群实践；“genre”“trope”“identity”之间的边界经常由使用情境塑造。[A11][A13][A16] 实际搜索时，建议把最关键的 2–4 个语义条件放在主查询里，再用 summary 与作者说明确认剩余细节。
+
+### 2. 阅读成本轴：我愿意怎样读
+
+第二轴描述的不是故事主题，而是一次阅读承诺：
+
+- completed / work in progress；
+- 最小与最大字数；
+- 语言；
+- 更新时间或首次发布日期；
+- single chapter / multi-chapter；
+- crossover 接受度；
+- 分级与 Archive Warnings；
+- 需要登录才能查看的作品是否进入候选。
+
+这条轴很重要，因为同一个 trope 在 3,000 字 one-shot 与 400,000 字长篇里的体验差异极大。把“我想看 slow burn”与“我只想今晚读完”同时写进查询，会比单独按 kudos 排序更接近真实需求。
+
+AO3 的 Terms FAQ 还提醒读者，Archive Warnings 采用一个刻意精简的强制体系，Additional Tags、summary 与 bookmark 信息承担额外补充角色。[P2] 因此对内容敏感的读者，可以把 warnings、排除标签、summary 与公开书签视为多层筛选，而不是把任意单一字段当成完整内容描述。
+
+## 三、排序不是答案：把 kudos、hits、bookmarks 当成“导航信号”
+
+在大型 fandom 中，按 kudos 或 bookmarks 排序确实非常省时间。它会迅速把很多读者曾经互动过的作品推到前面，作为第一次进入 fandom 的候选生成器很有效。近期 r/AO3 讨论里，读者也持续把 kudos、bookmark、作者主页与别人的公开书签组合使用。[P23]-[P27]
+
+问题在于，这些数字混合了作品质量之外的因素：发布时间早晚、fandom 规模、ship 热度、作者既有读者群、更新时间策略、作品是否跨平台传播，以及读者是否习惯公开互动。Lauren Moore 对 AO3 发布趋势的分析与数字阅读研究都提醒我们，平台上的可见度指标需要放进时间和社群背景理解。[A9][A19] 因此“kudos 高 = 更适合我”是一个过于压缩的假设。
+
+一个实用做法是采用 **两轮排序**：
+
+1. 第一轮用 kudos / bookmarks / hits 快速看 fandom 的“公共记忆”；
+2. 第二轮切回 date updated、word count、complete status 或更具体标签，主动寻找进入时间较晚、体量较小、或者属于小众 pairing 的作品。
+
+这种切换等于同时利用“社会证明”和“长尾探索”。它也能解释为什么社区里常有人说：高 kudos 页面很方便，但真正让自己惊喜的作品往往来自作者书签、较新条目、冷门 tag 或朋友推荐。[P23]-[P27]
+
+## 四、书签是“二阶元数据”：它保存读者怎么看一篇作品
+
+AO3 的 Bookmarks 特别值得单独理解。作品页上的 creator tags 描述作者选择公开的作品信息；公开 bookmark 可以附加另一个读者自己的 tags、notes 与 recommendation 状态。也就是说，书签形成了一层**作品之外的读者策展元数据**。[P7]
+
+这层元数据有三种用途。
+
+第一种是**个人阅读记忆**。读者会用 bookmark note 记录读到哪一章、想重读的原因、情绪关键词，或者给自己建立 “To Read”“Favorites”“Research” 一类个人标签。近期 r/AO3 的讨论清楚显示，同一个 bookmarks 功能在不同用户手里有完全不同的语义：有人只收藏最喜欢的作品，有人把它当阅读历史，有人配合订阅追更，也有人给自己的 bookmark 建立私有标签体系。[P23][P24][P25]
+
+第二种是**公开推荐网络**。如果一个作者或读者的口味与你高度重合，他们公开 bookmarks 的边际价值可能比整个 fandom 的全站排序更高。你已经知道这个人喜欢什么，因此浏览其 bookmarks 相当于把“相似用户”人工引入推荐过程。这与 affinity spaces、fan information behaviour、collective literacies 的研究非常一致：社群成员通过共享资源、评价与路径构成可学习的知识网络。[A2][A3][A12]
+
+第三种是**补充风险信息**。AO3 官方 Terms FAQ 明确提到，想进一步判断作品内容的读者可以参考其他用户用于组织作品的 bookmarks。[P2] 这里需要尊重一个边界：公开 bookmark note 是公开文本，私人 bookmark 则属于用户自己的阅读管理空间；WebNR 的发现目录只链接第一方入口，不复制这些个人策展数据。
+
+## 五、合集与书签不是同一个东西
+
+新用户经常把 collections 理解成“我的私人歌单”。AO3 的 collections 实际上还有 challenge、exchange、anonymous/unrevealed 等社区协作语义，维护者与作者之间存在更复杂的权限关系。[P6] 近期社区问题也反复出现“为什么 private collection 和 private bookmark 行为不同”的困惑。[P24]
+
+读者可以把两者这样区分：
+
+- **Bookmarks** 更适合“我如何保存、标注、推荐这篇作品”；
+- **Collections** 更适合“这些作品为什么在一个活动、主题、交换、策展项目里被组织到一起”。
+
+于是，合集的推荐价值来自“策展上下文”。一个高质量 exchange collection、fandom challenge 或主题项目，往往给你提供一组共享约束下的作品；而个人 bookmark 则更像读者品味轨迹。两种入口同时使用，会比只按数字排序更接近图书馆目录 + 书友推荐的组合。
+
+Sunset 当前公开 collections 页面也能看到相似的组织方式：2026 年仍有 prompt meme、seasonal challenge 与 fandom-oriented collection 在活动。[P19] 这说明 OTW-Archive 风格的 archive software 可以承载相似的集合机制，但每个独立站点仍拥有自己的治理、社区与内容范围。
+
+## 六、作者页、公开书签与社区：把发现过程变成一张“人际图”
+
+当你读到一篇真正喜欢的作品时，下一步往往不是返回总榜，而是沿着它的社会关系走：
+
+**作品 → 作者 → 作者的其他作品 → 作者公开书签 → 同一 pairing/tag 下常出现的其他作者 → collection / challenge → 社区讨论。**
+
+这条路径的优势是上下文越来越丰富。第一篇作品给出一个偏好样本；作者的其他作品告诉你这个样本是否代表其稳定风格；书签暴露作者作为读者的口味；collection 揭示参与的社群项目；论坛、Reddit、Tumblr 或 Discord 讨论再补充自然语言评价。
+
+fan studies 与数字素养研究长期观察到，fanfiction communities 同时是写作、阅读、反馈、学习与身份协商空间。[A1][A3][A6][A7][A17] Price 对 fan communities 的信息行为研究也把“找信息”放在 serious leisure 与社群实践中理解。[A12] 对实际读者来说，这意味着推荐本身就是一种分布式信息检索：每个可靠的人际节点都在替你缩小搜索空间。
+
+社区材料需要保持证据边界。Reddit 上十几个高赞回复可以证明“有人这样找 fic”，却无法直接推出“多数 AO3 用户都这样找”。本文使用社区帖子来观察策略、困惑和术语，只把 AO3 功能、政策和接口事实交给第一方 FAQ、TOS 与代码仓库确认。[P1]-[P8][P23]-[P27]
+
+## 七、AO3 之外：同人生态本来就是多档案的
+
+AO3 的规模和标签工具让它成为很多读者的默认入口，但同人历史一直包含多个 archive、论坛、作者站、专题社区和平台。把 AO3 当成完整宇宙，会错过不同媒介、不同年代与不同社区治理下形成的作品。
+
+### FanFiction.Net
+
+FanFiction.Net 仍公开提供 Story / Writer / Forum / Community 搜索与 fandom、crossover 浏览入口。[P20] 对一些老 fandom 来说，它保留了与 AO3 不同的历史层。WebNR 当前只把第一方搜索页作为发现入口，因为当前公开条款与 crawler policy 对自动化和再分发有明确约束；发现动作留在正常浏览路径里。
+
+### Fimfiction
+
+Fimfiction 是 My Little Pony 同人生态里非常强的专门化 archive。它当前公开的 Story Search 文档支持标签、布尔表达式、标题/描述字段、字数、views、rating、likes、发布时间、更新时间与完成状态等查询。[P21] 它同时拥有官方 API，因此比多数大型同人站更适合未来做经过限流、缓存和删除语义审计的机器接口。WebNR 当前仍采用第一方链接，后续 richer adapter 的升级条件已经明确：调用边界、身份、分页、缓存、删除、超时与版本化 fixtures 都要先进入测试合同。
+
+### Scribble Hub
+
+Scribble Hub 的 Series Finder 与 Genre 体系把 Fanfiction 和 LitRPG、Isekai、Romance、Girls Love 等连载小说标签放在同一发现空间里。[P22] 这类平台对“同人 + 原创 Web serial”交叉读者尤其有价值。它也说明同人发现并不总围绕传统 archive 组织，有时会嵌在一个更广的连载平台里。
+
+### SquidgeWorld
+
+SquidgeWorld 提供 OTW-Archive 风格的公开 Work Search，能够按 fandom、relationships、additional tags、completion、word count、language、ratings、warnings 与互动统计过滤。[P12][P13] Squidge.org 对用户数据所有权和站点托管边界有自己的条款；当前还明确限制面向 AI / machine-learning dataset 的 scraping/aggregation。WebNR 因此只提供第一方搜索链接，保留每个独立 archive 的政策自主性。
+
+### fanfiction.lol
+
+fanfiction.lol 是一个规模较小、仍主动开发的独立 archive，公开 Fandoms 目录。[P14][P15] 它在站点上直接提醒用户功能与数据稳定性仍可能变化。对读者来说，这种小型 archive 的价值常在于社区密度和新实验；同时，发现系统应该把稳定性信息显式暴露，而不是把所有来源伪装成同一成熟度。
+
+### Sunset
+
+Sunset 自我描述为 fan-created、fan-run、nonprofit、noncommercial 的 transformative fanworks archive，聚焦 F/F、F/NB 与 NB/NB。[P17] 2026 年 8 月仍有新的站点更新与 active collections。[P19] 它说明独立 archive 可以把某个社群的内容范围与价值观做成第一层组织结构。WebNR 当前把其第一方首页作为专门化发现入口，作品与合集数据继续由 Sunset 自己维护。
+
+### 历史保存与迁移
+
+Ad Astra 的 legacy archive 公开说明旧站会作为 read-only snapshot 保留，而当前主站在本次自动化环境中启用了 Anubis anti-bot challenge。[P26] 这种情况提醒我们：**“旧站可读”“新站活跃”“机器可抓取”是三个不同事实。** 一个可靠发现目录应该分别记录，而不是看到一个 200 页面就假设整个来源可以长期自动同步。
+
+## 八、Open Doors 给“保存”划出更清楚的治理边界
+
+OTW Open Doors 的意义不仅是保存旧 fan archives，它还展示了一套比“把网页全抓下来”复杂得多的迁移伦理：联系 archivists、向创作者说明迁移、保留作者身份、提供 claim / orphan / delete 等控制路径，并在具体 archive 项目里记录来源历史。[P9][P10]
+
+这对 WebNR 很重要。一个本地阅读器最适合承担的是**读者个人控制层**：用户已经合法获得的 TXT、下载文件、自己拥有的文本或明确允许保存的内容，可以在本地建立阅读进度、主题与离线体验。平台级 archive preservation 则涉及作者权利、账户、删除、归属、公开传播和长期治理，不能因为技术上能下载就被降格成普通缓存问题。
+
+Jacobs 与 Lowe 关于 fanbinding 的案例、Pilati 等关于 fanfiction forums 作为 digital heritage communities 的研究，也说明“保存”同时具有物质、社群与文化层面。[A17][A24] 对发现产品而言，最稳健的设计是保留来源 URL、作品身份和 provenance，让个人保存与公共再分发保持区分。
+
+## 九、Atom feed 的真实用途：关注“新出现”，而不是替代整个 AO3
+
+AO3 官方 Subscriptions and Feeds FAQ 提供了一个很有价值、又经常被忽略的机器入口：多数 canonical tag 和 metatag 可以订阅 Atom feed，relationship / character tag 也可用；freeform 非 canonical tag 则没有相同保证。[P5] 官方还明确说这些 feeds 可以放进个人 feed reader，也可以 syndicate 到其他网站。
+
+但这里有一个关键时间语义：**feed 在 work 原始发布时加入条目，后续 chapter update 不会把同一作品当成新 feed item 重新推送。**[P5] 因此 Atom 更适合回答“这个 canonical tag 最近有什么新作品”，而不是“我追的 WIP 刚更新了哪一章”。章节更新仍应使用 AO3 subscription 或回到作品/作者层。
+
+这一区别可以概括成三种时间语义：
+
+1. **new-work time**：一个 tag 下出现新 work；Atom 很合适；
+2. **update time**：已有 work 新增章节；subscription / work page 更合适；
+3. **taxonomy time**：canonical relation、wrangling 或 archive policy 变化；需要重新核验 FAQ/news，而不是从旧 feed 推断。
+
+OTW-Archive 官方代码仓库目前仍明确说明“there is currently no API for OTW-Archive”。[P8] 所以，把 AO3 Atom feed 说成“AO3 API”并不准确。WebNR 当前的 repository loader 读取 `search_index.yml`，也没有通用 Atom parser。今天把 AO3 从 defer 升级为第一方 discovery route 是基于最新政策和接口证据；把 canonical-tag feed 升级成动态来源，则还需要浏览器传输/CORS、feed identity、response bounds、截断/分页、更新时间、失败重试和版本化 fixtures 的工程验证。
+
+## 十、一条可以直接照做的 20 分钟找文流程
+
+当你面对一个陌生 fandom，可以按下面顺序操作。
+
+**第 1–3 分钟：定义双轴。** 写下 fandom / ship / character / trope，再写 complete 状态、字数、语言、warnings、更新时间等阅读成本。
+
+**第 4–7 分钟：AO3 生成候选。** 用 Work Search 或 tag page 建立初始集合；先看与你目标直接相关的 tags 与 summary；如果列表很大，先用 kudos/bookmarks 看一遍公共记忆，再切 date updated 或更窄标签看长尾。
+
+**第 8–11 分钟：沿人际图扩展。** 选 2–3 篇真正喜欢的作品，打开作者其他作品与公开 bookmarks；观察哪些作者、tags、collections 反复出现。
+
+**第 12–15 分钟：去社区找“为什么”。** 用具体需求提问或搜索现有 Reddit/Tumblr/Discord 讨论，例如“30k–100k、completed、某 pairing、偏角色研究、低 angst”。自然语言条件越具体，社区推荐越有信息量。
+
+**第 16–18 分钟：跨 archive 补集。** 老 fandom 看 FanFiction.Net；MLP 看 Fimfiction；Web serial 交叉口看 Scribble Hub；多 fandom 独立 archive 看 SquidgeWorld；专门化 queer/femslash archive 看 Sunset；同时记录每个平台的成熟度与治理差异。
+
+**第 19–20 分钟：建立个人阅读队列。** 把第一方链接保存下来；对来源明确允许下载或由你合法拥有的文件，再导入 WebNR 等本地阅读器。保留原始 URL、作者与来源备注，后续遇到版本变化时还能回到源站复查。
+
+这个流程的优势是每一步都能解释：AO3 提供结构化候选，人际网络提供口味相似性，社区提供自然语言理由，独立 archive 提供生态覆盖，本地阅读器提供个人控制。
+
+## 十一、几个容易踩的坑
+
+### 1. 把高热度当成稳定质量排序
+
+热度是有用信号，同时包含暴露量和时间效应。更稳妥的方式是把它作为第一轮入口，再用窄标签、更新时间与人际策展做第二轮。
+
+### 2. 把 tags 当成作者承诺书
+
+AO3 的 mandatory warnings 与 additional tags 承担的责任层级不同；用户标签还会随 wrangling 发生 canonical 关系变化。[P2][P4][P11] 对重要内容约束，summary、notes、warnings 与公开 bookmarks 可以交叉参考。
+
+### 3. 把 collections 当私人文件夹
+
+Collections 带有策展、挑战、匿名/未公开等 archive 工作流；个人整理优先用 bookmarks 和 bookmark tags 更清晰。[P6][P7][P24]
+
+### 4. 把“有 feed”理解成“有完整 API”
+
+AO3 canonical tag Atom feed 是一个公开且官方说明的 syndication surface；OTW-Archive 代码仓库同时明确当前没有通用 API。[P5][P8] 两个事实可以同时成立。
+
+### 5. 把“可打开网页”理解成“适合自动抓取”
+
+来源接入需要把普通浏览、API/feed、批量抓取、再分发、账户自动化分别审计。FanFiction.Net、Fimfiction、SquidgeWorld、AO3 的政策和接口条件都不同。WebNR 的当前 Fanfiction Discovery Starter 选择窄的 link-only 能力，是为了只声明已经有第一方证据和运行时验证的行为；下一步会优先把 Fimfiction official API 与 AO3 canonical-tag Atom 作为机器接口候选分别做 capability-limited adapter，而不是把 link-only 当成永久终点。
+
+## 十二、结论：同人发现的核心是“可解释的路径”，不是一个万能榜
+
+同人小说生态很难被压进单一推荐分数，因为作品本身、标签体系、读者社群、作者关系、archive 治理与平台历史共同决定了“你会在哪里遇到一篇作品”。AO3 的强项是可组合的档案检索与标签治理；公开书签和合集提供二阶策展；社区讨论提供自然语言理由；独立 archive 保存不同社群与年代；本地阅读器则把最后一公里交回读者。
+
+如果只保留一句操作原则，可以记住：**先用标签说清“我要什么”，再用状态说清“我愿意怎么读”，随后沿人际策展找相似口味，跨 archive 补齐生态，最后把个人有权保存的文件带回本地。**
+
+从产品角度看，这也给 WebNR 一条清楚的演进路线：第一阶段提供经过来源审计的第一方发现入口；第二阶段为明确允许的 API/feed 实现带速率、身份、更新与删除语义的适配器；第三阶段把这些来源与本地个人图书馆连接，同时保留 provenance。今天 AO3 已从“缺少当前政策证据的 defer”升级为正式 discovery route；canonical-tag Atom 与 Fimfiction official API 则进入下一层机器接口验证队列。
+
+## 学术与研究文献
+
+[A1] Jen Scott Curwood, Alecia Marie Magnifico, Jayne C. Lammers. *Writing in the Wild: Writers’ Motivation in Fan-Based Affinity Spaces*. https://onlinelibrary.wiley.com/doi/pdfdirect/10.1002/JAAL.192
+
+[A2] Jayne C. Lammers, Jen Scott Curwood, Alecia Marie Magnifico. *Toward an Affinity Space Methodology: Considerations for Literacy Research*. http://hdl.handle.net/1802/27489
+
+[A3] Henry Jenkins. *‘Art Happens not in Isolation, But in Community’: The Collective Literacies of Media Fandom*. https://www.sciendo.com/pdf/10.5334/csci.125
+
+[A4] Kathy A. Mills. *A Review of the “Digital Turn” in the New Literacy Studies*. https://eprints.qut.edu.au/32979/1/32979.pdf
+
+[A5] Christine Greenhow, Beth Robelia. *Old Communication, New Literacies: Social Network Sites as Social Learning Resources*. https://academic.oup.com/jcmc/article-pdf/14/4/1130/22318194/jjcmcom1130.pdf
+
+[A6] Carlos A. Scolari et al. *Transmedia literacy in the new media ecology: Teens’ transmedia skills and informal learning strategies*. https://recyt.fecyt.es/index.php/EPI/article/download/epi.2018.jul.09/40580
+
+[A7] Boris Vázquez-Calvo, Leticia-Tian Zhang, Mariona Pascual, Daniel Cassany. *Fan translation of games, anime, and fanfiction*. https://scholarspace.manoa.hawaii.edu/bitstreams/13af851a-696a-4132-ae63-f2b0e5c4caf3/download
+
+[A8] Brianna Dym, Casey Fiesler. *Social Norm Vulnerability and its Consequences for Privacy and Safety in an Online Community*. https://dl.acm.org/doi/pdf/10.1145/3415226
+
+[A9] Simone Rebora et al. *Digital humanities and digital social reading*. https://academic.oup.com/dsh/article-pdf/36/Supplement_2/ii230/41091194/fqab020.pdf
+
+[A10] Federico Pianzola. *Digital Social Reading*. https://direct.mit.edu/books/oa-monograph-pdf/2498089/book_9780262381352.pdf
+
+[A11] Adrienne E. Raw. *Normalizing Disability: Tagging and Disability Identity Construction through Marvel Cinematic Universe Fanfiction*. https://cjds.uwaterloo.ca/index.php/cjds/article/download/498/751
+
+[A12] Ludi Price. *Serious leisure in the digital world: exploring the information behaviour of fan communities*. https://openaccess.city.ac.uk/id/eprint/19090/1/Price%2C%20Ludovica%20%28Redacted%29.pdf
+
+[A13] Kristina Busse. *Fan Fiction Tropes as Literary and Cultural Practices*. https://www.vr-elibrary.de/doi/pdf/10.14220/9783737007450.127
+
+[A14] Kelly Lynn Dalton. *Searching the archive of our own: The usefulness of the tagging structure*. https://dc.uwm.edu/etd/26
+
+[A15] Julia Amber Bullard. *Classification design: understanding the decisions between theory and consequence*. http://hdl.handle.net/2152/63497
+
+[A16] Melissa K. Nelson, Julia Bullard. *When Is It Genre? Complicating the Categorization of Fan-Generated Metadata*. https://muse.jhu.edu/pub/1/article/970680/pdf
+
+[A17] Federico Pilati, Maria Tartari, Antoine Houssard, Pier Luigi Sacco. *From fandoms to heritage. Understanding fanfiction forums as Digital Heritage Communities*. https://journals.sagepub.com/doi/pdf/10.1177/13548565241302245?download=true
+
+[A18] Veronica Koven-Matasy. *Fannish Librarians: The Intersection of Fandom and Library and Information Science*. https://cdr.lib.unc.edu/record/uuid:88807062-7aa9-4ea8-b5ba-f9f6b24cf205
+
+[A19] Lauren Moore. *Fanfiction today: An analysis of publishing trends on Archive of Our Own*. https://aquila.usm.edu/cgi/viewcontent.cgi?article=1265&context=slisconnecting
+
+[A20] Roi Alfassi et al. *Fanfiction in the Age of AI: Community Perspectives on Creativity, Authenticity and Adoption*. https://www.tandfonline.com/doi/pdf/10.1080/10447318.2025.2531272?needAccess=true
+
+[A21] Alexandra Xanthoudakis. *Mushroom for improvement: a model for the circulation of fanfiction sub-genres*. http://summit.sfu.ca/item/21406
+
+[A22] Suzanne Black. *From novel to network: digital intertextuality in twenty-first-century fiction and fanfiction*. https://hdl.handle.net/1842/37850
+
+[A23] Alison Harding. *“I’m mixing comic book canon and MCU canon to suit my own needs”: Information Sharing as Community Building in a Fandom in Flux*. https://ideaexchange.uakron.edu/cgi/viewcontent.cgi?article=1220&context=docam
+
+[A24] Naomi Jacobs, JSA Lowe. *The Design of Printed Fanfiction: A Case Study of Down to Agincourt Fanbinding*. https://ideaexchange.uakron.edu/cgi/viewcontent.cgi?article=1192&context=docam
+
+## 第一方、平台与社区来源
+
+[P1] Archive of Our Own. *Terms of Service*. https://archiveofourown.org/tos
+
+[P2] Archive of Our Own. *Terms of Service FAQ*. https://archiveofourown.org/tos_faq
+
+[P3] Archive of Our Own. *Search and Browse FAQ*. https://archiveofourown.org/faq/search-and-browse
+
+[P4] Archive of Our Own. *Tags FAQ*. https://archiveofourown.org/faq/tags
+
+[P5] Archive of Our Own. *Subscriptions and Feeds FAQ*. https://archiveofourown.org/faq/subscriptions-and-feeds
+
+[P6] Archive of Our Own. *Collections FAQ*. https://archiveofourown.org/faq/collections
+
+[P7] Archive of Our Own. *Bookmarks FAQ*. https://archiveofourown.org/faq/bookmarks
+
+[P8] Organization for Transformative Works. *OTW-Archive source repository*. https://github.com/otwcode/otwarchive
+
+[P9] Organization for Transformative Works, Open Doors. *FAQ*. https://opendoors.transformativeworks.org/en/faq/
+
+[P10] Organization for Transformative Works, Open Doors. *Online Archives*. https://opendoors.transformativeworks.org/en/online-archives/
+
+[P11] Archive of Our Own. *Updates to “No Fandom” Additional Tags*（2026 年持续更新系列）. https://archiveofourown.org/admin_posts
+
+[P12] SquidgeWorld Archive. *Home*. https://squidgeworld.org/
+
+[P13] SquidgeWorld Archive. *Work Search*. https://squidgeworld.org/works/search
+
+[P14] fanfiction.lol. *Home*. https://fanfiction.lol/
+
+[P15] fanfiction.lol. *Fandoms*. https://fanfiction.lol/media
+
+[P16] fanfiction.lol. *Content Policy*. https://fanfiction.lol/content_policy
+
+[P17] Sunset. *Home*. https://sunset.femslash.club/
+
+[P18] Sunset. *Terms of Service FAQ*. https://sunset.femslash.club/tos_faq
+
+[P19] Sunset. *Collections*. https://sunset.femslash.club/collections
+
+[P20] FanFiction.Net. *Story / Writer / Forum / Community Search*. https://www.fanfiction.net/search/?ready=1
+
+[P21] Fimfiction. *Story Search*. https://www.fimfiction.net/articles/story-search
+
+[P22] Scribble Hub. *Series Finder*. https://www.scribblehub.com/series-finder/
+
+[P23] r/AO3. *Do you use bookmarks or subscriptions? Also why?* 2026-05-30. https://www.reddit.com/r/AO3/comments/1trsxq0/do_you_use_bookmarks_or_subscriptions_also_why/
+
+[P24] r/AO3. *Bookmark Collections??* 2026-01-24. https://www.reddit.com/r/AO3/comments/1ql91wm/bookmark_collections/
+
+[P25] r/AO3. *How do you personally use bookmarks?* 2026-07-11. https://www.reddit.com/r/AO3/comments/1ut863f/how_do_you_personally_use_bookmarks/
+
+[P26] Ad Astra. *Legacy archive*. https://classic.adastrafanfic.com/
+
+[P27] r/FanFiction. *what's your browsing habit on Ao3?* 2026-01-06. https://www.reddit.com/r/FanFiction/comments/1q52o99/whats_your_browsing_habit_on_ao3/
+
+## 核验说明
+
+平台功能、接口、条款与 archive 状态按 2026-08-26 可访问的第一方公开材料核验；动态计数、排序与社区帖子会随时间变化。社区讨论只作为读者策略的定性样本。WebNR 的 Fanfiction Discovery Starter 在本轮只保存第一方 URL 和 WebNR 自行撰写的发现说明，不复制来源站作品、作者资料、评分、评论、书签、合集成员、封面或正文；AO3 canonical-tag Atom 与 Fimfiction official API 则作为后续 capability-limited adapter 的独立工程审计对象。

--- a/docs/blog/posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md
+++ b/docs/blog/posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md
@@ -63,7 +63,7 @@ Tags FAQ 说明 canonical tags 会把相关用户标签连接到可浏览入口�
 
 AO3 的 Terms FAQ 还说明 Archive Warnings 采用一个刻意精简的强制体系，Additional Tags、summary 与 bookmark 信息承担额外补充角色。[P2] 对内容敏感的读者，可以把 warnings、排除标签、summary 与公开书签视为多层筛选。
 
-## 三、排序是导航信号，而不是口味本身
+## 三、排序提供导航信号，口味需要额外判断
 
 在大型 fandom 中，按 kudos 或 bookmarks 排序非常省时间。它会迅速把很多读者曾经互动过的作品推到前面，作为第一次进入 fandom 的候选生成器很有效。近期 r/AO3 讨论里，读者也持续把 kudos、bookmark、作者主页与别人的公开书签组合使用。[P23]-[P27]
 
@@ -139,7 +139,7 @@ Sunset 自我描述为 fan-created、fan-run、nonprofit、noncommercial 的 tra
 
 ### 历史保存与迁移
 
-Ad Astra 的 legacy archive 公开说明旧站作为 read-only snapshot 保留，而当前主站在本次自动化环境中启用了 Anubis anti-bot challenge。[P26] 这说明“旧站可读”“新站活跃”“机器接口可用”是需要分别记录的事实。可靠发现目录应该逐项核验，而不是把普通页面访问自动扩展成批量同步能力。
+Ad Astra 的 legacy archive 公开说明旧站作为 read-only snapshot 保留，而当前主站在本次自动化环境中启用了 Anubis anti-bot challenge。[P26] 这说明“旧站可读”“新站活跃”“机器接口可用”是需要分别记录的事实。可靠发现目录应该逐项核验，并把普通页面访问与批量同步能力分开记录。
 
 ## 八、Open Doors 展示了保存所需的治理层
 

--- a/public/sources/fanfiction-discovery-starter/README.txt
+++ b/public/sources/fanfiction-discovery-starter/README.txt
@@ -11,7 +11,7 @@ https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Ffanfi
 
 Purpose
 -------
-This WebNR-maintained source is a small link-only directory for readers looking
+This WebNR-maintained source is a small discovery directory for readers looking
 for fan fiction and transformative serial fiction. It points to first-party
 search or browse surfaces while leaving work metadata, fandom ownership,
 accounts, ratings, comments, downloads, and story text at the origin.
@@ -21,6 +21,9 @@ Included discovery routes
 - FanFiction.Net — first-party story and crossover search across its fandom archive
 - Fimfiction — first-party story browse and search for My Little Pony fanfiction
 - Scribble Hub — first-party Fanfiction genre directory for serialized works hosted on Scribble Hub
+- Archive of Our Own (AO3) — first-party work search across fanworks and transformative works
+- SquidgeWorld Archive — first-party work search across its independent multifandom archive
+- fanfiction.lol — first-party fandom directory for a small independent archive in active development
 
 Content and rights boundary
 ---------------------------
@@ -46,11 +49,39 @@ current API/rights review, request bounds, deletion semantics, and versioned
 fixtures.
 
 Scribble Hub exposes a public Series Finder and a first-party Fanfiction genre.
-Its Terms of Service, last observed updated 2026-06-29, describe user-posted works
-as User Content and grant Scribble Hub service-specific hosting/display rights;
-WebNR does not infer a redistribution license from that relationship. The current
-integration therefore links the public Fanfiction directory without copying or
-polling user submissions.
+Its Terms of Service describe user-posted works as User Content and grant
+Scribble Hub service-specific hosting/display rights; WebNR does not infer a
+redistribution license from that relationship. The current integration therefore
+links the public Fanfiction directory without copying or polling user
+submissions.
+
+AO3's current Terms of Service and Terms FAQ distinguish prohibited commercial
+scraping and policy-violating automation from generally permitted noncommercial
+bot or scraping purposes, while reserving the Archive's right to apply
+robots.txt and other technical limits. The official OTW-Archive code repository
+also states that the software currently has no API. AO3 separately documents
+Atom feeds for most canonical tags and expressly describes those feeds as usable
+in personal feed readers or for syndication on other sites. This evidence is
+enough to admit AO3 as a first-party discovery route and to record Atom as a
+future machine-interface candidate. WebNR's current repository runtime consumes
+`search_index.yml`, not arbitrary Atom feeds, so this cycle does not pretend that
+the reader can yet synchronize those feeds. A later Atom adapter must prove
+browser/runtime transport, feed identity, pagination or truncation behavior,
+update semantics, rate limits, response bounds, attribution, and fixtures before
+promotion.
+
+SquidgeWorld Archive exposes a public OTW-Archive-style Work Search. Squidge.org
+states that users own their data and Squidge hosts it, and its current terms
+expressly prohibit scraping or aggregation for AI or machine-learning datasets.
+The admitted WebNR capability makes no origin requests beyond a reader following
+the normal search link and performs no content aggregation, so it stays within a
+narrow discovery boundary.
+
+fanfiction.lol exposes a public fandom directory and current first-party content
+policy. The site prominently identifies itself as an active-development service
+where features may break and data may be accidentally deleted. The WebNR entry
+therefore makes that stability limitation visible and keeps the capability to a
+normal first-party discovery link. No site content is copied into WebNR.
 
 Current WebNR behavior
 ----------------------
@@ -58,7 +89,7 @@ Selecting an item opens the corresponding first-party discovery page. WebNR does
 not call origin APIs, crawl catalog HTML, poll rankings or updates, proxy
 responses, mirror metadata, cache origin assets, automate accounts, submit forms,
 perform downloads, or attempt to bypass age, login, payment, captcha, robots,
-rate-limit, or other access controls.
+rate-limit, anti-bot, or other access controls.
 
 Because the admitted capability is static link-only, the WebNR reader path adds
 no origin-site CORS, cookie, login, pagination, request-cadence, response-size,
@@ -67,33 +98,82 @@ reader encounters after following a normal link remain those of the origin.
 
 Audit boundary
 --------------
-The three included HTTPS discovery routes were checked through normal public web
-access on 2026-08-25. FanFiction.Net's search surface did not require an account
-for the audited reader path. Fimfiction's public Stories page rendered a browse
-and filter surface without requiring an account, while also indicating that some
-site functionality benefits from JavaScript. Scribble Hub's Series Finder and
-Fanfiction genre were publicly discoverable without an account in the audited
-path.
+The six included HTTPS discovery routes were checked through normal public web
+access on 2026-08-26 or retained from the immediately preceding verified cycle.
+The new source-specific review covered origin identity, public access, current
+terms or content-policy evidence, redistribution boundary, machine-interface
+claims, account/access controls, runtime transport, and the exact capability
+shipped.
 
-The committed search index is the versioned fixture for this static link-only
-capability. A richer adapter for any origin would require a separate audit of an
+AO3's first-party Search and Browse FAQ documents work search across tags, title,
+author, words, hits, kudos, published date, and language, and its current Tags
+FAQ documents canonical tags and tag-wrangling behavior. Current first-party
+news from June 2026 confirms that tag wranglers continue to revise canonical
+"No Fandom" tag relationships. The source entry therefore points to search
+rather than encoding a frozen interpretation of AO3's tag taxonomy.
+
+SquidgeWorld's public Work Search rendered without requiring an account for the
+audited reader path and exposed completion, crossover, word-count, language,
+fandom, rating, warning, character, relationship, additional-tag, hit, kudos,
+comment, and bookmark filters.
+
+fanfiction.lol's public fandom directory rendered without an account and exposed
+its current archive categories. Its active-development warning is treated as a
+source-health limitation rather than suppressed.
+
+The committed `search_index.yml` is the versioned fixture for this discovery
+capability. A richer adapter for any origin requires a separate audit of an
 explicitly permitted machine interface, current terms and robots behavior,
 stable work/edition identity, pagination, request cadence, rate limits, timeouts
 and backoff, provenance, attribution, update/deletion semantics, regional and
 age/access boundaries, maximum response size, and representative versioned
 fixtures.
 
-Candidate boundary
-------------------
-Archive of Our Own (AO3) remains a high-value candidate for the scheduled
-fanfiction ecosystem work, but no source capability was admitted in this cycle
-because the operating environment did not provide sufficiently current
-first-party machine-access and policy evidence for a complete source audit.
-Twisting the Hellmouth was also screened but its first-party reader surface was
-not reliably accessible from the operating environment during this cycle. Neither
-candidate is treated as failed, licensed, or safe for automated ingestion by
-assumption; both remain deferred for a later evidence-complete audit.
+Candidate review
+----------------
+Five additional adjacent archive families were screened for this cycle beyond
+the prior starter set: SquidgeWorld Archive, fanfiction.lol, Sunset, Ad Astra,
+and the Comic Fanfiction Authors Archive (CFAA). SquidgeWorld and
+fanfiction.lol passed the complete bounded audit and are admitted above. Sunset
+also exposed a current public first-party home and current Terms FAQ, and remains
+a healthy candidate for a later source expansion once its exact discovery route
+and source-specific differences from the upstream OTW-Archive policy text are
+captured in a versioned audit.
+
+Ad Astra's legacy archive remains publicly readable and explicitly says the old
+site is a preserved read-only snapshot, while its current primary archive is
+protected by an Anubis anti-bot challenge in the operating environment. The
+current primary reader surface therefore remains deferred from a WebNR source
+definition until a normal, reproducible reader route can be verified without
+bypassing that control.
+
+CFAA remains discoverable as an active comics-focused archive through current
+fandom archival references, while its first-party site also presents an Anubis
+anti-bot challenge in the operating environment and current first-party terms
+could not be completed in this cycle. It remains deferred rather than being
+treated as safe for ingestion by assumption.
+
+Rotating health review
+----------------------
+The existing FanFiction.Net search, Fimfiction Stories browser, and Scribble Hub
+Fanfiction directory remained the retained baseline for this starter. Their
+capability remains limited to ordinary first-party discovery links; no broader
+machine-access or redistribution permission is inferred from availability.
+
+Machine-interface upgrade path
+------------------------------
+AO3 is no longer deferred for lack of policy evidence. Current first-party
+evidence supports ordinary discovery and documents an official Atom feed surface
+for canonical tags, while the OTW-Archive repository confirms there is no
+general API. The remaining blocker for a richer AO3 integration is WebNR's
+runtime capability and transport/fixture validation, not an invented claim that
+AO3 has an API or that all scraping is forbidden.
+
+Fimfiction remains the strongest existing official-API upgrade candidate. Its
+next richer integration should be a capability-limited API adapter with explicit
+rate-limit, cache, identity, deletion, pagination, timeout, and fixture behavior,
+rather than a catalog mirror.
 
 Last verified
 -------------
-2026-08-25
+2026-08-26

--- a/public/sources/fanfiction-discovery-starter/README.txt
+++ b/public/sources/fanfiction-discovery-starter/README.txt
@@ -24,6 +24,7 @@ Included discovery routes
 - Archive of Our Own (AO3) — first-party work search across fanworks and transformative works
 - SquidgeWorld Archive — first-party work search across its independent multifandom archive
 - fanfiction.lol — first-party fandom directory for a small independent archive in active development
+- Sunset — first-party home for a fan-run F/F, F/NB, and NB/NB transformative-work archive
 
 Content and rights boundary
 ---------------------------
@@ -83,6 +84,16 @@ where features may break and data may be accidentally deleted. The WebNR entry
 therefore makes that stability limitation visible and keeps the capability to a
 normal first-party discovery link. No site content is copied into WebNR.
 
+Sunset identifies itself as a fan-created, fan-run, nonprofit, noncommercial
+archive dedicated to F/F, F/NB, and NB/NB transformative works. Its public home,
+collections surface, and current Terms FAQ rendered through ordinary public web
+access during this audit. The currently published Terms FAQ carries the same
+OTW-Archive-style distinction between policy-violating scraping and generally
+permitted non-policy-violating automation while retaining site-level technical
+control. WebNR admits only Sunset's public home as a specialized archive-discovery
+route in this cycle, so no source-side tag vocabulary, work metadata, collection
+membership, account state, or content is replicated.
+
 Current WebNR behavior
 ----------------------
 Selecting an item opens the corresponding first-party discovery page. WebNR does
@@ -98,7 +109,7 @@ reader encounters after following a normal link remain those of the origin.
 
 Audit boundary
 --------------
-The six included HTTPS discovery routes were checked through normal public web
+The seven included HTTPS discovery routes were checked through normal public web
 access on 2026-08-26 or retained from the immediately preceding verified cycle.
 The new source-specific review covered origin identity, public access, current
 terms or content-policy evidence, redistribution boundary, machine-interface
@@ -121,6 +132,12 @@ fanfiction.lol's public fandom directory rendered without an account and exposed
 its current archive categories. Its active-development warning is treated as a
 source-health limitation rather than suppressed.
 
+Sunset's public home rendered without an account and described the archive's
+specialized scope. A current first-party Collections surface also rendered and
+showed active 2026 collections and prompt projects, while account-only creation
+and subscription functions remain origin-owned. This bounded review is complete
+for the single public-home discovery capability admitted here.
+
 The committed `search_index.yml` is the versioned fixture for this discovery
 capability. A richer adapter for any origin requires a separate audit of an
 explicitly permitted machine interface, current terms and robots behavior,
@@ -133,12 +150,9 @@ Candidate review
 ----------------
 Five additional adjacent archive families were screened for this cycle beyond
 the prior starter set: SquidgeWorld Archive, fanfiction.lol, Sunset, Ad Astra,
-and the Comic Fanfiction Authors Archive (CFAA). SquidgeWorld and
-fanfiction.lol passed the complete bounded audit and are admitted above. Sunset
-also exposed a current public first-party home and current Terms FAQ, and remains
-a healthy candidate for a later source expansion once its exact discovery route
-and source-specific differences from the upstream OTW-Archive policy text are
-captured in a versioned audit.
+and the Comic Fanfiction Authors Archive (CFAA). SquidgeWorld, fanfiction.lol,
+and Sunset received complete bounded source-specific review for the exact
+link-only capability considered here and are admitted above.
 
 Ad Astra's legacy archive remains publicly readable and explicitly says the old
 site is a preserved read-only snapshot, while its current primary archive is
@@ -155,8 +169,9 @@ treated as safe for ingestion by assumption.
 
 Rotating health review
 ----------------------
-The existing FanFiction.Net search, Fimfiction Stories browser, and Scribble Hub
-Fanfiction directory remained the retained baseline for this starter. Their
+The existing FanFiction.Net search, Fimfiction Stories/search documentation, and
+Scribble Hub Series Finder/Fanfiction discovery surfaces were rechecked on
+2026-08-26 and remained publicly discoverable in the audited reader path. Their
 capability remains limited to ordinary first-party discovery links; no broader
 machine-access or redistribution permission is inferred from availability.
 

--- a/public/sources/fanfiction-discovery-starter/search_index.yml
+++ b/public/sources/fanfiction-discovery-starter/search_index.yml
@@ -45,3 +45,52 @@ fanfiction-discovery/scribble-hub-fanfiction.md:
   categories:
     - Fanfiction discovery
   region: en
+
+fanfiction-discovery/ao3-work-search.md:
+  title: Archive of Our Own (AO3) — Work Search
+  author: Organization for Transformative Works
+  description: AO3 的第一方作品搜索入口，可组合 fandom、关系、角色、附加标签、分级、警告、语言、字数与完成状态等字段发现同人及其他变形创作。WebNR 当前保存官方搜索链接和自行撰写的发现说明；AO3 同时提供部分 canonical tag 的 Atom feed，后续可在 WebNR 具备经过测试的 Atom 运行时后单独审计升级。
+  page_url: https://archiveofourown.org/works/search
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - AO3
+    - Archive of Our Own
+    - Fan fiction
+    - Transformative works
+    - Tag search
+  categories:
+    - Fanfiction discovery
+  region: en
+
+fanfiction-discovery/squidgeworld-work-search.md:
+  title: SquidgeWorld Archive — Work Search
+  author: Squidge.org
+  description: SquidgeWorld Archive 的第一方作品搜索入口，支持按作品字段、fandom、关系与附加标签、完成状态、字数和作品统计等条件发现多 fandom 作品。WebNR 仅保存官方搜索链接与自行撰写的说明，内容、标签元数据、账户和正文继续留在 SquidgeWorld。
+  page_url: https://squidgeworld.org/works/search
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - SquidgeWorld
+    - Fan fiction
+    - Multifandom
+    - Work search
+  categories:
+    - Fanfiction discovery
+  region: en
+
+fanfiction-discovery/fanfiction-lol-fandoms.md:
+  title: fanfiction.lol — Fandom Browse
+  author: fanfiction.lol
+  description: fanfiction.lol 的第一方 Fandoms 目录，为一个仍在主动开发的小型独立 fanwork archive 提供题材发现入口。站点自身明确提示功能与数据仍可能变化；WebNR 因此只链接当前公开目录，并把稳定性风险留给读者可见说明。
+  page_url: https://fanfiction.lol/media
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - fanfiction.lol
+    - Fan fiction
+    - Independent archive
+    - Fandom browse
+  categories:
+    - Fanfiction discovery
+  region: en

--- a/public/sources/fanfiction-discovery-starter/search_index.yml
+++ b/public/sources/fanfiction-discovery-starter/search_index.yml
@@ -94,3 +94,20 @@ fanfiction-discovery/fanfiction-lol-fandoms.md:
   categories:
     - Fanfiction discovery
   region: en
+
+fanfiction-discovery/sunset-femslash.md:
+  title: Sunset — Femslash Transformative Fanworks
+  author: Sunset
+  description: Sunset 是由粉丝创建、运营的非营利非商业变形创作档案，重点收录 F/F、F/NB 与 NB/NB fanworks。WebNR 当前链接其第一方公开首页作为专门化 archive 的发现入口；站内标签、作品、账号、合集及正文继续留在 Sunset。
+  page_url: https://sunset.femslash.club/
+  source: WebNR Fanfiction Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Sunset
+    - Fan fiction
+    - Femslash
+    - Transformative works
+    - Independent archive
+  categories:
+    - Fanfiction discovery
+  region: en


### PR DESCRIPTION
## Scope
Complete the 2026-08-26 fanfiction / transformative-serial discovery cycle as one coherent reader-discovery change.

- expand the existing `Fanfiction Discovery Starter`
- admit AO3 Work Search after refreshing first-party policy/machine-interface evidence
- admit SquidgeWorld Work Search, fanfiction.lol Fandom Browse, and the specialized Sunset archive after bounded source-specific audits
- preserve the existing FanFiction.Net, Fimfiction, and Scribble Hub routes
- record Ad Astra and CFAA defer boundaries without bypassing anti-bot controls
- publish the scheduled research guide on AO3 tags, bookmarks, collections, community curation, adjacent archives, Atom feeds, preservation, and local reading
- record AO3 canonical-tag Atom and the Fimfiction official API as future machine-interface candidates while keeping the shipped runtime truthful to WebNR's current `search_index.yml` loader

## Evidence and boundary
The shipped source capability remains a static first-party discovery directory. It stores only origin URLs plus WebNR-authored labels/descriptions and does not copy origin works or metadata. AO3's current first-party TOS/FAQ permits non-policy-violating automation in general, documents canonical-tag Atom feeds for feed readers/syndication, and the official OTW-Archive repository states there is currently no general API. WebNR cannot truthfully claim live Atom synchronization until browser/runtime transport, bounds, identity, update semantics, and fixtures are implemented and tested.

Five new adjacent archive families were screened beyond the prior starter set: SquidgeWorld, fanfiction.lol, Sunset, Ad Astra, and CFAA. The first three received complete bounded review for the exact link-only capability and are admitted. Ad Astra's current primary site and CFAA present Anubis anti-bot challenges to this operating environment; no bypass is attempted.

The research guide uses multi-round scholarly research plus current first-party and community evidence. It separates archive retrieval from recommendation, treats community threads as qualitative examples rather than population statistics, and preserves first-party ownership of policy/interface claims.

## Acceptance
- repository index remains valid YAML and exposes seven discovery entries
- existing source entries remain intact
- new first-party routes are represented only within the audited link-only boundary
- the substantial Chinese research guide satisfies the repository research cadence and citation requirements
- app/docs analytics, unrelated routes, canonical ownership, navigation, and unrelated source definitions remain unchanged
- full expected Quality workflow is green, followed by a fresh from-scratch review
- after squash merge, the exact source commit is verified in production by the repository's unchanged production-evidence path

## Rollback
Revert the squash commit; no migration, external account state, or origin mutation is involved.