### PR TITLE
Add Open Medieval French direct TXT starter

### DIFF
--- a/public/sources/open-medieval-french-txt-starter/README.txt
+++ b/public/sources/open-medieval-french-txt-starter/README.txt
@@ -1,0 +1,95 @@
+Open Medieval French Direct TXT Starter
+=======================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/open-medieval-french-txt-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fopen-medieval-french-txt-starter
+
+Purpose
+-------
+This starter exposes three bounded plain-text examples from the Open Medieval
+French `OpenMedFr/texts` repository. The upstream project describes the corpus as
+plain-text medieval French derived from critical editions believed to be out of
+copyright or known to use Creative Commons licenses, and publishes the repository
+under CC BY-NC-SA 4.0. WebNR keeps only a small reviewed catalog and points
+readers to exact commit-pinned upstream files. It does not mirror, clone, crawl,
+or periodically synchronize the wider corpus.
+
+Upstream identity, rights, and attribution
+-----------------------------------------
+The exact upstream identity audited for this starter is:
+
+OpenMedFr/texts commit 0d3112783556775fa30ab4bdac84a4c383cc0217
+
+The repository README states that its files are plain-text versions of medieval
+French texts derived from critical editions believed to be out of copyright or
+known to be under Creative Commons licenses. It also states that the repository
+is published under Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+International, documents a takedown procedure, and suggests citing each text as
+an Open Medieval French file. WebNR preserves that source identity and does not
+turn the upstream project's good-faith rights statement into a broader claim
+about the critical editions, manuscripts, or unrelated repositories.
+
+The three selected entries all come from the exact audited commit and are well
+below 1 MiB:
+
+- Cliges.txt — Cligès, Chrétien de Troyes — 203,200 bytes
+- Yvain.txt — Yvain: Le Chevalier au Lion, Chrétien de Troyes — 211,242 bytes
+- PercevalKu.txt — Perceval: Le Conte du Graal, Chrétien de Troyes — 277,626 bytes
+
+Titles and authors come from the metadata headers inside those exact upstream
+files. Every `download_url` embeds the audited commit rather than following the
+mutable `master` branch.
+
+Runtime boundary
+----------------
+Adding this source fetches only WebNR's small YAML index. A reader explicitly
+choosing one entry causes the existing browser-side URL-import path to request
+that one HTTPS raw file from `raw.githubusercontent.com`. This is the same bounded
+transport pattern already used by maintained GITenberg and CLiGS direct-TXT
+starters. WebNR performs no background polling, bulk clone, catalog crawl,
+server-side proxy, credential or cookie use, account automation, JavaScript
+execution, or archive extraction.
+
+WebNR does not host copies of the three text files. An origin or CORS failure
+remains a visible import failure; the reader is never silently redirected to an
+unreviewed mirror. The upstream CC BY-NC-SA 4.0 attribution/non-commercial/
+share-alike boundary remains visible in this source record rather than being
+relabelled as unrestricted public-domain redistribution.
+
+Identity, update, deletion, and failure behavior
+-----------------------------------------------
+- Stable identity: OpenMedFr repository plus the upstream text filename/TextURI.
+- Snapshot identity: `OpenMedFr/texts` commit
+  `0d3112783556775fa30ab4bdac84a4c383cc0217` embedded in each raw URL.
+- Pagination: none; this starter contains three explicit entries.
+- Request cadence: no polling; one upstream TXT request only after an explicit
+  reader import action.
+- Response size: the three audited files are each below 300 KiB.
+- Encoding: the audited files are readable UTF-8 text through the existing GitHub
+  raw-file transport.
+- Updates: a later operating cycle may audit a newer upstream revision and update
+  the pinned URLs only through the normal PR, CI, and production-verification
+  lane.
+- Deletions: an upstream deletion or rename never silently removes a WebNR entry;
+  replacement or removal requires an explicit reviewed change.
+- Attribution: future changes must preserve Open Medieval French provenance and
+  the upstream CC BY-NC-SA 4.0 repository boundary.
+- Failure: unavailable, moved, oversized, malformed, or CORS-blocked upstream
+  content is surfaced as an import failure instead of replaced with guessed text.
+
+Why this is a small pilot
+-------------------------
+The Open Medieval French repository contains texts from multiple critical
+editions and the upstream rights statement deliberately uses good-faith language.
+This starter therefore proves only three exact files with clear in-file identity
+and does not infer blanket rights for every underlying edition. Expansion should
+keep file-level provenance, attribution, transport, and rights evidence reviewable.
+
+Last verified
+-------------
+2026-09-06

--- a/public/sources/open-medieval-french-txt-starter/search_index.yml
+++ b/public/sources/open-medieval-french-txt-starter/search_index.yml
@@ -1,0 +1,59 @@
+openmedfr/cliges.md:
+  title: Cligès
+  author: Chrétien de Troyes
+  description: Open Medieval French 的中世纪法语 romance 纯文本。标题与作者来自该文件自己的 metadata header；WebNR 把下载地址固定到已审计的 OpenMedFr commit，读者明确选择后才直接请求上游 raw TXT，不镜像整个语料库。
+  filename: Cliges.txt
+  page_url: https://github.com/OpenMedFr/texts/blob/0d3112783556775fa30ab4bdac84a4c383cc0217/Cliges.txt
+  download_url: https://raw.githubusercontent.com/OpenMedFr/texts/0d3112783556775fa30ab4bdac84a4c383cc0217/Cliges.txt
+  source: Open Medieval French / OpenMedFr texts
+  license: Origin-CC-BY-NC-SA-4.0-OpenMedFr
+  tags:
+    - Open Medieval French
+    - Medieval French
+    - CC BY-NC-SA 4.0
+    - Raw TXT
+    - Romance
+  categories:
+    - Free TXT reading
+  region: fr-FR
+  chapters: 1
+
+openmedfr/yvain.md:
+  title: Yvain — Le Chevalier au Lion
+  author: Chrétien de Troyes
+  description: OpenMedFr 的 Yvain 中世纪法语纯文本；上游 metadata 将标题记为 Yvain、副标题记为 Le Chevalier au Lion。WebNR 只维护这一版本化入口，并保留 Open Medieval French 来源与 CC BY-NC-SA 4.0 仓库边界。
+  filename: Yvain.txt
+  page_url: https://github.com/OpenMedFr/texts/blob/0d3112783556775fa30ab4bdac84a4c383cc0217/Yvain.txt
+  download_url: https://raw.githubusercontent.com/OpenMedFr/texts/0d3112783556775fa30ab4bdac84a4c383cc0217/Yvain.txt
+  source: Open Medieval French / OpenMedFr texts
+  license: Origin-CC-BY-NC-SA-4.0-OpenMedFr
+  tags:
+    - Open Medieval French
+    - Medieval French
+    - CC BY-NC-SA 4.0
+    - Raw TXT
+    - Romance
+  categories:
+    - Free TXT reading
+  region: fr-FR
+  chapters: 1
+
+openmedfr/perceval.md:
+  title: Perceval — Le Conte du Graal
+  author: Chrétien de Troyes
+  description: OpenMedFr 的 Perceval 中世纪法语纯文本；标题、作者与副标题来自 commit-pinned 文件头。WebNR 不复制正文，只让现有浏览器 URL-import 在用户明确导入时读取这一条上游 raw 文件。
+  filename: PercevalKu.txt
+  page_url: https://github.com/OpenMedFr/texts/blob/0d3112783556775fa30ab4bdac84a4c383cc0217/PercevalKu.txt
+  download_url: https://raw.githubusercontent.com/OpenMedFr/texts/0d3112783556775fa30ab4bdac84a4c383cc0217/PercevalKu.txt
+  source: Open Medieval French / OpenMedFr texts
+  license: Origin-CC-BY-NC-SA-4.0-OpenMedFr
+  tags:
+    - Open Medieval French
+    - Medieval French
+    - CC BY-NC-SA 4.0
+    - Raw TXT
+    - Grail romance
+  categories:
+    - Free TXT reading
+  region: fr-FR
+  chapters: 1


### PR DESCRIPTION
## Rationale
The 2026-09-06 source audit identified OpenMedFr/texts as a bounded new direct-TXT source with explicit repository-level CC BY-NC-SA 4.0 terms, in-file identity metadata, small plain-text files, and a transport pattern already exercised by maintained GitHub-raw TXT sources.

## Scope
- add `public/sources/open-medieval-french-txt-starter/README.txt`
- add a three-entry commit-pinned `search_index.yml` for Cligès, Yvain, and Perceval
- preserve the origin's attribution/non-commercial/share-alike boundary and good-faith rights wording

No existing source definition, application code, documentation, canonical route, analytics implementation, Legado behavior, crawler scope, or deployment workflow changes.

## Runtime and rights boundary
The starter stores only a small WebNR-authored catalog. A reader explicitly choosing an entry causes the existing browser URL-import path to fetch that exact `raw.githubusercontent.com` file pinned to OpenMedFr commit `0d3112783556775fa30ab4bdac84a4c383cc0217`. WebNR does not mirror, bulk clone, crawl, poll, proxy, use credentials, execute scripts, or silently substitute another copy. The upstream repository says its medieval French plain-text corpus derives from editions believed out of copyright or known open-licensed and publishes the repository under CC BY-NC-SA 4.0; this PR does not broaden that statement into a blanket claim about every underlying critical edition.

## Validation and production acceptance
Expected Quality jobs: Web quality, Documentation quality, Production evidence, Chromium user journeys. After all succeed, review the complete final PR from scratch before exact-head squash merge. Production acceptance requires the application deployment for the exact squash commit, the deployed starter index with all three commit-pinned entries, unchanged GA4/full-URL behavior, and representative existing source behavior remaining intact.

## Risk and rollback
Risk is limited to one additive source directory. A source-specific transport or provenance problem can be rolled back by removing this directory in a normal reviewed PR; no existing reader data or source is migrated.