### PR TITLE
Add DBNL public-domain discovery starter

### DIFF
--- a/public/sources/dbnl-public-domain-discovery-starter/README.txt
+++ b/public/sources/dbnl-public-domain-discovery-starter/README.txt
@@ -1,0 +1,77 @@
+DBNL Public Domain Discovery Starter
+====================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/dbnl-public-domain-discovery-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fdbnl-public-domain-discovery-starter
+
+Purpose
+-------
+This starter gives readers a bounded route into DBNL's explicitly public-domain
+collection. DBNL's first-party collection page states that the titles listed
+there are public domain / copyright free, may be used for any purpose, and are
+also offered in XML and .txt formats.
+
+WebNR deliberately keeps this first admission discovery-only. The index contains
+the official collection plus three representative works whose own DBNL pages are
+marked `Auteursrechtvrij` and expose a `tekstbestand` download:
+
+- Brieven aan Sophie (1806) — Rhijnvis Feith
+- Camera Obscura (1871) — Nicolaas Beets
+- Historie van mejuffrouw Sara Burgerhart (1782) — Aagje Deken and Betje Wolff
+
+Rights and scope boundary
+-------------------------
+The distribution basis is DBNL's explicit `Collectie publiek domein` statement
+and the item-level `Auteursrechtvrij` labels on the three selected works. This
+starter does not generalize those statements to DBNL titles outside that
+collection, later editions with different rights, images, editorial material,
+or unrelated DBNL datasets.
+
+WebNR stores only first-party DBNL page URLs plus WebNR-authored labels and
+summaries. It does not copy the texts, metadata CSV, XML archive, bulk TXT ZIP,
+PDFs, ebooks, cover images, or site editorial material.
+
+Why this is not direct-TXT yet
+------------------------------
+DBNL exposes first-party `tekstbestand` endpoints for these works, which makes the
+collection a strong richer-interface candidate. WebNR's current direct-URL import
+runs in the reader's browser, however, so a usable direct-TXT source also requires
+repeatable evidence that the endpoint permits the cross-origin browser request
+and that response-size, identity, update/deletion, and failure behavior remain
+within the source contract.
+
+This operating cycle verified the public-domain status and current first-party
+TXT availability but did not obtain a repeatable browser-CORS result. Rather than
+turn server-side reachability into a false browser-compatibility claim, the
+starter therefore links the official DBNL pages only. A later reviewed change may
+upgrade selected entries after an actual browser transport fixture passes.
+
+Runtime boundary
+----------------
+Adding this source fetches only WebNR's small static YAML index. Opening an entry
+navigates the reader to the first-party DBNL collection or work page. There is no
+background polling, catalog crawl, bulk ZIP download, server-side proxy, account
+or credential use, cookie automation, JavaScript execution, CAPTCHA handling, or
+access-control bypass.
+
+Identity, update, deletion, and failure behavior
+-----------------------------------------------
+- Stable identity: DBNL collection plus the explicit DBNL work page identifier.
+- Content transport: none in this capability level; discovery links only.
+- Pagination: none; four explicit entries are maintained by WebNR.
+- Request cadence: no polling or synchronization.
+- Updates: a later cycle may revise the bounded list or upgrade a selected work
+  only after a new source-specific audit and normal PR/CI/public verification.
+- Deletions: an upstream omission never silently removes an entry; removal or
+  replacement is a reviewed WebNR change.
+- Failure: an unavailable or redirected origin is reported through source-health
+  review rather than silently replaced by a mirror.
+
+Last verified
+-------------
+2026-09-04

--- a/public/sources/dbnl-public-domain-discovery-starter/search_index.yml
+++ b/public/sources/dbnl-public-domain-discovery-starter/search_index.yml
@@ -1,0 +1,67 @@
+dbnl-public-domain/collection.md:
+  title: DBNL — Collectie publiek domein
+  author: Digitale Bibliotheek voor de Nederlandse Letteren
+  description: DBNL 的第一方公共领域合集明确说明本页所列标题均为公版，并同时提供 XML 与 TXT 下载。WebNR 当前只保存这个官方合集入口与自行撰写的说明，不批量下载 ZIP、不镜像文本，也不把 DBNL 其他栏目默认视为公版。
+  page_url: https://www.dbnl.org/letterkunde/pd/
+  source: WebNR DBNL Public Domain Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - DBNL
+    - Dutch
+    - Public domain
+    - TXT
+    - XML
+  categories:
+    - Public-domain discovery
+  region: nl-NL
+
+dbnl-public-domain/brieven-aan-sophie.md:
+  title: Brieven aan Sophie
+  author: Rhijnvis Feith
+  description: DBNL 将 1806 年《Brieven aan Sophie》的该数字版本明确标记为 Auteursrechtvrij，并在第一方作品页提供 tekstbestand 下载。WebNR 只链接官方作品页；虽然 DBNL 暴露直接 TXT 端点，本轮没有把它声明为浏览器 direct-TXT source，因为尚未取得可重复的跨域 CORS 证据。
+  page_url: https://www.dbnl.org/tekst/feit007brie07_01/
+  source: WebNR DBNL Public Domain Discovery Directory
+  license: Link-only-WebNR-editorial-public-domain-origin
+  tags:
+    - DBNL
+    - Dutch
+    - Public domain
+    - Poetry
+    - TXT available at origin
+  categories:
+    - Public-domain discovery
+  region: nl-NL
+
+dbnl-public-domain/camera-obscura.md:
+  title: Camera Obscura
+  author: Nicolaas Beets
+  description: DBNL 将 1871 年《Camera Obscura》的该数字版本明确标记为 Auteursrechtvrij，并在第一方作品页提供 XML 与 tekstbestand 下载。WebNR 只保存官方作品入口，不复制正文、电子书、图片或 DBNL 元数据集，也不把当前可下载状态推断成跨域导入已经通过。
+  page_url: https://www.dbnl.org/tekst/beet005came07_01/
+  source: WebNR DBNL Public Domain Discovery Directory
+  license: Link-only-WebNR-editorial-public-domain-origin
+  tags:
+    - DBNL
+    - Dutch
+    - Public domain
+    - Novel
+    - TXT available at origin
+  categories:
+    - Public-domain discovery
+  region: nl-NL
+
+dbnl-public-domain/sara-burgerhart.md:
+  title: Historie van mejuffrouw Sara Burgerhart
+  author: Aagje Deken; Betje Wolff
+  description: DBNL 将 1782 年《Historie van mejuffrouw Sara Burgerhart》的该版本标记为 Auteursrechtvrij，并提供第一方 tekstbestand。WebNR 当前只链接作品页并保留作者与公版状态的来源边界；后续若要升级 direct-TXT，需要单独验证浏览器 CORS、稳定身份、响应上限与失败语义。
+  page_url: https://www.dbnl.org/tekst/wolf016hist01_01/
+  source: WebNR DBNL Public Domain Discovery Directory
+  license: Link-only-WebNR-editorial-public-domain-origin
+  tags:
+    - DBNL
+    - Dutch
+    - Public domain
+    - Epistolary novel
+    - TXT available at origin
+  categories:
+    - Public-domain discovery
+  region: nl-NL


### PR DESCRIPTION
## Rationale
DBNL is the strongest candidate carried forward from the September 3 source-health cycle. Its first-party public-domain collection explicitly marks the listed titles copyright-free and offers XML/TXT downloads, while selected work pages are individually marked `Auteursrechtvrij`.

## Scope
- add a bounded DBNL public-domain discovery directory with the official collection plus three representative works;
- preserve first-party provenance and item-level public-domain evidence;
- deliberately keep this capability link-only until browser CORS and direct-TXT transport semantics are proven by a repeatable fixture.

## Preserved behavior
No existing source definition, application route, canonical, analytics configuration, content, navigation, or deployment behavior is changed. No DBNL text, metadata archive, ZIP, PDF, ebook, or image is mirrored.

## Validation / acceptance
Expected repository Quality workflow must pass all normal jobs. Public acceptance after merge is that the application artifact exposes `/sources/dbnl-public-domain-discovery-starter/search_index.yml` with four entries while existing representative source and reader behavior remains intact.

## Risk and rollback
Risk is limited to a new static source directory. If validation or production evidence fails, do not merge; after merge, rollback is deletion of this isolated directory through the normal PR lifecycle.