### PR TITLE
Add direct Project Ben-Yehuda TXT source

### DIFF
--- a/public/sources/project-ben-yehuda-txt-starter/README.txt
+++ b/public/sources/project-ben-yehuda-txt-starter/README.txt
@@ -1,0 +1,90 @@
+Project Ben-Yehuda Public Domain TXT Starter
+============================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/project-ben-yehuda-txt-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fproject-ben-yehuda-txt-starter
+
+Purpose
+-------
+This is a real raw-TXT source, not a static discovery-only directory. It exposes a
+small, bounded starter set from Project Ben-Yehuda's official public-domain dump
+so readers can import UTF-8 Hebrew text directly into WebNR while the full upstream
+catalog remains at its origin.
+
+Upstream and rights evidence
+----------------------------
+The upstream repository is maintained by the Project Ben-Yehuda GitHub
+organization at:
+
+https://github.com/projectbenyehuda/public_domain_dump
+
+The upstream README states that the dump contains more than twenty thousand
+public-domain Hebrew works in plaintext UTF-8 (with and without nikkud) and HTML,
+with pseudocatalogue.csv providing title, author, genre, and file-path metadata.
+The repository LICENSE states that the data files are in the public domain and may
+be used without permission; credit to "Project Ben-Yehuda volunteers" is optional
+and appreciated.
+
+This starter was audited against upstream commit:
+
+5e4277fead7b565f32cc4b352abd3565023a77d8
+
+The four download URLs below are pinned to that exact commit. The corresponding
+Project Ben-Yehuda reader pages are retained as human-readable provenance links.
+The source does not infer a broader license from free website access: its direct
+TXT capability is based on the explicit public-domain dump and LICENSE.
+
+Included direct TXT entries
+---------------------------
+- חצי-נחמה — אחד העם — upstream work 10
+- מעל מכסה האניה — אלחנן ליב לוינסקי — upstream work 28
+- הַתַּכְרִיך — אברהם שלום פרידברג — upstream work 33
+- שני ימים ולילה אחד בבית מלון אורחים — יהודה ליב גורדון — upstream work 40
+
+Runtime boundary
+----------------
+Adding this WebNR source fetches only the small WebNR-maintained YAML index.
+Choosing a downloadable entry uses the exact HTTPS raw-file URL recorded in that
+index. WebNR does not bulk-download the Project Ben-Yehuda dump, poll its website,
+mirror its full catalog, crawl reader pages, create accounts, or use cookies.
+
+Project Ben-Yehuda also documents a public API. That API is not used here because
+it requires an API key and has a documented request-rate boundary. Keeping the
+starter on the explicitly released public-domain dump avoids credentials and gives
+this first direct-TXT integration a stable, reviewable upstream identity.
+
+Identity, updates, and failure behavior
+---------------------------------------
+- Stable identity: Project Ben-Yehuda work ID plus the upstream dump path.
+- Snapshot identity: every download URL is pinned to the audited upstream commit.
+- Encoding: upstream declares the txt/ tree as plaintext UTF-8.
+- Pagination: none in the WebNR starter; the committed YAML contains four entries.
+- Request cadence: no background polling; an origin text is requested only when a
+  reader explicitly imports that entry.
+- Response bound: the WebNR repository index remains subject to WebNR's existing
+  5 MiB index limit; imported TXT is handled by the existing reader import path.
+- Updates/deletions: a later operating cycle may review a newer upstream dump and
+  update this source through the normal PR/CI/production-verification lane. An
+  upstream change never silently deletes a WebNR entry.
+- Failure: an unavailable upstream raw file is reported as an import failure; the
+  reader must not substitute a cached or guessed origin.
+
+Candidate audit context
+-----------------------
+The 2026-08-31 source cycle also screened Project Gutenberg Australia, Project
+Gutenberg Canada, GITenberg, and the Internet Sacred Text Archive. Those
+collections were not folded into this source: the Australian and Canadian sites
+carry jurisdiction-specific public-domain warnings; GITenberg substantially
+overlaps WebNR's existing Project Gutenberg discovery surface; and Sacred Texts
+mixes public-domain, attributed non-commercial, and copyrighted site material.
+This starter therefore keeps one coherent rights/runtime model instead of treating
+"free to read" collections as interchangeable.
+
+Last verified
+-------------
+2026-08-31

--- a/public/sources/project-ben-yehuda-txt-starter/search_index.yml
+++ b/public/sources/project-ben-yehuda-txt-starter/search_index.yml
@@ -1,0 +1,79 @@
+project-ben-yehuda/work-10.md:
+  title: חצי-נחמה
+  author: אחד העם
+  description: Project Ben-Yehuda 公共领域 dump 中的 UTF-8 纯文本作品。WebNR 保留官方阅读页作为来源说明，并把下载地址固定到已审计的上游 dump commit，使这条目可以真实导入 TXT，而不是只做发现链接。
+  filename: m10.txt
+  page_url: https://benyehuda.org/read/10
+  download_url: https://raw.githubusercontent.com/projectbenyehuda/public_domain_dump/5e4277fead7b565f32cc4b352abd3565023a77d8/txt/p23/m10.txt
+  source: Project Ben-Yehuda public_domain_dump
+  license: Public-Domain-Project-Ben-Yehuda
+  tags:
+    - Project Ben-Yehuda
+    - Hebrew
+    - Public domain
+    - Raw TXT
+    - Essay
+  categories:
+    - Free TXT reading
+  region: he-IL
+  chapters: 1
+
+project-ben-yehuda/work-28.md:
+  title: מעל מכסה האניה
+  author: אלחנן ליב לוינסקי
+  description: Project Ben-Yehuda 公共领域 dump 中的 UTF-8 希伯来语散文。条目使用官方作品页做 provenance，并直接指向固定 commit 的原始 TXT 文件；WebNR 不抓取网站目录或调用需要凭据的 API。
+  filename: m28.txt
+  page_url: https://benyehuda.org/read/28
+  download_url: https://raw.githubusercontent.com/projectbenyehuda/public_domain_dump/5e4277fead7b565f32cc4b352abd3565023a77d8/txt/p33/m28.txt
+  source: Project Ben-Yehuda public_domain_dump
+  license: Public-Domain-Project-Ben-Yehuda
+  tags:
+    - Project Ben-Yehuda
+    - Hebrew
+    - Public domain
+    - Raw TXT
+    - Prose
+  categories:
+    - Free TXT reading
+  region: he-IL
+  chapters: 1
+
+project-ben-yehuda/work-33.md:
+  title: הַתַּכְרִיך
+  author: אברהם שלום פרידברג
+  description: Project Ben-Yehuda 官方页面将该作品标为公共领域，官方 dump 同时以 UTF-8 TXT 发布。WebNR 的直接下载 URL 固定在审计过的上游 commit，便于可重复导入与回滚。
+  filename: m33.txt
+  page_url: https://benyehuda.org/read/33
+  download_url: https://raw.githubusercontent.com/projectbenyehuda/public_domain_dump/5e4277fead7b565f32cc4b352abd3565023a77d8/txt/p21/m33.txt
+  source: Project Ben-Yehuda public_domain_dump
+  license: Public-Domain-Project-Ben-Yehuda
+  tags:
+    - Project Ben-Yehuda
+    - Hebrew
+    - Public domain
+    - Raw TXT
+    - Prose
+  categories:
+    - Free TXT reading
+  region: he-IL
+  chapters: 1
+
+project-ben-yehuda/work-40.md:
+  title: שני ימים ולילה אחד בבית מלון אורחים
+  author: יהודה ליב גורדון
+  description: Project Ben-Yehuda 的公共领域希伯来语散文，正文来自官方 GitHub dump 的 UTF-8 TXT。WebNR 只维护一个小型版本化目录，实际阅读导入使用固定上游 commit 的原始文件。
+  filename: m40.txt
+  page_url: https://benyehuda.org/read/40
+  download_url: https://raw.githubusercontent.com/projectbenyehuda/public_domain_dump/5e4277fead7b565f32cc4b352abd3565023a77d8/txt/p46/m40.txt
+  source: Project Ben-Yehuda public_domain_dump
+  license: Public-Domain-Project-Ben-Yehuda
+  tags:
+    - Project Ben-Yehuda
+    - Hebrew
+    - Public domain
+    - Raw TXT
+    - Prose
+  categories:
+    - Free TXT reading
+  region: he-IL
+  chapters: 1


### PR DESCRIPTION
## Why
The 2026-08-31 source cycle is preparing the scheduled raw-TXT collection/import work. Project Ben-Yehuda publishes an official public-domain dump with 20,000+ Hebrew works in plaintext UTF-8, explicit public-domain reuse permission, machine-readable metadata, and a stable Git history. This is stronger evidence than another discovery-only link directory and gives WebNR a real direct-TXT source without credentials or crawling.

## Scope
- add `project-ben-yehuda-txt-starter`
- expose four representative Hebrew works as direct TXT imports
- pin every raw download URL to audited upstream commit `5e4277fead7b565f32cc4b352abd3565023a77d8`
- preserve Project Ben-Yehuda reader pages as human-readable provenance
- document rights, identity, update/deletion, failure, and runtime boundaries

## Evidence and boundary
The official upstream README and LICENSE state that the dump contains public-domain works and that the data files may be used without permission. The upstream dump supplies UTF-8 plaintext and pseudocatalogue metadata. The separate Project Ben-Yehuda API is deliberately not used because it requires an API key and has a request-rate boundary. WebNR does not bulk-download or poll the upstream collection.

The same source cycle also screened Project Gutenberg Australia, Project Gutenberg Canada, GITenberg, and Internet Sacred Text Archive. They are not mixed into this PR because their jurisdiction, mixed-rights, or duplication boundaries differ.

## Preserved behavior
No application code, routes, canonical ownership, analytics, existing source definitions, Legado fixtures, or documentation content changes. Existing sources remain intact.

## Validation
- branch is based on current `main` (`d2a3c820a057ca3f56238a3c075d353ca5fc3cea`)
- base-to-head diff is exactly two new source files
- upstream work IDs/paths and representative plaintext files were independently checked against the pinned dump
- CI must complete Web quality, Documentation quality, Production evidence, and Chromium user journeys before merge

## Risk / rollback
Main risk is upstream raw-file availability. URLs are commit-pinned and failures remain ordinary import failures; no cached or guessed fallback is introduced. Rollback is the single squash commit for this source.

## Production acceptance
After exact-head squash merge and application deployment, verify the new public `search_index.yml` is present on `app.webnovel.win`, contains all four direct `download_url` entries, representative existing source output remains present, analytics behavior is unchanged, and the recorded production build identity matches the merge commit.