### PR TITLE
Add bounded Folger direct TXT source

### DIFF
--- a/public/sources/folger-shakespeare-txt-starter/README.txt
+++ b/public/sources/folger-shakespeare-txt-starter/README.txt
@@ -1,0 +1,82 @@
+Folger Shakespeare TXT Starter
+==============================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/folger-shakespeare-txt-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Ffolger-shakespeare-txt-starter
+
+Purpose
+-------
+This starter promotes one previously deferred Folger Shakespeare Digital Texts
+candidate to a bounded direct-TXT capability. It exposes three Folger-provided
+English plain-text editions: Macbeth, Hamlet, and Romeo and Juliet. WebNR stores
+only a three-record catalog plus provenance and license notes. It does not mirror,
+proxy, rewrite, bulk-download, or background-poll Folger text.
+
+Upstream and rights evidence
+----------------------------
+Folger's current Download Shakespeare page explicitly offers TXT among six free
+download formats and says those files are free to use for non-commercial
+purposes. Folger's current copyright policy identifies Folger Digital Texts as
+Creative Commons Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0). The
+policy requires attribution to Folger Digital Texts and prohibits commercial use.
+This source therefore labels the texts as CC BY-NC 3.0; it does not call the
+Folger editions unrestricted public-domain files merely because Shakespeare's
+underlying works are old.
+
+The three catalog records preserve Folger Shakespeare Library / Folger Digital
+Texts as the source and link to the official Folger work pages. The raw TXT files
+themselves contain the work title, William Shakespeare, Folger Shakespeare
+Library, and editorial attribution. Romeo and Juliet was rechecked through the
+current Folger work page on 2026-09-02; its official TXT download resolved to the
+same first-party Folger S3 asset recorded in this source. Macbeth and Hamlet were
+rechecked through their current Folger work pages and first-party TXT assets in
+the same operating audit.
+
+Runtime boundary
+----------------
+Adding this source fetches only the small WebNR YAML catalog. A reader explicitly
+choosing one record uses WebNR's existing browser-side URL-import path to request
+that one public HTTPS TXT asset from Folger's first-party asset host. There is no
+server-side fetch, cache, content mirror, bulk corpus download, account use,
+credential or cookie use, crawler, or scheduled poll.
+
+Browser CORS and ordinary network availability still apply. The source does not
+claim to bypass them. If a Folger asset stops being readable from the browser,
+WebNR should surface the import failure and later downgrade or repair the record
+through a reviewed change; it must not silently switch to an unreviewed mirror.
+
+Identity, update, and failure behavior
+--------------------------------------
+- Stable identity: the Folger work slug plus official work page.
+- Download identity: the explicit first-party Folger asset URL stored per record.
+- Pagination: none; the source contains exactly three records.
+- Request cadence: no polling; one text request only after an explicit reader
+  import action.
+- Format: Folger's plain-text download format; the current usage guide describes
+  these as ASCII 7-encoded files intended for simple, stable application use.
+- Updates: a later cycle may re-audit a changed Folger asset or edition and update
+  the catalog through the normal PR, CI, deployment, and public-verification lane.
+- Deletions: an upstream disappearance does not silently remove or replace an
+  entry.
+- Attribution: Folger Shakespeare Library / Folger Digital Texts remains visible
+  in source metadata and the official work page remains the provenance link.
+- License boundary: CC BY-NC 3.0; WebNR makes no broader redistribution claim.
+
+Why this is narrower than a Folger corpus mirror
+------------------------------------------------
+Folger offers many works and multiple machine-readable formats, including XML and
+TEI Simple, and it also documents an experimental API. This starter deliberately
+does not convert that availability into a blanket synchronized corpus. A broader
+adapter would need a source-specific catalog identity, update/deletion semantics,
+request/resource budgets, versioned fixtures, attribution handling, and tested
+runtime behavior. The three-record direct-TXT starter gives readers a real,
+auditable import route without assuming those wider capabilities.
+
+Last verified
+-------------
+2026-09-02

--- a/public/sources/folger-shakespeare-txt-starter/search_index.yml
+++ b/public/sources/folger-shakespeare-txt-starter/search_index.yml
@@ -1,0 +1,59 @@
+folger-shakespeare/macbeth.md:
+  title: Macbeth
+  author: William Shakespeare
+  description: Folger Shakespeare Library 提供的官方 Macbeth 纯文本下载。WebNR 只保存 Folger 作品页、第一方 TXT 地址与许可/来源说明；读者明确选择该条目时由浏览器直接请求 Folger 的公开文本文件，WebNR 不代理或镜像正文。
+  filename: macbeth_TXT_FolgerShakespeare.txt
+  page_url: https://www.folger.edu/explore/shakespeares-works/macbeth/read/
+  download_url: https://folger-main-site-assets.s3.amazonaws.com/uploads/2022/11/macbeth_TXT_FolgerShakespeare.txt
+  source: Folger Shakespeare Library / Folger Digital Texts
+  license: CC-BY-NC-3.0-Folger-Digital-Texts
+  tags:
+    - Folger Shakespeare
+    - English
+    - Direct TXT
+    - Drama
+    - CC BY-NC 3.0
+  categories:
+    - Authorized TXT reading
+  region: en-US
+  chapters: 1
+
+folger-shakespeare/hamlet.md:
+  title: Hamlet
+  author: William Shakespeare
+  description: Folger Shakespeare Library 提供的官方 Hamlet 纯文本下载。文本的编辑与数字版本来源归属 Folger Digital Texts；WebNR 仅维护一个小型目录并指向 Folger 第一方下载资产，不复制评论、注释、账号状态或正文缓存。
+  filename: hamlet_TXT_FolgerShakespeare.txt
+  page_url: https://www.folger.edu/explore/shakespeares-works/hamlet/read/
+  download_url: https://folger-main-site-assets.s3.amazonaws.com/uploads/2022/11/hamlet_TXT_FolgerShakespeare.txt
+  source: Folger Shakespeare Library / Folger Digital Texts
+  license: CC-BY-NC-3.0-Folger-Digital-Texts
+  tags:
+    - Folger Shakespeare
+    - English
+    - Direct TXT
+    - Drama
+    - CC BY-NC 3.0
+  categories:
+    - Authorized TXT reading
+  region: en-US
+  chapters: 1
+
+folger-shakespeare/romeo-and-juliet.md:
+  title: Romeo and Juliet
+  author: William Shakespeare
+  description: Folger Shakespeare Library 提供的官方 Romeo and Juliet TXT。2026-09-02 审计确认 Folger 的 TXT 下载重定向到该第一方公开资产；文件自身标明 Folger Shakespeare Library 与编辑者信息。WebNR 不改写文本，也不把非商业许可扩大解释为一般公版授权。
+  filename: romeo-and-juliet_TXT_FolgerShakespeare.txt
+  page_url: https://www.folger.edu/explore/shakespeares-works/romeo-and-juliet/read/
+  download_url: https://folger-main-site-assets.s3.amazonaws.com/uploads/2022/11/romeo-and-juliet_TXT_FolgerShakespeare.txt
+  source: Folger Shakespeare Library / Folger Digital Texts
+  license: CC-BY-NC-3.0-Folger-Digital-Texts
+  tags:
+    - Folger Shakespeare
+    - English
+    - Direct TXT
+    - Drama
+    - CC BY-NC 3.0
+  categories:
+    - Authorized TXT reading
+  region: en-US
+  chapters: 1


### PR DESCRIPTION
## Summary

Adds `Folger Shakespeare TXT Starter`, a bounded three-entry direct-TXT source for Macbeth, Hamlet, and Romeo and Juliet using Folger Shakespeare Library first-party TXT assets.

## Evidence and scope

- Folger currently offers TXT downloads for Shakespeare works and states those digital texts are available for non-commercial use.
- Folger's current copyright policy identifies Folger Digital Texts as CC BY-NC 3.0 and requires attribution.
- The source keeps Folger provenance and official work-page links, labels the license conservatively, and does not treat the edited Folger editions as unrestricted public-domain files.
- WebNR stores only the small catalog. A reader explicitly selecting one entry uses the existing browser-side URL-import path for one Folger first-party TXT asset.

## Preserved behavior

No existing source, application route, canonical, analytics configuration, reader storage behavior, Legado compatibility behavior, or documentation page is changed. There is no crawler, proxy, mirror, scheduled poll, account/credential use, or access-control bypass.

## Validation and acceptance

Expected repository Quality jobs must all succeed: Web quality, Documentation quality, Production evidence, and Chromium user journeys. After CI, the complete final PR will be reviewed from the original operating contract before any merge. After squash merge, acceptance is the exact application deployment plus the public source catalog containing all three records while representative existing sources remain intact.

## Risk and rollback

Primary risks are upstream Folger asset availability/CORS or a future change in the source-specific license/runtime behavior. Failure must remain visible and must not silently switch to another mirror. Rollback is removal of this isolated source directory in a reviewed corrective PR; existing sources are unaffected.