### PR TITLE
Add classics and open reading discovery source

### DIFF
--- a/public/sources/classics-open-reading-discovery-starter/README.txt
+++ b/public/sources/classics-open-reading-discovery-starter/README.txt
@@ -1,0 +1,98 @@
+Classics & Open Reading Discovery Starter
+=========================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/classics-open-reading-discovery-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fclassics-open-reading-discovery-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small discovery directory for freely reachable
+reading collections whose useful reader surfaces are broader than WebNR's current
+TXT import runtime. It points readers to first-party browsing environments while
+keeping origin content, per-item rights, media, annotations, and account state at
+the source.
+
+Included discovery routes
+-------------------------
+- Lit2Go — University of South Florida / FCIT collection of stories, poems, MP3 audiobooks, and companion PDFs
+- Alpheios Texts — Ancient Greek and Classical Latin Reading Center with an explicit default CC BY-SA 4.0 text notice, subject to item-level exceptions
+- Perseus Scaife Viewer — Open Greek and Latin / Perseus reading environment for pre-modern editions and translations
+
+Content and rights boundary
+---------------------------
+The committed index contains only first-party destination URLs plus short
+WebNR-authored labels and descriptions. It does not copy story or book text,
+abstracts, edition metadata, translations, annotations, audio, PDFs, images,
+lesson material, lexicon data, user wordlists, or account state.
+
+Lit2Go's first-party license, rechecked on 2026-08-29, permits limited reuse in
+non-commercial educational projects and requires written permission for larger
+or commercial reuse. WebNR therefore does not treat the site's free availability
+as a general redistribution license and does not import Lit2Go files into this
+starter.
+
+Alpheios Texts states on its public Reading Center that, unless otherwise noted,
+texts in the reader are licensed CC BY-SA 4.0. Because that notice explicitly
+allows item-level exceptions and the current WebNR source runtime does not model
+per-work attribution/license inheritance for this collection, the admitted
+capability remains a first-party discovery link rather than a mirrored catalog.
+
+The Scaife Viewer publicly exposes a browsable Open Greek and Latin library and
+identifies itself as a reading environment for pre-modern text collections in
+original languages and translations. This audit did not establish one blanket
+redistribution grant covering every displayed edition and translation, so WebNR
+links the first-party library instead of copying its catalog or texts.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens the corresponding first-party reading environment. WebNR
+does not crawl those origins, call an API, poll their catalogs, proxy responses,
+mirror metadata, download media, create accounts, or bypass browser, robots,
+authentication, paywall, rate-limit, or access-control behavior. The committed
+search index is the versioned fixture for this static discovery capability.
+
+Candidate audit notes
+---------------------
+Five candidate families were screened on 2026-08-29. Lit2Go, Alpheios Texts, and
+Perseus Scaife Viewer completed the source-specific audit for the bounded
+link-only capability and are included above.
+
+StoryWeaver remains a strong future candidate because its first-party policy says
+stories and illustrations are openly licensed under CC BY 4.0 with explicit
+attribution requirements. During this operating cycle, however, direct requests
+to its reader and open-content routes from the verification environment returned
+HTTP 402 while indexed first-party policy pages remained discoverable. WebNR did
+not infer reliable reader-path availability from cached/search evidence, so no
+route was admitted today.
+
+Project Runeberg was also screened. Its first-party site describes a volunteer
+project for free electronic editions of Nordic literature, but its current 2025
+project note also says it has relaxed earlier copyright caution for some newer
+periodicals and reference works, and discusses server pressure from automated
+clients. That makes a blanket machine-ingestion or rights claim inappropriate.
+It remains a candidate for a narrower, item-specific public-domain audit rather
+than being admitted from project identity alone.
+
+Runtime and health boundary
+---------------------------
+All three included HTTPS destinations were reachable through the operating
+browser/search environment on 2026-08-29 without an authenticated WebNR action.
+Because the admitted capability makes no automated origin request beyond a reader
+choosing a normal link, origin CORS, cookies, pagination, request cadence,
+response-size limits, and authenticated sessions are outside the runtime path.
+
+A richer adapter requires source-specific proof for the exact machine interface,
+current terms and robots behavior, stable work/edition identity, pagination,
+request cadence, response and timeout bounds, caching/backoff, provenance,
+attribution, per-item license handling, updates/deletions, regional availability,
+and representative versioned fixtures. Open licensing by itself is not evidence
+that WebNR has implemented those runtime semantics.
+
+Last verified
+-------------
+2026-08-29

--- a/public/sources/classics-open-reading-discovery-starter/search_index.yml
+++ b/public/sources/classics-open-reading-discovery-starter/search_index.yml
@@ -1,0 +1,47 @@
+classics-open-reading/lit2go.md:
+  title: Lit2Go — Stories, Poems & Audiobooks
+  author: Florida Center for Instructional Technology, University of South Florida
+  description: Lit2Go 的第一方公开阅读目录提供故事、诗歌、经典文学、MP3 有声内容和配套 PDF。WebNR 当前仅保存官方入口与自行撰写的发现说明；Lit2Go 的现行许可对文件再利用设置教育、非商业与数量边界，因此不复制、缓存或重发其文本、音频、PDF、教学材料或站点元数据。
+  page_url: https://etc.usf.edu/lit2go/
+  source: WebNR Classics & Open Reading Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Lit2Go
+    - Classic literature
+    - Audiobooks
+    - Education
+  categories:
+    - Free reading discovery
+  region: en
+
+classics-open-reading/alpheios-texts.md:
+  title: Alpheios Texts — Greek & Latin Reading Center
+  author: Alpheios Project
+  description: Alpheios Texts 的第一方 Reading Center 提供古希腊语与古典拉丁语文本浏览；站点说明除另有标注外，Reader 中的文本采用 CC BY-SA 4.0。WebNR 当前只链接官方阅读入口，不复制文本、注释、词典数据、用户词表或站点资产，并保留逐项许可差异在来源站点处理。
+  page_url: https://texts.alpheios.net/
+  source: WebNR Classics & Open Reading Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Alpheios
+    - Ancient Greek
+    - Classical Latin
+    - Open texts
+  categories:
+    - Free reading discovery
+  region: multilingual
+
+classics-open-reading/scaife-viewer.md:
+  title: Perseus Scaife Viewer — Open Greek & Latin Library
+  author: Perseus Digital Library / Open Greek and Latin
+  description: Scaife Viewer 是 Perseus Digital Library / Open Greek and Latin 的第一方预现代文本阅读环境，可浏览古希腊语、拉丁语及相关译本。WebNR 仅保存官方 Library 入口和自行撰写的说明，不复制具体 edition、translation、annotation、词形数据或正文，也不把项目开放访问误写成所有版本均具有统一再分发许可。
+  page_url: https://scaife.perseus.org/
+  source: WebNR Classics & Open Reading Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Perseus Digital Library
+    - Scaife Viewer
+    - Ancient Greek
+    - Classical Latin
+  categories:
+    - Free reading discovery
+  region: multilingual


### PR DESCRIPTION
## Scope
- add a bounded Classics & Open Reading Discovery Starter with three first-party routes: Lit2Go, Alpheios Texts, and Perseus Scaife Viewer
- document the exact rights/runtime boundary for each route and keep the admitted capability link-only
- record the same-cycle screening outcome for StoryWeaver and Project Runeberg so their current access/rights uncertainties are not silently promoted into runtime assumptions

## Evidence and behavior
- Lit2Go is publicly reachable; its current first-party license limits file reuse to non-commercial educational use and requires permission for larger/commercial reuse, so WebNR copies no Lit2Go files
- Alpheios Texts is publicly reachable and states that Reader texts are CC BY-SA 4.0 unless otherwise indicated; WebNR does not flatten those item-level exceptions into a mirrored catalog
- Scaife Viewer is publicly reachable as the Open Greek and Latin / Perseus reading environment; no blanket edition/translation redistribution claim is made
- StoryWeaver first-party policy evidence remains strong (CC BY 4.0), but direct reader/open-content requests from this cycle's verification environment returned HTTP 402, so no reader route is admitted without reproducible availability
- Project Runeberg's current first-party project note describes both free electronic editions and a recent relaxation of copyright caution for some material, so it remains an item-specific audit candidate rather than a blanket ingestion target

## Preserved behavior
No application code, routes, canonical ownership, analytics, existing source definitions, content, or navigation are changed. The new source only adds a static WebNR catalog under `public/sources/`.

## Acceptance / rollback
Expected CI: full repository Quality workflow. Public acceptance after merge: the exact application deployment contains `sources/classics-open-reading-discovery-starter/search_index.yml`, the source can be added as a WebNR repository, and representative existing source/catalog behavior remains intact. Rollback is removal of the isolated source directory.