### PR TITLE
Harden Chromium CI Playwright setup

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -130,9 +130,23 @@ jobs:
       - name: Install application dependencies
         run: npm ci
       - name: Install pinned Playwright runner
-        run: npm install --no-save --package-lock=false @playwright/test@1.62.0
+        run: |
+          set -euo pipefail
+          runner_dir="${RUNNER_TEMP}/webnr-playwright"
+          for attempt in 1 2 3; do
+            rm -rf "${runner_dir}"
+            if npm install --prefix "${runner_dir}" --no-save --package-lock=false @playwright/test@1.62.0; then
+              echo "${runner_dir}/node_modules/.bin" >> "${GITHUB_PATH}"
+              echo "NODE_PATH=${runner_dir}/node_modules" >> "${GITHUB_ENV}"
+              exit 0
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+          exit 1
       - name: Install Chromium for Playwright
-        run: npx playwright install --with-deps chromium
+        run: playwright install --with-deps chromium
       - name: Build production application
         run: npm run build
       - name: Run browser user journeys
@@ -156,7 +170,7 @@ jobs:
             exit 1
           fi
 
-          npx playwright test --config=tests/e2e/playwright.config.cjs
+          playwright test --config=tests/e2e/playwright.config.cjs
 
   docs:
     name: Documentation quality


### PR DESCRIPTION
## Why
The post-merge Quality run for the completed 2026-08-31 closeout exposed a reproducible CI fragility in `Chromium user journeys`. The job first runs `npm ci`, then runs `npm install --no-save --package-lock=false @playwright/test@1.62.0` in the repository root. Re-running that root-level install re-resolves the application dependency graph against live registry state. Three post-merge attempts failed before browser tests could run: once after a transient `canvas` prebuild fetch reset triggered a native fallback without `pixman-1`, then twice with registry `ETARGET` errors for unrelated `@typescript-eslint` packages. The exact PR-head Chromium job had succeeded minutes earlier, so this is setup fragility rather than a reader regression.

## Fix
Keep Playwright pinned at `1.62.0`, but install it into an isolated temporary prefix instead of mutating/re-resolving the repository dependency graph. The step:
- removes any partial temporary runner directory before each attempt;
- retries the small isolated Playwright install up to three times for transient registry/network failures;
- exports only that isolated runner's `.bin` and `node_modules` through `GITHUB_PATH` / `NODE_PATH`;
- uses the pinned `playwright` executable for Chromium installation and tests.

Application dependencies remain installed solely by the existing lockfile-backed `npm ci`.

## Scope
Only `.github/workflows/quality.yml` changes. No application code, source definitions, documentation content, analytics implementation, canonical ownership, production verifier, Legado behavior, or deployment configuration is weakened.

## Acceptance
The complete PR Quality workflow must pass Web quality, Documentation quality, Production evidence, and Chromium user journeys. In Chromium, the isolated Playwright install must complete, Chromium must install, the production application must build, and the actual browser user journeys must run successfully. After every expected job is terminal-success, perform the required fresh from-scratch review and exact-head squash merge.