### PR TITLE
Finish reader-first cleanup of core WebNR blog guides

### DIFF
--- a/.github/seo-data/status.md
+++ b/.github/seo-data/status.md
@@ -3,22 +3,22 @@
 ## Current state
 
 - Last merged product/source change: pull request #145, squash merge `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`
-- Latest merged reader-content change: pull request #143, squash merge `85342ba1f37b9b2f0d341b146378d13f5412c944`
-- Last successful attributable application deployment: `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`
-- Current application verification target: `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`
-- Last successful attributable documentation deployment: `85342ba1f37b9b2f0d341b146378d13f5412c944`
-- Current documentation mirror verification target: `85342ba1f37b9b2f0d341b146378d13f5412c944`
-- Last successful canonical Cloudflare documentation deployment: `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`
-- Current canonical documentation verification target: `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`
-- Latest application deployment artifact branch commit: `c426e6d2166327e4b616b2162ef40570dc2af7a1`
-- Latest documentation mirror artifact branch commit: `17f73d915dd1e0e12d6a6985b3014fcde539c405`
+- Latest merged reader-content change: pull request #147, squash merge `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Last successful attributable application deployment: `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Current application verification target: `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Last successful attributable documentation deployment: `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Current documentation mirror verification target: `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Last successful canonical Cloudflare documentation deployment: `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Current canonical documentation verification target: `0359bae0d3c8dc1a1725975faf294b81bc123620`
+- Latest application deployment artifact branch commit: `fdf00ad236feaaa5220622d3a4087f2f653b9e71`
+- Latest documentation mirror artifact branch commit: `cd94f6aa92ee4b07be16def647dc0ad19ff0fcf8`
 - Canonical public documentation and editorial URL: `https://www.webnovel.win/`
 - Working reader URL: `https://app.webnovel.win/`
 - Working documentation build mirror URL: `https://autoarchive.github.io/webNR/`
-- Reader public-site target: exact source commit `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c` from pull request #145. Application workflow run `34047678054` built and validated the static reader, published `app-pages` artifact commit `c426e6d2166327e4b616b2162ef40570dc2af7a1`, and completed its unchanged exact-production check successfully. The deployed artifact `build.json` names the same source commit and contains all three Open Medieval French direct-TXT entries.
-- Documentation-mirror target: exact source commit `85342ba1f37b9b2f0d341b146378d13f5412c944`, artifact commit `17f73d915dd1e0e12d6a6985b3014fcde539c405`. Pull request #145 is source-only, so the GitHub Pages documentation mirror did not rebuild.
-- Canonical Cloudflare documentation target: exact source commit `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`. Preliminary closeout Quality run `34048125384` directly verified the independent canonical build through the unchanged Production evidence job before this last-successful label was advanced. The full four-job Quality workflow must run again on the finalized metadata head before merge.
-- Pull-request Quality run `34047508228` for #145 completed Web quality, Documentation quality, Production evidence, and Chromium user journeys successfully before exact-head squash merge. Post-merge Quality run `34047677992` also completed all four jobs successfully.
+- Reader public-site target: exact source commit `0359bae0d3c8dc1a1725975faf294b81bc123620` from pull request #147. Application workflow run `34074127475` completed successfully and published `app-pages` artifact commit `fdf00ad236feaaa5220622d3a4087f2f653b9e71`; the deployed `build.json` names the same source commit. Pull request #147 does not change reader runtime/source behavior, so the rebuild preserves the previously reviewed application/source contracts while aligning the public artifact with the homepage/blog repair commit.
+- Documentation-mirror target: exact source commit `0359bae0d3c8dc1a1725975faf294b81bc123620`, artifact commit `cd94f6aa92ee4b07be16def647dc0ad19ff0fcf8`. Documentation workflow run `34074127481` built, validated, published, and verified the generated mirror successfully.
+- Canonical Cloudflare documentation target: exact source commit `0359bae0d3c8dc1a1725975faf294b81bc123620`. Documentation workflow run `34074127481` completed its `Wait for legacy Pages mirror and verify canonical output` step successfully, independently confirming the canonical public documentation after the #147 presentation repair.
+- Pull-request Quality run `34073977510` for #147 completed Web quality, Documentation quality, Production evidence, and Chromium user journeys successfully before exact-head squash merge. Post-merge Quality run `34074127477` also completed successfully, and the exact application/documentation publication workflows above finished successfully.
 - Current skill submodule: `f42128a3f05c73cf10c786a2711c488bb3a14839`, exactly matching the current `AutoArchive/seo-skill` default branch during the 2026-09-06 cycle.
 - Current analytics export state: the configured Google Drive folder is accessible, but the 2026-09-06 direct non-trashed child listing exposes no matching GA4 or Search Console exports; missing provider data is unavailable rather than zero.
 - Current Cloudflare traffic-analytics state: a Cloudflare provider request-analytics connector exposing the configured zone is not available in the 2026-09-06 operating environment. Request metrics are unavailable rather than zero; exact build/deployment evidence remains covered by repository production workflows.
@@ -26,6 +26,7 @@
 ## Current signals
 
 - WebNR remains a local-first browser TXT reader. Imported book content and reading progress stay in the current browser profile; the reader and documentation site intentionally send page views to the single GA4 destination `G-DGH8HNQKE4` using full `page_location: window.location.href` and query-bearing `page_path: window.location.pathname + window.location.search`. Google signals and ad-personalization signals remain disabled.
+- Pull request #147 restores the public documentation root to the compact product-first WebNR landing structure, turns `/blog/` into a curated reader hub with concise post cards, disables archive/category navigation sprawl, rewrites the most confusing reader posts, and adds durable presentation guardrails. Stable public article URLs remain in place; the repair does not delete maintained source families or roll back reader/runtime capability.
 - Pull request #145 admits **Open Medieval French Direct TXT Starter** as the 25th maintained source family. It exposes three commit-pinned raw TXT files — `Cliges.txt`, `Yvain.txt`, and `PercevalKu.txt` — from `OpenMedFr/texts` commit `0d3112783556775fa30ab4bdac84a4c383cc0217`. The upstream repository publishes under CC BY-NC-SA 4.0 and uses good-faith rights/takedown language for underlying editions. WebNR preserves that attribution/noncommercial/share-alike boundary, does not claim blanket rights over every critical edition, and does not mirror, crawl, poll, proxy, bulk clone, use credentials, or silently substitute other copies.
 - The 2026-09-06 candidate pass also screened NeoLatDraCor, UW EMDrama, Digital Parisian Stage Corpus, and Corpus-DB. NeoLatDraCor is a strong CC0 TEI candidate but waits on deterministic TEI-to-reading-text fixtures; EMDrama is CC0 but metadata joining and incremental reader value are not yet strong enough for admission; Digital Parisian Stage is promising but requires exact cleaned-file/runtime/attribution review; Corpus-DB substantially duplicates Gutenberg/GITenberg and its REST API remains incomplete.
 - Rotating health checks on GITenberg direct TXT, CLiGS Spanish-American direct TXT, and Alice & Books discovery passed at their current admitted capability levels. No reproducible failure required removal or downgrade.
@@ -47,7 +48,7 @@
 
 ## Active focus
 
-1. Preserve the independently verified production identities through the unchanged public-evidence gate: application `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c`, documentation mirror `85342ba1f37b9b2f0d341b146378d13f5412c944`, and canonical documentation `b2f317c70dfd4bad8e195dcd75f97a7ddfbbb45c` unless exact attributable evidence later proves a different current identity.
+1. Preserve the independently verified production identities through the unchanged public-evidence gate: application `0359bae0d3c8dc1a1725975faf294b81bc123620`, documentation mirror `0359bae0d3c8dc1a1725975faf294b81bc123620`, and canonical documentation `0359bae0d3c8dc1a1725975faf294b81bc123620` unless exact attributable evidence later proves a different current identity.
 2. Preserve all 25 maintained source families and continue rotating health checks; remove, downgrade, or replace only reproducible failures rather than manufacturing source churn.
 3. Keep Open Medieval French bounded to the three audited commit-pinned files and preserve upstream CC BY-NC-SA 4.0 provenance/noncommercial/share-alike language. Expand only after file-level review.
 4. Keep Alice & Books discovery-only under its current site-access terms and DBNL discovery-only until a real browser CORS fixture proves direct-TXT transport.

--- a/docs/blog/posts/2026-08-08-legal-free-novels-txt-collections.md
+++ b/docs/blog/posts/2026-08-08-legal-free-novels-txt-collections.md
@@ -2,7 +2,7 @@
 title: 2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录
 date: 2026-08-08
 slug: legal-free-novels-txt-collections
-description: 面向读者整理 2026 年仍可核验的公版、作者授权和开放数字图书馆路线，并区分可以直接读、只能跳转发现、需要逐本判断版权和目前尚不适合 WebNR 直接导入的来源。
+description: 面向读者整理仍可核验的公版、作者授权与开放数字图书馆路线，并说明哪些适合直接读、哪些更适合做发现入口，以及 TXT、EPUB、扫描 PDF 的差别。
 categories:
   - Reader guides
   - Sources
@@ -10,140 +10,123 @@ categories:
 
 # 2026 年哪里能合法免费看小说？公版、作者授权与 TXT/电子书资源目录
 
-**直接答案：** 想找长期稳定、来源清楚的免费小说，优先顺序可以很简单：先看明确公版或由作者授权的数字图书馆，再看开放电子书项目和机构馆藏，最后才把搜索引擎、镜像站和社区分享当作发现线索。对 WebNR 用户而言，当前最容易直接阅读的是明确允许分发的 TXT；EPUB、扫描 PDF、特殊编码文本和只提供作品页的馆藏，应该先作为发现链接，等阅读器具备对应解析器和逐本权利判断后再开放直接导入。
+**先说结论：** 想找来源清楚、长期比较稳定的免费小说，优先顺序可以很简单：**公共领域或作者明确授权的项目 → 开放电子书项目 → 图书馆与机构馆藏 → 搜索/聚合服务作为线索**。不要把“网页免费打开”直接等同于“可以任意下载、机器抓取或再分发”。
 
-本文于 **2026 年 8 月 8 日**重新核验来源项目的官方页面、版权说明、访问方式和 WebNR 当前能力。今天同时上线一个新的 **Standard Ebooks Starter** 发现源，读者可以把四部经典小说的官方作品页加入 WebNR 来源列表：
+对 WebNR 用户，最省事的是本地 TXT 或已经审计过的 direct-TXT；EPUB、扫描 PDF、特殊编码文本和只提供作品页的馆藏，则先把它们当作**找书入口**。WebNR 不会为了“看起来支持更多格式”把 EPUB 假装成 TXT，也不会把一个公开网站自动变成抓取源。
 
 [添加 Standard Ebooks Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fstandard-ebooks-starter){ .md-button .md-button--primary }
 
-这个源只提供官方作品页链接，不复制 EPUB，也不把电子书下载地址伪装成 TXT。此前已经上线的 [Legado 书源查找与验源指南](2026-08-06-legado-source-guide.md) 解释了为什么“规则文件公开”与“内容可以合法获取”必须分开判断；本文把重点放在读者真正可以使用的免费阅读路线。
+## 一张表先分清“免费”是什么意思
 
-## 先看一张表：不同“免费来源”其实不是同一种东西
-
-| 来源类型 | 读者能得到什么 | WebNR 当前适合的方式 | 最容易忽略的边界 |
+| 来源类型 | 读者通常能得到什么 | WebNR 更适合怎么用 | 最容易误解的地方 |
 | --- | --- | --- | --- |
-| 作者授权或项目原创 TXT | 直接文本文件 | 可以直接导入或建立静态目录 | 授权范围是否允许再分发 |
-| 公版电子书项目 | 在线阅读、EPUB、作品页、目录 Feed | 先做作品发现；TXT 可直接读，EPUB 等解析器完成后再接入 | 公版状态随国家/地区而变化 |
-| 国家图书馆与数字馆藏 | 作品页、扫描件、全文或元数据 | 作品发现和跳转 | “可查看”不等于“可批量下载或再分发” |
-| Wikisource 等协作文本库 | 网页正文、导出文件、版本历史 | 语言/作品级 adapter | 页面许可、原作版权和译文版权可能不同 |
-| 搜索与聚合 API | 元数据、可读状态、落地页 | 发现层，不当作内容许可证 | API 返回“可见”不代表内容可自由复制 |
+| 作者授权 / 项目原创 TXT | 可直接保存的文本 | 本地导入或 direct-TXT source | 免费阅读不一定包含再分发权 |
+| 公版电子书项目 | HTML、TXT、EPUB、作品页 | TXT 可直接读；其他格式先做发现 | 公版期限随法域、版本、译者而变化 |
+| 国家图书馆 / 数字馆藏 | 扫描、全文、书目页 | 发现与跳转 | Full View 不一定允许整本下载 |
+| Wikisource 等协作文本库 | 网页正文、历史版本、导出 | 按作品/语言审计 | 原作、译文和编辑贡献可能不是同一权利状态 |
+| 搜索 / 聚合 API | 元数据、可读状态、落地页 | 找书线索 | API 返回“可见”不等于内容可自由复制 |
 
-这里最关键的判断是：**免费访问、公共领域、开放许可、机构允许下载、允许机器访问、允许第三方再分发，是六个不同问题。** 一个页面在浏览器里免费打开，只说明此刻可以访问；WebNR 若要把它变成长期可维护的书源，还需要知道来源是谁、作品权利状态、请求方式、格式、编码和失败边界。
+判断一个来源时，把下面六件事分开：**免费访问、公共领域、开放许可、允许下载、允许机器访问、允许第三方再分发**。它们不是同义词。
 
-## 第一组：最适合普通读者长期收藏的免费项目
+## 最适合普通读者先看的几条路线
 
-### Standard Ebooks：适合想要排版精良英文经典的人
+### Project Gutenberg：先解决“有没有免费版本”
 
-[Standard Ebooks](https://standardebooks.org/) 把公版文学制作成高质量电子书，并提供在线阅读、兼容 EPUB、Kindle/Kobo 格式以及作品源码。项目说明由 Standard Ebooks 制作的内容采用 **CC0 1.0**；每本书的页面又单独提示作品在美国是否被认为已经没有版权限制，并提醒美国以外读者核对所在地法律。
+[Project Gutenberg](https://www.gutenberg.org/) 适合做英文经典的第一层检索：馆藏大、无需账号，很多作品提供 HTML、EPUB 和 plain text。它也有专门的机器访问政策和目录路线，所以人类找书与程序化访问不需要混在一起。
 
-今天核验的四个官方页面是：
+对读者来说，最简单的方法仍然是从官方作品页开始。对 WebNR 来说，Project Gutenberg 更适合承担**发现大目录**的角色；真正 direct-TXT 的条目则应明确作品身份、具体文件和版本，而不是让每个浏览器客户端去扫描主站。
 
-- [Pride and Prejudice — Jane Austen](https://standardebooks.org/ebooks/jane-austen/pride-and-prejudice)
-- [Frankenstein — Mary Shelley](https://standardebooks.org/ebooks/mary-shelley/frankenstein)
-- [The Picture of Dorian Gray — Oscar Wilde](https://standardebooks.org/ebooks/oscar-wilde/the-picture-of-dorian-gray)
-- [The Time Machine — H. G. Wells](https://standardebooks.org/ebooks/h-g-wells/the-time-machine)
+需要注意：Project Gutenberg 的版权判断以美国为重要基准。一本书在美国进入公共领域，不代表它在你的所在地也一定如此。
 
-这些页面都能直接在线阅读，也提供电子书下载。WebNR 目前仍以 TXT 为正式支持格式，因此今天的集成选择“**链接到官方作品页**”，而不是做一个看似方便、实际没有经过 EPUB 安全测试的下载按钮。这样读者马上获得稳定入口，同时阅读器不会虚假宣称已经支持一种格式。
+第一方入口：
 
-Standard Ebooks 还提供 OPDS/Atom/RSS 形式的电子书 Feed，不过完整 Feed 存在不同访问路径。今天的 Starter 不依赖这些 Feed；后续只有在明确符合公开或开源项目访问条件并建立固定测试后，才会升级为自动目录 adapter。
+- [Project Gutenberg](https://www.gutenberg.org/)
+- [Reading options](https://www.gutenberg.org/help/reading_options.html)
+- [Robot access](https://www.gutenberg.org/policy/robot_access.html)
 
-### Project Gutenberg：目录巨大，但机器访问要走机器路线
+### Standard Ebooks：更在意“这本 EPUB 做得好不好”
 
-[Project Gutenberg](https://www.gutenberg.org/) 是最常见的英文免费电子书入口之一。它的目录以美国版权判断为基础，既有美国公共领域作品，也可能保留历史上经权利人授权发布的条目。因此“Gutenberg 上有”并不适合被简化成“全世界都属于公版”。
+[Standard Ebooks](https://standardebooks.org/) 的优势不是“又一份免费文件”，而是把公版文本重新校对、排版并做成现代 EPUB。对 Kindle、Kobo、Apple Books、Thorium、Calibre 等成熟 EPUB 阅读器用户，它往往比原始 TXT 更舒服。
 
-对普通读者，直接打开作品落地页最清楚。对程序和书源，项目明确区分主网站的人类访问与机器人/批量访问，并提供机器可读目录、镜像和离线元数据路线。WebNR 后续的 Gutenberg adapter 应当使用这些官方机器入口、缓存目录结果、保持低频，并尽量链接作品页，而不是让每个客户端反复抓取主站网页或把第三方镜像当作权威来源。
+WebNR 的 **Standard Ebooks Starter** 只链接官方作品页，不复制 EPUB，也不宣称 WebNR 已经原生支持 EPUB。当前比较适合从这里发现高质量版本的作品包括 *Pride and Prejudice*、*Frankenstein*、*The Picture of Dorian Gray* 与 *The Time Machine*。
 
-Gutenberg 因此很适合作为“大目录发现层”：它能回答“这本经典有没有合法免费版本”，但具体下载、再分发以及所在法域是否已进入公共领域，仍需要看单本作品与当地法律。
+第一方入口：
 
-### 青空文库：日文经典入口已经可以在 WebNR 里发现
+- [Standard Ebooks](https://standardebooks.org/)
+- [About](https://standardebooks.org/about)
+- [Public domain policy](https://standardebooks.org/about/standard-ebooks-and-the-public-domain)
 
-[青空文库](https://www.aozora.gr.jp/) 是日本文学的重要免费数字项目。WebNR 已经上线 **Aozora Bunko Starter**，当前包含《吾輩は猫である》《羅生門》《走れメロス》《よだかの星》四个经过核验的官方图书卡链接。
+### 青空文库：日文经典和近代文本的自然入口
 
-青空文库的图书卡/书架数据有明确的再利用条件，但具体作品仍需考虑原作、译文等权利状态；文件格式还常见 ZIP、Shift_JIS、青空文库注记和 XHTML。WebNR 因此先把它做成作品发现源。等 ZIP、编码和 ruby 注记解析有版本化测试后，才适合讨论直接阅读。
+[青空文库](https://www.aozora.gr.jp/) 对日文公版文学非常重要。它有稳定的作品卡、书架与文本文件，但常见 ZIP、Shift_JIS、青空文库注记和 XHTML，不是所有文件都适合直接当 UTF-8 TXT 读取。
 
-这个策略对其他区域图书馆同样适用：**先把稳定、官方、可解释的作品入口交给读者，再逐步增加格式能力。**
+WebNR 当前把它作为作品发现入口，先保留官方图书卡和作品身份。这样读者能找到《吾輩は猫である》《羅生門》《走れメロス》等作品，同时避免在没有 ZIP/注记解析 fixture 的情况下假装“直接导入已经完整兼容”。
 
-### Project Madurai：泰米尔语电子文本的区域性宝库
+### Project Madurai：泰米尔文学的长期数字化项目
 
-[Project Madurai](https://www.projectmadurai.org/) 是一个长期运行的志愿数字化项目，目标是制作并免费发布泰米尔文学电子文本。官方说明称收藏中的作品来自公共领域，或已经得到相应作者/权利方许可；其档案同时保留早期 TSCII 编码和较新的 Unicode HTML/PDF 版本。
+[Project Madurai](https://www.projectmadurai.org/) 长期发布泰米尔文学电子文本。收藏横跨较早的 TSCII 编码和较新的 Unicode HTML/PDF，作品的来源与发布条件也需要按具体条目理解。
 
-它非常适合成为 WebNR 的区域来源候选，不过接入方式需要比“抓一个 TXT 链接”更细：不同年代文件的字符编码、HTML 结构、PDF 与纯文本能力不一致，早期档案还带有个人使用措辞。今天的决定是保留为高价值 adapter 候选，优先从明确 Unicode、作品状态和下载条件的条目建立 fixture，而不是一口气索引整个档案。
+因此 **Project Madurai** 很适合做区域文学发现，也适合从明确 Unicode、权利状态和下载条件的条目逐步建立兼容；它不适合被一句“免费项目”粗暴地当成统一 TXT 仓库。
 
-### Project Ben-Yehuda：公版与明确授权并存的希伯来语数字图书馆
+### Project Ben-Yehuda：把权利状态直接做成目录信息
 
-[Project Ben-Yehuda](https://benyehuda.org/) 把希伯来文学制作成免费、可搜索的数字版本。项目自己的介绍明确说明，站内作品主要来自版权已经到期的内容，或取得了出版许可；作品列表还把“公共领域”“经授权发布”等权利状态直接作为筛选条件，并提供文本/电子书导出能力。
+[Project Ben-Yehuda](https://benyehuda.org/) 提供希伯来文学数字文本，并区分公共领域和获得授权的作品。对阅读器来说，这种“作品为什么能公开”的信息非常有价值。
 
-这类站点对 WebNR 很有价值，因为“作品为什么能公开”本身就是目录数据的一部分。今天把它加入区域来源队列，下一步应使用官方作品状态与导出接口做小规模 fixture，确保每个条目都保留原始作品页和权利标签。
+WebNR 后续已经基于其公开的 public-domain dump 建立 **Project Ben-Yehuda Public Domain TXT Starter**：只对明确公共领域、UTF-8、身份可固定的小型样本提供 direct-TXT，而不是把整个站点的所有内容都视为同一许可。
 
-## 第二组：非常有用，但更适合作为发现层
+## 很有用，但更适合做发现层的来源
 
-### Wikisource：适合从网页和导出开始，不适合把整个站视为一种许可证
+### Wikisource
 
-[Wikisource](https://wikisource.org/) 的不同语言项目拥有大量可阅读文本，并有 EPUB/PDF 等导出能力。它的优势是版本历史、校对和页面级来源清楚；复杂之处是原作、译文、编辑贡献以及不同语言项目的具体信息需要逐项处理。
+Wikisource 的优势是网页正文、版本历史和校对过程清楚，也提供不同导出方式。复杂点在于原作、译文、编辑贡献和不同语言站点的规则可能不同，所以最好按具体作品与版本判断，而不是给整个 Wikimedia 项目套一个统一版权结论。
 
-WebNR 已把 Wikisource 留在 adapter 队列。合理设计是保存语言、作品页、导出方式和许可/版权模板，而不是只根据“Wikimedia”这个品牌给整站贴一个统一权利标签。
+### HathiTrust
 
-### Project Runeberg：北欧文学很强，法域判断必须跟着作者和译者走
+HathiTrust 很适合确认某本书是否存在机构数字版本，以及它当前是 Full View、受限查看还是只有检索。**能在线看**与**允许整本下载**并不是同一状态；下载能力还可能受登录资格、作品状态与数字化来源影响。
 
-[Project Runeberg](https://runeberg.org/) 长期数字化北欧文学，并明确说明它按照版权期限谨慎发布作品。对于北欧经典发现，它提供了独特价值；对于全球读者，作者、译者、版本和所在地版权期限仍可能产生差异。
+### Project Runeberg
 
-因此它适合做区域发现与逐本链接，不适合生成“整个 Runeberg 都可以任意再分发”的结论。
+Project Runeberg 对北欧文学发现很有价值，但法域、作者、译者和版本差异都需要保留。最合理的使用方式是逐本作品页发现，而不是把整个站视为全球统一公版库。
 
-### HathiTrust：Full View 很有价值，下载权限仍要看条目和数字化来源
+## 搜索和聚合服务：拿来找，不拿来证明版权
 
-[HathiTrust Digital Library](https://www.hathitrust.org/) 汇集大量图书馆数字化内容。没有登录的用户也能阅读许多 **Full View** 条目；但整本下载能力受作品状态、登录资格以及数字化来源影响，Google 扫描的条目尤其可能有下载限制。
+DPLA、Library of Congress API、Google Books、Internet Archive 等服务都很适合回答“哪里可能有这本书”。但它们提供的是**发现能力**：真实全文、扫描件和下载权限仍由具体提供机构、条目和所在地规则决定。
 
-对 WebNR 来说，HathiTrust 很适合作为“是否存在机构完整视图”的发现信号，暂时不适合作为统一直链下载源。一个未来 adapter 应明确区分 Full View、Search-only、下载限制和作品落地页。
+尤其要避免一个常见误区：Google Books 显示 Full View，或 Internet Archive 某个 item 可以打开，并不能自动推导出“任何第三方都能重新托管这份内容”。
 
-## 第三组：搜索能力很强，但元数据本身不是内容授权
+## 如果你只想今晚开始读，怎么选
 
-今天还新增核验了几类发现候选：
+**英文经典：** 先搜 Project Gutenberg；如果有 Standard Ebooks 版本并且你用 EPUB 阅读器，优先试精修版。
 
-- **Digital Public Library of America (DPLA)**：聚合元数据采用非常宽松的开放政策，很适合发现美国机构收藏；实际图片、扫描件或文本仍由各提供机构的 rights statement 决定。
-- **Library of Congress JSON API**：不需要 API key 就能查询大量公开元数据，适合低频目录发现；条目格式与权利状态具有异质性，需要保留作品页和逐项 rights 信息。
-- **Google Books API / Full View**：能提供书目、预览/可读状态和购买/落地信息；Full View 与下载能力会随作品权利和用户所在地变化，所以应把 `accessInfo` 当成“当前可读性信号”，而不是全局公版证明。
-- **Internet Archive Texts**：拥有庞大文本与元数据集合，但不同项目、借阅模型和单本作品的权利状态差异很大。WebNR 可以研究元数据/明确开放集合，通用“Internet Archive 全站下载源”则缺少足够窄的权利边界。
+**日文经典：** 青空文库先找作品卡；遇到 ZIP / Shift_JIS / 注记文件时，不要把格式问题误判成“作品不能读”。
 
-这些来源证明了一件很实用的事：一个好的阅读器目录不必把所有书都自己托管。**发现层负责告诉读者哪里有可靠版本；导入层只处理已经满足格式、访问和权利条件的内容。**
+**泰米尔语：** Project Madurai 是很好的第一方入口，优先选 Unicode 条目。
 
-## 如果你只想“找一本文本马上读”，怎么选
+**希伯来语：** Project Ben-Yehuda 适合找公版/授权文本；WebNR 已有小型 public-domain direct-TXT starter。
 
-可以按下面的顺序降低踩坑概率：
+**你已经有 TXT：** 不必先找 source，直接在 WebNR 本地导入即可。编码或 CORS 问题看 [TXT 导入指南](2026-09-01-raw-txt-collection-import-guide.md)。
 
-1. **先搜索作者或项目官方页面。** 作者自己发布的 TXT、明确授权下载页、项目原创内容最容易判断。
-2. **再找公版项目的作品页。** Standard Ebooks、Project Gutenberg、青空文库、Project Madurai、Project Ben-Yehuda、Project Runeberg 都比无来源 TXT 打包站更容易追溯。
-3. **需要更多版本时再去机构馆藏。** Wikisource、HathiTrust、DPLA、Library of Congress、Google Books 可以帮助确定版本、扫描件和可读状态。
-4. **看到“TXT 全集”“万能书源”先检查来源。** 文件名、网盘地址和“免费”标签本身不能回答作者、版本、授权和法域问题。
-5. **给 WebNR 导入时看格式。** 当前可靠路径是 TXT 与已验证的文本 URL；EPUB、ZIP、特殊编码和复杂网页规则应该等对应能力通过测试。
+## 如何判断一个“免费小说站”值不值得长期信任
 
-一个来源如果只有文件、没有作者和 metadata，并不必然不能用。WebNR 的规则是：可以从文件名生成展示标题，未知作者保持 Unknown；但**绝不通过猜测补作者、许可、发布日期或热度**。比起漂亮但虚构的目录，一个诚实的“未知”更容易在以后被纠正。
+看五件事就够了：
 
-## 今天的来源审计与接入结果
+1. 有没有清楚的项目/机构身份与作品页；
+2. 权利说明是整站笼统口号，还是能落实到作品/版本；
+3. 下载格式和编码是否明确；
+4. 程序访问有没有官方 Feed/API/镜像/robots/频率说明；
+5. 上游失效时，你还能否用稳定作品 ID 或版本重新找到同一文本。
 
-本轮重新核验了现有 WebNR Originals 和 Aozora Bunko Starter，并扩展了免费阅读候选池。新增发现方向包括 HathiTrust、DPLA、Google Books Full View、Internet Archive Texts、Project Madurai 和 Project Ben-Yehuda。
+这比“今天能不能 curl 到一个 URL”更接近长期可维护的阅读来源。
 
-深入审计后形成三个直接结论：
+## 与 WebNR 的关系
 
-- **Standard Ebooks：通过，今天接入。** 使用官方作品页和项目自己的 CC0/版权说明，只做 link-based discovery，不使用受条件约束的完整 Feed，也不复制 EPUB。
-- **Project Madurai：通过读者价值审计，等待编码/权利 fixture。** 免费电子文本价值高，先从 Unicode 和权利说明明确的条目做 adapter。
-- **Project Ben-Yehuda：通过读者价值审计，等待权利状态/导出 fixture。** 站点直接区分公版和授权发布，适合做保留权利标签的区域目录。
+WebNR 的来源系统并不等于“把互联网小说搬进 WebNR”。它更像一层**可解释的发现与导入目录**：
 
-新的 **Standard Ebooks Starter** 因此成为 WebNR 第三个正式来源。它的作用不是取代 Standard Ebooks，而是给 WebNR 用户一个可验证的作品发现入口；任何阅读和下载仍回到官方作品页。
+- 有明确、稳定、可审计 TXT 时，可以做 direct-TXT；
+- 只有可靠作品页时，就保持 discovery；
+- EPUB/PDF/特殊格式没有真正 parser 时，不冒充兼容；
+- 登录、验证码、付费、DRM 和访问控制不通过绕过来解决。
 
-## 为什么今天没有直接接一个“大型 TXT 合集”
+如果你关心某个来源为什么只是 discovery-only，而不是 direct-TXT，可以继续看 [WebNR 当前来源目录与健康说明](2026-09-03-first-month-source-directory-health-report.md)。
 
-TXT 合集非常适合 WebNR，但“没有 metadata”与“没有来源依据”是两回事。前者可以解决：文件名就能先成为标题，未知字段保持未知。后者不能靠技术补齐：如果不知道文本来自哪里、是否公版或获授权，就不能因为文件格式方便而把它包装成官方推荐源。
-
-所以接下来的 TXT 工作会优先寻找三类集合：作者明确授权发布、项目自身原创/开放许可、公共领域项目明确允许分发的文本包。Project Madurai、Project Ben-Yehuda 和部分区域数字项目都可能提供这样的材料，但要先逐项把许可措辞、编码和文件入口做成可重复测试。
-
-## 下一步
-
-今天之后，免费阅读目录会持续更新来源健康和接入能力，而不是停在一篇“资源推荐”。接下来最值得做的是：
-
-- 为 Project Gutenberg 建立目录缓存、作品落地页优先的低频 adapter；
-- 为 Wikisource 固定语言、导出与归属 fixture；
-- 为 Project Madurai 测试 Unicode/TSCII 编码边界；
-- 为 Project Ben-Yehuda 保留公版/授权状态并测试文本导出；
-- 等 WebNR 的 EPUB 安全解析器完成后，把 Standard Ebooks 从发现源升级为真正可读的格式适配器。
-
-免费小说资源的长期价值来自三件事同时成立：**读者找得到，来源讲得清，阅读器真的能稳定处理。** WebNR 会把这三件事分别验证，再把通过的部分逐步连起来。
+核验日期：**2026-08-08**。项目目录、版权期限和访问政策会变化；需要当前状态时，以来源项目第一方页面和 WebNR 最新 Sources 页面为准。

--- a/docs/blog/posts/2026-08-30-legado-compatibility-report.md
+++ b/docs/blog/posts/2026-08-30-legado-compatibility-report.md
@@ -2,7 +2,6 @@
 title: WebNR 到底支持哪些 Legado 书源能力？2026-08-30 版本化兼容报告
 date: 2026-08-30
 slug: legado-compatibility-report
-_description: 用版本化 fixtures 说明 WebNR 当前可以安全导入和检查哪些 Legado JSON 字段、哪些规则尚不能执行，以及 L1–L5 兼容级别分别意味着什么。
 description: 用版本化 fixtures 说明 WebNR 当前可以安全导入和检查哪些 Legado JSON 字段、哪些规则尚不能执行，以及 L1–L5 兼容级别分别意味着什么。
 categories:
   - Reader guides
@@ -12,97 +11,100 @@ categories:
 
 # WebNR 到底支持哪些 Legado 书源能力？2026-08-30 版本化兼容报告
 
-**直接答案：截至 2026 年 8 月 30 日，WebNR 对 Legado 书源的正式兼容级别是 L1：本地导入与检查。** 你现在可以在 WebNR 的“Import Novel / 导入”页面选择一个 Legado JSON 或 TXT 书源定义文件；文件只在当前浏览器里读取，WebNR 会解析单条定义或数组、保留未知的顶层字段、识别常见字段属于哪一类能力，并生成一份兼容报告。这个检查器**不会执行搜索规则、正文规则、JavaScript、Cookie、登录流程或 WebView，也不会请求书源指向的网站**。
+**直接答案：截至 2026 年 8 月 30 日，WebNR 对 Legado 书源的正式兼容级别是 L1：本地导入与检查。** 你可以选择一个 Legado JSON/TXT 定义文件，让 WebNR 在浏览器本地解析它、保留未知顶层字段，并告诉你这份定义最低需要哪一层能力；它**不会执行搜索/正文规则，不运行 JavaScript，不保存目标站 Cookie，不模拟登录，也不会请求定义指向的网站**。
 
-本次报告绑定的 fixture suite 是 **`2026-08-30.1`**。后续任何“WebNR 支持 Legado”之类的公开说法都应该同时给出能力级别和 fixture 版本，而不是只写一个容易误解的“兼容”。
+本报告对应 fixture suite **`2026-08-30.1`**。以后看到“WebNR 兼容 Legado”时，应同时看**能力级别 + fixture 版本**，而不是把“JSON 能打开”误解成“所有书源已经能跑”。
 
 [打开 WebNR，在导入页检查 Legado JSON](https://app.webnovel.win/){ .md-button .md-button--primary }
 
-如果你的目标只是把自己的 TXT 放进浏览器阅读，WebNR 原有路径不变；如果你想判断一份 Legado JSON 为什么不能直接在 WebNR 运行，新的检查器给出了第一个可重复的答案入口。
+## 一张表看懂 L1–L5
 
-## 一张表看懂今天的边界
-
-| 能力级别 | 2026-08-30 状态 | WebNR 今天实际做什么 | 明确不做什么 |
+| 级别 | 当前状态 | WebNR 能做什么 | 当前明确不做什么 |
 | --- | --- | --- | --- |
-| **L1 / Phase 1：Import & Inspect** | **已支持** | 本地读取 JSON/TXT；接受单对象或数组；保留顶层未知字段；识别常见字段；报告最高所需能力；2 MiB、最多 500 条定义的输入边界 | 不联网，不执行任何书源规则 |
-| **L2 / Phase 2：Declarative Rules** | **未执行** | 能识别 `searchUrl`、`ruleSearch`、`ruleBookInfo`、`ruleToc`、`ruleContent` 等需要声明式运行时 | 不执行 CSS/XPath/JSONPath/正则，不抓搜索/详情/目录/正文 |
-| **L3 / Phase 3：Stateful Rules** | **未执行** | 能把 Cookie、登录、并发/频率等字段标成需要状态与权限边界 | 不保存目标站 Cookie，不模拟登录，不共享账号状态 |
-| **L4 / Phase 4：Restricted Script** | **受限、未执行** | 发现 `<js>`、`@js:`、`loginCheckJs` 等脚本标记时升级风险级别 | 不执行第三方 JavaScript，不给规则开放浏览器、文件或凭据能力 |
-| **L5 / Phase 5：Bridge / WebView** | **受限、未执行** | 识别 WebView/Bridge 依赖并明确报告 | 不绕过 CORS、验证码、登录、Cloudflare、付费墙、DRM 或其他访问控制 |
+| **L1 — Import & Inspect** | **已支持** | 本地读取 JSON/TXT；单对象或数组；保留 unknown 顶层字段；能力分类；2 MiB / 500 definitions 输入边界 | 不联网、不执行规则 |
+| **L2 — Declarative Rules** | **未执行** | 能识别 `searchUrl`、`ruleSearch`、`ruleBookInfo`、`ruleToc`、`ruleContent` 等需求 | 不执行 CSS/XPath/JSONPath/正则，不抓搜索/详情/目录/正文 |
+| **L3 — Stateful Rules** | **未执行** | 能识别 Cookie、登录、并发/频率等状态需求 | 不保存第三方 Cookie，不模拟登录，不共享账号状态 |
+| **L4 — Restricted Script** | **未执行** | 能发现 `<js>`、`@js:`、`loginCheckJs` 等脚本迹象并升级风险级别 | 不执行第三方 JavaScript |
+| **L5 — Bridge / WebView** | **未执行** | 能识别 WebView / Java bridge 一类依赖 | 不绕过 CORS、验证码、登录、Cloudflare、付费墙、DRM 或访问控制 |
 
-这里最重要的区别是：**“能够识别字段”不等于“能够执行字段”。** L1 解决的是导入、结构保真和能力分级；L2–L5 才涉及真正把第三方规则跑起来。
+最重要的一句是：**“能识别”不等于“能执行”。** L1 是兼容检查器；L2–L5 才涉及真正的规则运行时。
 
-## 为什么先做 L1，而不是直接承诺“兼容全部书源”
+## 为什么不直接做“全部兼容”
 
-Legado 的“书源”不是一个简单 RSS 地址。官方旧版入门文档把书源描述为通过规则抓取第三方网页中的书籍、章节和正文；公开文档支持从本地文件或网络地址导入 JSON/TXT。[P1][P2] 一份常见定义可能同时包含：
+Legado 定义可能同时包含几类完全不同的东西：
 
-- 书源名称、URL、分组、启用状态等 metadata；
-- 搜索 URL 和发现 URL；
-- `ruleSearch`、`ruleBookInfo`、`ruleToc`、`ruleContent` 等规则对象；
-- header、charset、POST body、分页和替换净化；
-- Cookie、登录状态、变量和请求并发；
+- 名称、URL、分组、启用状态等 metadata；
+- 搜索 URL、发现 URL；
+- 搜索、书籍详情、目录、正文规则；
+- header、charset、POST body、分页和替换；
+- Cookie、登录、变量和并发；
 - JavaScript；
 - Android WebView、Java bridge 或其他浏览器之外的能力。
 
-这些能力的安全边界完全不同。如果把“JSON 可以解析”写成“书源可以用”，读者会以为搜索、详情、目录、正文都已通过；如果把“某个网站在 Android App 能打开”写成“浏览器也兼容”，又会忽略 CORS、Cookie、WebView 和权限模型差异。
+如果只因为 JSON 能解析就宣称“兼容”，用户会自然理解成搜索、详情、目录、正文都可以用；如果只因为 Android App 能访问某站，就假设浏览器也可以，又会忽略 CORS、Cookie 和 WebView 的差异。
 
-所以 WebNR 现在把兼容拆成可以逐项验证的层级。第一层看起来朴素，却解决了几个基础问题：文件是否能导入？单对象和数组是否都能识别？未知字段会不会被悄悄丢掉？一条规则到底只需要声明式解析，还是已经出现脚本、登录或 WebView？这些问题没有稳定答案之前，后面的执行器很难安全迭代。
+所以 WebNR 把兼容拆成**可以回归测试的能力层**。这让失败更容易解释，也避免一个后续功能悄悄把今天的安全边界扩大。
 
-## L1 今天具体支持什么
+## L1 现在实际会做什么
 
-### 1. 本地文件读取，不上传到 WebNR 内容服务器
+### 本地读取，不把定义上传到内容服务器
 
-新的检查器位于阅读器“Import Novel”页面。用户选择 `.json` 或 `.txt` 后，浏览器通过本地 File API 读取文本，再调用 JSON parser。检查流程没有远程 fetch，也不会因为 `bookSourceUrl` 存在就访问那个域名。
+检查器位于 WebNR 的导入页。选择 `.json` 或 `.txt` 后，浏览器通过 File API 读取内容，再做 JSON 解析。`bookSourceUrl` 只是被检查的数据，不会因为它存在就触发 fetch。
 
-这条设计和 WebNR 的 local-first reader 一致：本地小说正文、书架和阅读进度已经主要留在浏览器侧；兼容检查也不需要把用户的书源文件变成服务端数据。
+### 支持单条定义和数组
 
-### 2. 单条定义和数组都能检查
+一份 Legado 文件可能是单对象，也可能是很多定义组成的数组。L1 都能检查。空数组、非对象条目和无效 JSON 会明确失败。
 
-Legado 社区文件既可能是一条对象，也可能是很多条对象组成的 JSON 数组。L1 会把单对象规范化为一条输入，把数组逐条生成报告。空数组会被拒绝；为了避免把浏览器变成一个没有边界的大文件分析器，本版本最多检查 500 条定义。
+资源边界固定为：
 
-### 3. 未知顶层字段不会因为 WebNR 不认识就消失
+- 最大输入：**2 MiB**；
+- 最多：**500 个 source definition**。
 
-兼容迁移最危险的一种失败不是报错，而是“看起来成功，但字段被静默删除”。L1 inspection 的结果会保留原始对象的顶层字段，并单独列出 unknown fields。未来某个字段如果进入 L2/L3/L4 分类，fixture 可以验证它从“unknown preserved”变成明确能力，而不是依靠人工记忆。
+超过边界时直接报错，不会裁掉后半部分再给出一个看似完整的报告。
 
-注意：这里说的“保留”是**检查器在本次解析结果中保持字段和值**，并不代表 WebNR 已经把整份 Legado JSON 存进书源数据库或会把它作为运行时 source 安装。
+### Unknown 字段保留，而不是静默丢弃
 
-### 4. 常见字段会被分到能力层
+迁移工具最危险的失败之一是“导入成功”，但不认识的字段被悄悄删除。L1 会把未知顶层字段列为 unknown，并在检查结果里保留原值。
 
-当前 L1 把 `bookSourceName`、`bookSourceUrl`、`bookSourceGroup`、`enabled` 等基础 metadata 归为 Phase 1；把 `searchUrl`、`exploreUrl`、`ruleSearch`、`ruleBookInfo`、`ruleToc`、`ruleContent`、`header` 等归为 Phase 2；Cookie、login 和 concurrency 类字段进入 Phase 3；脚本标记进入 Phase 4；WebView / Java bridge 迹象进入 Phase 5。
+这不代表 WebNR 已经把整份 Legado JSON 安装进自己的 source 数据库；只是保证**检查不会假装未知信息不存在**。
 
-这不是一份“Legado 全字段标准”。它是一个**保守分类器**：认识的字段给出最低已知需求，不认识的字段留下来并标 unknown，而不是猜测其语义。
+### 常见字段会进入最低能力分类
 
-### 5. 明确输入上限和失败方式
+当前分类器大致把字段分成：
 
-fixture `2026-08-30.1` 对输入设置了 2 MiB 和最多 500 条 source definition 的边界。不是因为 Legado 格式只能这么大，而是因为“本地检查器”需要一个明确的资源上限。超过边界会明确报错，不会自动裁掉后半部分后再生成看似完整的报告。
+- **L1 metadata**：`bookSourceName`、`bookSourceUrl`、`bookSourceGroup`、`enabled` 等；
+- **L2 declarative**：`searchUrl`、`exploreUrl`、`ruleSearch`、`ruleBookInfo`、`ruleToc`、`ruleContent`、`header` 等；
+- **L3 stateful**：Cookie、login、concurrency 一类字段；
+- **L4 script**：脚本 marker；
+- **L5 bridge**：WebView / Java bridge 迹象。
 
-无效 JSON、非对象条目、空数组同样会失败。这个原则以后也会延伸到 L2：请求大小、分页数量、redirect、timeout、编码和失败结果都必须有上限，不能只测试 happy path。
+这不是一份“Legado 全字段标准”。不认识的字段继续保持 unknown，而不是猜语义。
 
-## 三个版本化 fixture 测什么
+## 三个 clean-room fixture 分别验证什么
 
-本次仓库加入了一个完全由 WebNR 编写的 clean-room corpus。fixture 只使用 `example.invalid` 之类不会成为真实第三方小说站的保留域名，不包含任何小说正文、账号、Cookie、Token，也不复制社区书源里的实际抓取规则。
+fixture suite `2026-08-30.1` 使用 WebNR 自己编写的合成定义和保留域名，不包含真实小说正文、账号、Cookie、Token，也不复制社区书源的第三方抓取规则。
 
-### Fixture 01：Declarative
+### `01-declarative.json`
 
-`01-declarative.json` 包含书源 metadata、`searchUrl`、`exploreUrl`、header、search/book info/TOC/content 四类规则，以及一个 WebNR 故意不认识的 `fixtureExtension`。
+包含 metadata、`searchUrl`、`exploreUrl`、header、search/book info/TOC/content 规则和一个未知扩展字段。
 
-它验证两件事：第一，L1 能把常见声明式字段识别为“L2 required，但当前不执行”；第二，未知扩展会被报告并保留，不会因为 schema 不认识就消失。
+预期结果：WebNR 能判断它需要 L2，但**不执行**；未知字段仍保留。
 
-### Fixture 02：Stateful
+### `02-stateful.json`
 
-`02-stateful.json` 增加 `enabledCookieJar`、`concurrentRate`、`loginUrl` 和 `loginUi`。
+增加 Cookie、并发和登录相关字段。
 
-它不是一个可登录网站的测试账号。相反，它专门验证 WebNR 不会把“存在登录字段”当成普通声明式抓取。只要定义依赖目标站状态，就应该进入更高能力层，后续实现必须回答 Cookie 存储范围、站点权限、退出/删除、跨源隔离、并发限制和用户可见控制。
+预期结果：最高需求进入 L3。它不是测试账号，也不会真的登录；它只验证“依赖站点状态的定义不能被当成普通声明式规则”。
 
-### Fixture 03：Script & Bridge
+### `03-script-bridge.json`
 
-`03-script-bridge.json` 使用无害的脚本 marker 和 `webView` 字段。检查器只检测字符串中的 `<js>` / `@js:` 等标记，不 eval、不创建 Worker、不请求目标 URL。
+包含无害脚本 marker 和 WebView 字段。
 
-这条 fixture 的成功标准恰恰是“**不执行**”。如果以后 L4 引入受限脚本，它会使用新的 capability suite 和新的安全测试，而不是让今天的 L1 突然开始跑第三方代码。
+预期结果：报告 L4/L5 需求，**不 eval、不开 Worker、不访问 URL**。这个 fixture 的成功恰恰意味着脚本没有被执行。
 
-## 工作示例：一份 JSON 会得到什么结果
+## 一个最小例子
 
-例如把下面的合成定义保存为 `demo.json`：
+例如 `demo.json`：
 
 ```json
 {
@@ -120,172 +122,68 @@ fixture `2026-08-30.1` 对输入设置了 2 MiB 和最多 500 条 source definit
 }
 ```
 
-导入后，WebNR 会告诉你：基础 metadata 可在 L1 检查；`searchUrl` 和 `ruleSearch` 需要 L2 声明式运行时；`futureField` 是 unknown but preserved。它不会真的访问 `example.invalid`，也不会尝试搜索一本书。
+L1 会告诉你：
 
-如果同一份定义在 `ruleContent` 中出现 `<js>...</js>`，最高需求会升到 L4；如果出现 WebView/Java bridge marker，则会升到 L5。这个结果的用途是帮助用户和开发者回答“**为什么这份源目前不能在纯浏览器里直接运行**”，不是给第三方站点生成“已兼容”认证。
+- metadata 可以检查；
+- `searchUrl` / `ruleSearch` 需要 L2；
+- `futureField` 是 unknown but preserved；
+- 没有任何网络请求发生。
 
-## WebNR 原生 source 和 Legado JSON 现在仍是两条不同路径
+如果定义再加入脚本 marker，最高需求会升到 L4；出现 WebView / bridge 依赖，则升到 L5。
 
-WebNR 当前真正用于 reader discovery 的原生来源仍然是自己的 `search_index.yml` repository format。它包含经过审核的作品或官方发现入口，并由 `app/lib/discover.ts` 读取；索引有 5 MiB 上限，只接受 HTTP(S) 页面/下载 URL，并对标题、作者、标签、日期等 metadata 做保守规范化。[W1][W2]
+## WebNR Source 与 Legado JSON 是两条不同路径
 
-因此今天有两个容易混淆的动作：
+这个区别很重要：
 
-1. **Connect to Sources / 连接 WebNR source：** 把 WebNR 原生目录加入阅读器，可用于发现和后续合法导入流程；
-2. **Inspect a Legado JSON / 检查 Legado 定义：** 只在本地分析兼容能力，不把它安装成可执行 source。
+**Connect to Sources / 连接 WebNR source**：加入 WebNR 自己的 `search_index.yml` 目录，用来发现经过审计的作品或第一方入口。
 
-L2 真正上线之后，这两者才会开始出现受控的交集，例如把一条经过审核、只使用声明式规则的 Legado 定义转换成 WebNR 可运行 adapter。今天不能把这个未来状态提前写成已实现。
+**Inspect Legado JSON / 检查 Legado 定义**：分析一份定义需要哪些能力，但不把它安装成可执行 source。
 
-## 这次为什么审计五个社区集合，却不把它们“全量接入”
+所以今天你不能把任意 Legado JSON 丢进 WebNR，然后期待搜索、目录和正文马上工作。检查器的作用是告诉你**为什么不能**，以及它距离浏览器运行时还缺哪一层。
 
-今天的 source program 筛查了五个公开集合/项目，用来观察真实世界里字段和失败模式的分布。审计目标是 compatibility corpus，而不是替读者批量抓这些集合背后的第三方站点。
+## L2 以后真正需要解决什么
 
-### 1. XIU2/Yuedu：适合作为字段与失效模式参考，不适合直接变成 WebNR 推荐源包
+下一层不是“多认几个字段”而已。一个可信的 declarative runtime 至少需要明确：
 
-XIU2/Yuedu 当前仍公开维护书源集合，仓库采用 GPL-3.0；README 明确说明这些规则面向第三方小说网站，并提醒网站存在访问频率限制、IP 限制或验证，建议降低预下载和搜索线程数。[P3][P4]
+- 允许的 selector / JSONPath / regex 子集；
+- 每个请求的 timeout、响应体大小和 redirect 上限；
+- charset 和错误编码怎么处理；
+- pagination 最大页数；
+- stable identity 如何生成；
+- 上游更新/删除怎样反映；
+- 失败时是空结果、部分结果还是明确错误；
+- versioned fixtures 如何证明升级没有破坏已有定义。
 
-这给兼容测试两个很有价值的信号：真实规则确实会遇到限速和站点结构漂移；“规则文件有开源许可”也不能代替“目标站内容允许第三方自动抓取/再分发”。因此 WebNR 只把常见字段族和失败模式写进 clean-room fixture，不复制目标站规则进入推荐目录。
+直到这些边界能被测试，L2 都不会被写成“已支持”。
 
-### 2. tickmao/Novel：规模说明 parser 必须有边界
+## 哪些问题不会通过“兼容”来绕过
 
-该仓库在 2026 年 8 月仍维护约 1000 条 Legado source，并同时整理其他阅读器格式；README 还明确把它描述为聚合与分享，要求使用者支持正版并自行处理来源版权。[P5][P6]
+即使未来进入 L3–L5，下面这些也不是“想办法绕过去”的目标：
 
-对 WebNR 来说，最有价值的不是“1000 条一键装进去”，而是它提醒我们：一个真实集合可以很大。于是 L1 明确设置 2 MiB / 500 条的单次检查边界；以后如果需要大集合分析，应该做流式/分页或专门工具，而不是让 UI 在没有限制的情况下吞任意文件。
+- 登录和账号权限；
+- CAPTCHA / anti-bot challenge；
+- 付费内容；
+- DRM；
+- robots / 服务条款 / 访问控制；
+- 需要第三方凭据但 WebNR 没有正式授权的 API。
 
-### 3. ZWolken/Light-Novel-Yuedu-Source：登录、半维护和反爬会把“格式兼容”与“来源健康”分开
+WebNR 可以把“这份定义需要这些能力”报告清楚，但不会把突破这些边界当成兼容成功。
 
-该项目当前 README 明确写着半维护状态，一些来源需要登录，部分搜索有问题；维护说明还记录过目标站的反爬、字体混淆等导致长期稳定性差的情况。[P7]
+## 如果你是 Legado 用户，应该怎么用这个报告
 
-这正好证明为什么兼容报告不能只给绿色/红色：“JSON 能 parse”与“来源今天可用”至少是两张不同的表。登录依赖进入 L3，复杂脚本和浏览器行为进入 L4/L5；目标站是否授权、是否健康则属于 source-specific audit，不能由 parser 自动推断。
+**只想读自己的 TXT：** 直接使用 [TXT 导入指南](2026-09-01-raw-txt-collection-import-guide.md)，不需要 Legado inspector。
 
-### 4. aoaostar/legado：聚合规模和同步状态不能替代安全审计
+**想知道一份 JSON 为什么不能跑：** 本地导入 inspection，看它最高需要 L2、L3、L4 还是 L5。
 
-该项目公开页面在 2026 年 8 月显示数千条聚合 source，并对不同集合给出同步成功/失败状态。[P8] 它的 issue 里还能看到“空规则”或疑似恶意脚本 source 的过滤讨论。[P9]
+**想找当前可以直接使用的 WebNR 来源：** 看 [来源目录与健康说明](2026-09-03-first-month-source-directory-health-report.md)。
 
-对于 WebNR，最直接的设计结论是：以后即使做到 L2，也不能把“上游同步成功”当成安全许可。定义需要大小限制、域名边界、script detection、权限分类和 fixture；L4 更不应该默认继承 L2 的权限。
+**想理解 WebNR 为什么可以作为 Legado 用户的网页端替代之一：** 看 [WebNR：给 Legado 用户的一个独立网页端替代选择](2026-08-09-webnr-legado-web-alternative.md)。
 
-### 5. Orokapei/BookSource：真实定义会混合 CSS、POST/charset、分页和登录字段
+## 版本说明
 
-这个公开 JSON 集合可以观察到 CSS selector、下一页、POST body、charset、login 字段等组合。[P10] 这些形态对分类器有价值，但规则文件公开并没有自动建立每个目标站的访问和再分发授权，因此本轮只作为结构参考，不复制成 WebNR content source。
+- 报告日期：**2026-08-30**
+- Fixture suite：**`2026-08-30.1`**
+- 正式能力：**L1 / Import & Inspect**
+- L2–L5：**识别需求，但未执行**
 
-**本轮最终通过的“integration”是 compatibility-corpus integration，而不是第三方小说站 ingestion。** 三个 synthetic fixture 把上述审计里反复出现的 declarative、stateful、script/bridge 能力隔离出来，并进入版本化 browser E2E。这样每天的 source program 仍然产生可测试进展，同时不会为了满足“新增一个源”的数字去扩大不清楚的抓取范围。
-
-## 为什么不会执行你导入文件里的 JavaScript
-
-浏览器里执行第三方 source script 的风险和解析 JSON 完全不是一个等级。书源脚本可能接触 URL、headers、Cookie、正文页面、局部变量，传统 Android 环境还可能暴露 Java 对象或 WebView 行为。如果 WebNR 直接在主页面 `eval`，一条来源定义就可能获得与阅读器页面同级的 JavaScript 权限。
-
-因此 L1 的安全要求是零执行。未来 L4 如果实现，至少需要：
-
-- 独立 Worker 或更强隔离边界；
-- 明确允许的 capability，而不是“可以访问所有浏览器 API”；
-- CPU/墙钟超时；
-- 内存和输出大小限制；
-- 网络域名 allowlist 与请求预算；
-- 禁止访问书架正文、IndexedDB 中无关书籍、analytics 状态和其他 source 的 Cookie；
-- 可取消、可回滚；
-- 每一种开放能力都有 versioned fixture 和负向测试。
-
-所以“脚本暂不支持”不是 parser 偷懒，而是在没有沙箱合同之前避免把任意代码执行包装成兼容功能。
-
-## 浏览器 CORS 为什么也不能靠“加个代理”草率解决
-
-Android 原生网络栈和浏览器不是同一个安全环境。一个第三方 URL 在 Android App 能请求，并不意味着站点允许 `app.webnovel.win` 的 JavaScript 跨域读取响应。WebNR 现有的 URL TXT 导入只在目标服务器允许 CORS 时工作；这也是前一版 Legado 替代说明已经公开的边界。[W3]
-
-建设一个公共服务器代理固然可以技术上绕过一部分浏览器 CORS，但它会把来源访问、用户请求、站点限速、版权和安全责任集中到 WebNR 服务端，还可能变成规避目标站访问策略的工具。因此当前路线优先是：官方 Feed/API、明确开放的机器接口、同源或用户拥有的内容、以及未来可选的本地 Bridge；不是“所有失败都丢给公共代理”。
-
-## 兼容报告不等于版权或站点授权报告
-
-一个 source definition 可能采用 GPL/MIT 等开源许可，这通常说明规则文件本身如何复制和修改；它不自动给 WebNR 第三方小说正文、封面、评论或付费章节的再分发权。同样，网页公开可访问也不等于允许持续 crawler、缓存或镜像。
-
-所以 WebNR 继续把两套判断分开：
-
-- **compatibility audit：** 这个 JSON 用了哪些字段、规则和运行时能力？
-- **source admission audit：** 目标站是谁维护、条款/robots/机器接口是什么、允许什么请求频率、内容的授权或公共领域依据是什么、是否需要登录/验证码/付费、健康与删除语义怎样？
-
-只有第二套审计通过，某个真实来源才可能从 isolated corpus 进入 reader-facing source catalog。
-
-## 用户今天应该怎样使用这份报告
-
-如果你手里有一份 Legado JSON，最有效的流程是：
-
-1. 打开 WebNR，进入 **Import Novel**；
-2. 在 **Legado compatibility inspector / 书源兼容检查** 中选择本地 JSON/TXT；
-3. 查看每条 source 的 `Highest required capability`；
-4. L1 只说明“文件结构可检查”，不要期待它自动搜书；
-5. 如果是 L2，记录具体需要的 `searchUrl` / rule family，作为后续 declarative fixture；
-6. 如果是 L3，先确定是否真的需要 Cookie/登录，以及目标站是否允许该访问方式；
-7. 如果是 L4/L5，不要把脚本或 WebView 需求伪装成普通 CSS selector 问题；
-8. 遇到 unknown field，提交一个**脱敏、最小化** fixture 或字段说明，不要附 Cookie、Token、账号或小说正文。
-
-这种反馈比“这个源不能用”更容易转成可重复测试。
-
-## 下一版最应该实现什么
-
-L1 已经把“输入到底长什么样”变成机器可检查问题。下一步优先级仍是 **L2 declarative runtime**，但应从最小的 clean-room fixture 开始：
-
-1. 基础 GET search；
-2. CSS selector；
-3. JSONPath；
-4. XPath；
-5. book info；
-6. TOC；
-7. content；
-8. pagination；
-9. headers、charset 与 replacement；
-10. 每一步都有 request timeout、response-size、redirect 和域名边界。
-
-当这一条链在自建 fixture server 上稳定，再拿经过 source-specific rights/access 审计的真实候选做 bounded integration。Cookie/login 留给 L3；JS 留给 L4；必须依赖 Android WebView 的定义留给 L5/Bridge。
-
-这条顺序可能比“一次导入一千条书源”慢，但它会让“兼容”成为可以复跑、可以回归、可以精确解释失败原因的工程指标。
-
-## 本版本的验收标准
-
-`2026-08-30.1` 只有在下面这些事实同时成立时才能叫 L1 supported：
-
-- Chromium 中可以从导入页选择一份本地 JSON；
-- source name / URL 能显示；
-- common metadata 被识别为 L1；
-- declarative fields 被识别为 L2 requirement；
-- Cookie/login/concurrency 被识别为 L3 requirement；
-- script marker 被识别为 L4 restricted；
-- WebView/Java marker 被识别为 L5 restricted；
-- unknown top-level field 被报告而不是静默删除；
-- 检查过程不请求 `bookSourceUrl`；
-- 超过 2 MiB、超过 500 条、非法 JSON 或非对象条目会明确失败；
-- 原有 TXT 导入、URL 导入、IndexedDB 书架、PWA、WebNR source discovery 和 GA4 full-URL reporting 不因这个功能回归。
-
-任何一项失败，都应降低或撤回对应兼容声明，而不是修改文案掩盖测试结果。
-
-## 结论
-
-WebNR 今天终于可以对“你们支持 Legado 吗？”给出一个不模糊的版本答案：
-
-> **支持 L1 / fixture suite `2026-08-30.1`：本地导入、结构保真、字段分类和兼容报告。尚不支持把任意 Legado JSON 当作可执行书源运行。**
-
-这比“完全不支持”前进了一步，也比“已经兼容”诚实得多。接下来每增加一层，都必须同时增加执行能力、安全边界、fixtures、负向测试和真实来源的独立权限/健康审计。
-
-如果你只是读本地 TXT，WebNR 现有路径已经成熟；如果你依赖复杂 Legado source，现在可以先用 L1 把依赖拆出来。等 L2–L5 逐步落地时，迁移将不再靠猜，而会由明确的 capability report 告诉你差在哪里。
-
-## 参考资料
-
-### Legado 与社区来源（核验于 2026-08-30）
-
-- **[P1]** Legado 旧版公开文档，《导入书源》：<https://gedoor.github.io/docs/get-started-quickly/add-sources>
-- **[P2]** Legado 旧版公开文档，《入门》：<https://gedoor.github.io/docs/GettingStarted>
-- **[P3]** XIU2/Yuedu：<https://github.com/XIU2/Yuedu>
-- **[P4]** XIU2/Yuedu GPL-3.0 LICENSE：<https://github.com/XIU2/Yuedu/blob/master/LICENSE>
-- **[P5]** tickmao/Novel：<https://github.com/tickmao/Novel>
-- **[P6]** tickmao/Novel 2026-08 source statistics：<https://github.com/tickmao/Novel/blob/master/STATS.md>
-- **[P7]** ZWolken/Light-Novel-Yuedu-Source：<https://github.com/ZWolken/Light-Novel-Yuedu-Source>
-- **[P8]** aoaostar/legado：<https://github.com/aoaostar/legado>
-- **[P9]** aoaostar/legado issue #8，异常/脚本 source 过滤讨论：<https://github.com/aoaostar/legado/issues/8>
-- **[P10]** Orokapei/BookSource：<https://github.com/Orokapei/BookSource>
-- **[P11]** 当前 gedoor/legado 仓库：<https://github.com/gedoor/legado>
-- **[P12]** Legado 旧版公开说明，《开源阅读到底是什么》：<https://gedoor.github.io/intro>
-
-### WebNR 当前实现与前序说明
-
-- **[W1]** WebNR `app/lib/discover.ts`：<https://github.com/AutoArchive/webNR/blob/main/app/lib/discover.ts>
-- **[W2]** WebNR `app/types/repo.ts`：<https://github.com/AutoArchive/webNR/blob/main/app/types/repo.ts>
-- **[W3]** 《WebNR：给 Legado 用户的一个独立网页端替代选择》：<https://www.webnovel.win/blog/2026/08/09/webnr-legado-web-alternative/>
-- **[W4]** 《2026 年 Legado 书源在哪里找？》：<https://www.webnovel.win/blog/2026/08/06/legado-source-guide/>
-- **[W5]** WebNR repository：<https://github.com/AutoArchive/webNR>
+以后能力提升时应新增 fixture 版本和明确行为，而不是回头把本报告里的“未执行”改成模糊的“兼容”。

--- a/docs/blog/posts/2026-09-01-raw-txt-collection-import-guide.md
+++ b/docs/blog/posts/2026-09-01-raw-txt-collection-import-guide.md
@@ -2,8 +2,7 @@
 title: 没有目录的 TXT 小说合集怎么导入 WebNR？文件夹、编码、来源与自建 Source 实战
 date: 2026-09-01
 slug: raw-txt-collection-import-guide
-_description: 从单个 TXT、本地文件夹到可重复的 WebNR source，解释文件名、编码、CORS、来源证明、固定版本和失败边界，并给出 Project Ben-Yehuda 与 GITenberg 的真实直接导入案例。
-description: 从单个 TXT、本地文件夹到可重复的 WebNR source，解释文件名、编码、CORS、来源证明、固定版本和失败边界，并给出 Project Ben-Yehuda 与 GITenberg 的真实直接导入案例。
+description: 从单个 TXT、本地文件夹到可重复的 WebNR source，解释文件名、编码、CORS、来源证明、固定版本和失败边界，并用 Project Ben-Yehuda 与 GITenberg 展示 direct-TXT 做法。
 categories:
   - Reader guides
   - TXT
@@ -12,94 +11,79 @@ categories:
 
 # 没有目录的 TXT 小说合集怎么导入 WebNR？文件夹、编码、来源与自建 Source 实战
 
-很多免费小说、历史文本和个人整理档案最后都长成同一种样子：一个文件夹里放着几十、几百个 `.txt`，有时只有文件名，没有 OPDS、RSS、API、书目页，甚至没有一份像样的目录。对阅读器来说，真正困难的部分通常也不是“能不能把字显示出来”，而是怎样把一堆文件变成**可以重复导入、可以知道来源、可以在上游变化后仍然复现**的阅读集合。
+**先给结论：** 少量自己的 TXT，直接逐个本地导入；一整个长期收藏，先整理文件名和编码；如果这批文本要长期分享、重复导入或跟踪版本，再把它整理成一个小型 WebNR source。不要一开始就为了“批量”写复杂抓取器。
 
-WebNR 目前有两条成熟路径。第一条是**本地单文件导入**：把 `.txt` 交给浏览器，正文保存在本地 IndexedDB。第二条是**URL / WebNR source 导入**：source 保存书目与上游地址，读者选择一本书时浏览器直接请求该地址。对“只有一个文件夹，没有目录”的收藏，今天最稳的做法是先决定它属于一次性的私人阅读，还是值得长期维护的公开集合；前者逐个本地导入，后者生成一个小型 `search_index.yml`，把文件名、标题、来源页、固定版本和下载地址显式写出来。
+WebNR 当前有两条成熟路径：
 
-本文对应 WebNR 在 **2026-09-01** 的实际实现。今天同时上线了第二个真实 direct-TXT 示例：**GITenberg Direct TXT Starter**，用三本公共领域英文作品演示“Git 仓库里的 TXT 文件怎样变成可重复的一键导入 source”。它与此前的 **Project Ben-Yehuda Public Domain TXT Starter** 一起，形成两个不同语言、不同上游结构、但同样可复核的直接 TXT 路径。
+1. **本地 TXT 导入**：文件只在浏览器里读取，正文和阅读进度保存在本地；
+2. **URL / WebNR source**：目录保存书目与上游地址，读者选择一本书时浏览器再读取对应文本。
 
 [打开 WebNR 导入页](https://app.webnovel.win/){ .md-button .md-button--primary }
 
-## 先看结论：四种 TXT 情况分别怎么处理
+## 四种常见情况，分别怎么处理
 
-| 你的 TXT 在哪里 | 推荐路径 | 标题从哪里来 | 编码重点 | 来源重点 |
-| --- | --- | --- | --- | --- |
-| 自己电脑上的一个 `.txt` | 本地导入 | 文件名去掉扩展名 | WebNR 本地路径会先尝试 UTF-8，再做编码检测 | 文件属于你自己的本地资料即可 |
-| 自己电脑上的一个文件夹 | 目前逐个导入；长期收藏可先生成 WebNR source | 先整理文件名，或在 source 里写正式标题 | 文件之间可能混用编码，需要抽样检查 | 给整个文件夹保存一份 provenance 说明 |
-| 公网上一个稳定的 UTF-8/ASCII TXT | URL 导入或 WebNR source | URL 文件名，source 可提供更好的书目事实 | 优先选择 UTF-8 或正确声明 charset 的来源 | 保存人类可读来源页与精确下载 URL |
-| 公网上一批长期维护的 TXT | 建立版本化 WebNR source | `search_index.yml` 中明确写 title/author | 把编码当作 source contract 的一部分 | 固定 release/commit/hash；记录权利、更新和删除规则 |
+| 你的 TXT 在哪里 | 最省事的路径 | 需要特别注意什么 |
+| --- | --- | --- |
+| 自己电脑上的一个 `.txt` | 本地导入 | 文件名、编码 |
+| 自己电脑上的一个文件夹 | 少量逐个导入；长期收藏先整理目录 | 不要假设所有文件编码相同 |
+| 公网上一个稳定 TXT | URL 导入 | CORS、charset、来源页、文件是否会变 |
+| 公网上一批长期维护的 TXT | 建一个版本化 source | stable ID、许可、commit/release、更新/删除语义 |
 
-这里有一个很重要的现实边界：**WebNR 现在还没有“选择一个文件夹后一次导入全部 TXT”的浏览器 UI。** 当前文件选择器读取的是单个 `File`。因此“导入文件夹”在今天更适合被理解为一个整理工作流：少量文件逐个导入；数量变大、希望重复使用或分享时，就把文件夹变成一个有目录的 WebNR source。这样做比在浏览器里盲目批量吞掉几百个文件更容易检查标题、编码、权利和重复项。
+当前 WebNR **还没有“选择一个文件夹后一次吞掉所有 TXT”的 UI**。这不是缺一个按钮那么简单：批量导入还需要解决重复项、标题、编码混用、错误隔离和用户确认。对几十本以内的私人收藏，逐个导入往往更可靠。
 
-## 1. 单个本地 TXT：最省事，也拥有最好的编码兜底
+## 1. 单个本地 TXT：最稳的起点
 
-WebNR 的本地导入代码位于 [`app/lib/storage.ts`](https://github.com/AutoArchive/webNR/blob/main/app/lib/storage.ts)。当前 `importFromFile()` 只接受 `.txt`。浏览器先以 `ArrayBuffer` 读取文件，WebNR 再调用自己的 `detectAndDecodeText()`。
+WebNR 本地导入会先读取原始字节，再尝试解码。当前逻辑大致是：
 
-解码顺序很具体：
+1. 先严格尝试 UTF-8；
+2. UTF-8 失败后做字符集检测；
+3. 对常见结果映射到浏览器支持的编码，例如 GBK/GB2312 → GB18030、Big5、Shift_JIS、EUC-JP、EUC-KR；
+4. 无法确认时明确暴露失败，而不是悄悄把乱码当成功。
 
-1. 先用 `TextDecoder('utf-8', { fatal: true })` 尝试严格 UTF-8；
-2. UTF-8 失败后，让 `jschardet` 根据字节判断编码；
-3. 对常见结果做浏览器可执行的映射，例如 GB2312 / GBK → `gb18030`，以及 Big5、EUC-JP、Shift_JIS、EUC-KR；
-4. 如果检测出的编码无法被浏览器 `TextDecoder` 使用，最后回到 UTF-8 解码并把失败暴露在控制台。
+这也是为什么一份年代较久的中文/日文/韩文 TXT，**先下载到本地再导入**常常比直接贴远程 URL 更稳：你能拿到完整字节，且不受服务器错误 charset 声明影响。
 
-这意味着一份年代较久的中文、日文或韩文 TXT，**下载到本地再导入**往往比直接贴远程 URL 更稳。尤其是你不知道服务器有没有正确发送 `Content-Type` / `charset` 时，本地路径拥有更多字节级信息和 WebNR 自己的编码检测。
+### 文件名会直接影响书架体验
 
-本地导入之后，WebNR 默认把文件名去掉最后一个扩展名作为书名。例如：
-
-```text
-三体.txt            → 三体
-01_吾輩は猫である.txt → 01_吾輩は猫である
-Pride-and-Prejudice.txt → Pride-and-Prejudice
-```
-
-所以一个没有目录的私人 TXT 文件夹，最划算的第一步常常不是写脚本，而是把文件名整理好。推荐至少做到：
+本地导入时，WebNR 会把文件名去掉扩展名作为默认标题：
 
 ```text
-作者 - 书名.txt
+三体.txt                     → 三体
+01_吾輩は猫である.txt        → 01_吾輩は猫である
+Austen - Pride and Prejudice.txt → Austen - Pride and Prejudice
 ```
 
-或者在同一作者很多作品时：
+所以一个没有目录的私人收藏，最划算的第一步通常是**把文件名整理好**，而不是先写代码。
 
-```text
-作者/
-  书名一.txt
-  书名二.txt
-```
+## 2. 文件夹：把“批量读”拆成整理和导入
 
-WebNR 今天不会读取父目录名来补作者，因此真正进入书架的标题仍以文件名为主。目录结构主要帮助你自己管理原始收藏。
+### 十几本：保持简单
 
-## 2. 本地文件夹：先决定“私人批量阅读”还是“可维护集合”
+如果只是少量自己已经拥有的 TXT：
 
-文件夹里有 5 本书和有 5,000 本书，是两个完全不同的问题。
-
-### 少量私人文件：保持简单
-
-如果只是十几份自己已经拥有的 TXT，逐个导入的优点很明显：
-
-- 不需要上传；
+- 逐个导入；
+- 不上传；
 - 不需要 CORS；
-- 不需要把私人文件放进任何公开 source；
-- 每本书都走相同的本地编码检测；
-- 删除、改名和重新导入都由你控制。
+- 每本都能独立判断编码；
+- 出错时容易知道是哪一个文件。
 
-这条路径最符合 WebNR 的 local-first 设计。阅读正文、书签和进度主要保存在浏览器本地，WebNR 不需要知道你的文件夹来自哪里。
+这最符合 WebNR 的 local-first 设计。
 
-### 大型或长期收藏：先生成目录
+### 几百或几千本：先做目录
 
-当文件数量变大，真正需要自动化的是**目录生成**，而不是“让浏览器一次点开 500 个文件”。一个可维护目录至少要回答六个问题：
+大收藏真正需要自动化的，首先是**目录生成**。至少回答：
 
-1. **稳定 ID 是什么？** 文件名、上游作品 ID，还是内容 hash？
-2. **标题和作者从哪里来？** 只靠文件名，还是有 CSV/YAML 元数据？
-3. **正文地址会不会变？** 是本地路径、release URL、固定 commit，还是会漂移的 `main`？
-4. **编码是什么？** 全部 UTF-8，还是混合 GBK / Big5 / Shift_JIS？
-5. **这些文本能不能被公开列入 source？** “网上能下载”本身不提供再分发许可。
-6. **上游删除或改版时怎么办？** 目录更新不能静默把旧书删掉，也不能用同一个 URL 悄悄换成另一版。
+1. 稳定 ID 是文件名、上游作品 ID 还是内容 hash？
+2. 标题和作者从哪里来？
+3. 文件地址会不会变？
+4. 编码是统一 UTF-8，还是混合 GBK/Big5/Shift_JIS？
+5. 这批文本能不能公开分享，还是只适合私人使用？
+6. 上游删除/改版时，旧条目怎么处理？
 
-因此 WebNR source 的价值不是多一个 YAML 格式，而是把这些隐含信息变成可 review 的 contract。
+把这些问题写清楚，才值得做成可重复 source。
 
-## 3. 最小 WebNR source 长什么样
+## 3. 一个最小 WebNR TXT source 长什么样
 
-WebNR 原生目录使用 `search_index.yml`。对 raw TXT，最有用的字段通常是：
+WebNR 原生目录使用 `search_index.yml`。一个简化条目可以是：
 
 ```yaml
 my-collection/book-001.md:
@@ -113,313 +97,126 @@ my-collection/book-001.md:
   license: Public-Domain-or-Exact-License-Identifier
   tags:
     - Raw TXT
-    - Public domain
-  categories:
-    - Free TXT reading
-  region: en-US
-  chapters: 1
 ```
 
-其中 `page_url` 和 `download_url` 最好承担不同职责：
+`page_url` 和 `download_url` 最好分开：
 
-- `page_url` 给人看，应该能解释作品、作者、版本和来源；
-- `download_url` 给浏览器取正文，应该直接、稳定、尺寸可控。
+- **page_url**：给人看，解释作品、作者、版本与来源；
+- **download_url**：给浏览器读正文，应该稳定、直接、大小可控。
 
-如果上游是 Git 仓库，推荐把下载 URL 固定到 commit：
+如果上游使用 Git，优先固定到 commit：
 
 ```text
 https://raw.githubusercontent.com/ORG/REPO/<commit>/book.txt
 ```
 
-而不是：
+不要把已经审计过的条目指向会持续变化的 `main` / `master`。固定 commit 后，今天确认过的字节明天仍然是同一份，出了问题也有明确回滚点。
 
-```text
-https://raw.githubusercontent.com/ORG/REPO/main/book.txt
-```
+## 4. 为什么纯文本也要保存 provenance
 
-固定 commit 带来的收益非常实际：今天 review 的字节明天仍然是同一份；上游更新不会让 WebNR 的已发布条目在没有 PR 的情况下改变；出现问题时也有明确 rollback point。
+“只是 TXT”不代表版本无关紧要。经典作品可能同时存在：
 
-## 4. 为什么“可直接下载”仍然要保留 provenance
+- 原文与现代译文；
+- OCR 与人工校订；
+- 有注释版与去注释版；
+- 公版原作与仍受保护的现代编辑/翻译；
+- UTF-8 与旧字符集版本。
 
-纯文本看起来太简单，很容易让人忘记版本信息。一本经典作品可能同时存在：
+所以长期 source 最好保存三层身份：
 
-- 原文和译文；
-- 现代校订版和旧版；
-- 有注释版和去注释版；
-- OCR 版和人工校对版；
-- UTF-8 和旧字符集版；
-- 公共领域原作与仍受保护的现代翻译。
+**作品 → 数字版本/整理版本 → 当前文件快照。**
 
-所以 source 至少应保存三层身份：
+这能避免“URL 还是那个 URL，但里面已经换了一版”的静默漂移。
 
-**作品身份 → 版本/数字化身份 → 当前文件快照。**
+## 5. 两个真实 direct-TXT 例子
 
-Project Ben-Yehuda 的做法很适合展示这三层关系：WebNR 保存作品 ID 与官方阅读页；正文来自官方 `public_domain_dump`；`download_url` 再固定到经过审核的 dump commit。上游明确声明该 dump 的数据文件属于公共领域，TXT 为 UTF-8，因此 WebNR 可以把它做成真正 direct-TXT，而无需推断“免费访问”等同于授权。
+### Project Ben-Yehuda：官方作品身份 + public-domain dump
+
+Project Ben-Yehuda 同时提供人类可读作品页和明确 public-domain dump。WebNR 的小型 starter 保留官方作品 ID/页面，并把实际 TXT 固定到经过审核的 dump commit。
+
+这适合演示：**公版依据、来源页、UTF-8 文件和固定快照可以同时存在**。
 
 [打开 Project Ben-Yehuda TXT Starter](https://app.webnovel.win/sources/project-ben-yehuda-txt-starter)
 
-## 5. 今天新增的 GITenberg Direct TXT Starter：为什么这次值得从 defer 升级
+### GITenberg：每本书是 Git 仓库，适合可复现 TXT
 
-GITenberg 在 2026-08-31 的审计里曾经被暂缓。原因不是技术不可用，而是它和 WebNR 已有的 Project Gutenberg **发现入口**重叠很大：再加一个“点进去看 Gutenberg”的目录，对读者价值有限。
+GITenberg 把许多 Project Gutenberg 公版书放进独立 Git 仓库。WebNR 的 `GITenberg Direct TXT Starter` 只选三个小型样本：
 
-今天的问题换成了“没有目录的 raw TXT 如何形成可重复导入”。在这个问题下，GITenberg 提供了新的价值：**每本书是独立 Git 仓库，纯文本文件、README、LICENSE 和 metadata 可以一起固定到 commit。** 这让它成为 direct-TXT transport 的好样本，而不仅仅是第二个 Gutenberg 链接目录。
+| 作品 | 固定文件 |
+| --- | --- |
+| *Pride and Prejudice* | `1342-0.txt` |
+| *Frankenstein* | `84-0.txt` |
+| *The Adventures of Sherlock Holmes* | `1661.txt` |
 
-本轮加入三本书：
-
-| 作品 | 上游 | 固定 TXT | 审计快照 |
-| --- | --- | --- | --- |
-| *Pride and Prejudice* | GITenberg / PG #1342 | `1342-0.txt` | `81db45c9c48c592f0b77f01fc59e677ad0a5634e` |
-| *Frankenstein* | GITenberg / PG #84 | `84-0.txt` | `c98a483bd1f34e7366126b81bcedd1a6faee636e` |
-| *The Adventures of Sherlock Holmes* | GITenberg / PG #1661 | `1661.txt` | `7e5dd2703fbf503c004063e96ab7c61262375e5f` |
-
-三个仓库的 README 都把对应作品标为 Public Domain，并说明 GITenberg 保存的是 Project Gutenberg 图书的源文件。WebNR 只提交书目、provenance 和固定 raw URL；正文继续留在 GITenberg 上游。三个被选文件都小于 1 MiB，也没有 ZIP、登录、Cookie、JavaScript 或 source-specific parser 的依赖。
+这些条目固定到经过审核的 commit，而不是跟随 mutable branch。用户选中一本后，浏览器只请求那一个 TXT；没有 bulk clone、后台轮询、Cookie、账号或第三方脚本。
 
 [打开 GITenberg Direct TXT Starter](https://app.webnovel.win/sources/gitenberg-direct-txt-starter)
 
-这也是一个很有用的运营原则：**defer 是“当前能力/价值证据还不足”，不是永久判决。** 当读者问题、runtime capability 或上游证据变化后，同一个候选可以在新的、边界更窄的能力上重新审计。
+这个例子说明了一点：一个来源是否值得 direct-TXT，不取决于“我们以前是不是已经有它的 discovery link”，而取决于**当前这个文件能否提供新的、稳定、可解释的阅读能力**。
 
-## 6. URL 导入和本地导入的编码行为并不相同
+## 6. 远程 TXT 为什么经常比本地 TXT 更容易失败
 
-这点对 raw TXT 特别重要。
+远程 URL 导入多了浏览器网络边界：
 
-当前本地导入会读取原始字节并执行 WebNR 的编码检测；远程 `importFromUrl()` 则调用浏览器 `fetch()` 后使用 `response.text()`。WebNR 当前没有在 URL 路径上再跑一次与本地文件相同的 `jschardet` fallback。
+- 目标站必须允许 CORS；
+- redirect 必须最终仍是浏览器可访问文本；
+- `Content-Type` / charset 不能把文本误导成别的东西；
+- 文件不能无限大；
+- URL 不能悄悄指向登录页、HTML 错误页或 anti-bot challenge。
 
-因此远程 direct-TXT source 的优先级应该是：
+所以“服务器能 curl 到”并不等于“WebNR 浏览器可以读”。遇到远程 URL 失败时，先打开浏览器开发者工具看 CORS/status/content-type，再判断是不是编码问题。
 
-1. UTF-8；
-2. ASCII（天然也是有效 UTF-8）；
-3. 来源服务器明确且正确声明字符集；
-4. 其他旧编码先下载为本地文件，再使用本地导入路径。
+## 7. 哪些集合不应该直接批量塞进 WebNR
 
-青空文库就是很典型的反例：许多作品的经典下载形态涉及 ZIP、Shift_JIS 和青空文库注记。WebNR 目前的 Aozora Bunko Starter 因此仍保持作品发现链接，而没有把“有 TXT 下载”直接升级为 direct import。真正升级时至少要同时解决 ZIP 解包、编码、注记处理、单作品权利状态和 fixture，而不是只找到一个 `.zip` URL。
+即使文件格式是 TXT，也可能不适合做公共 source：
 
-这也解释了为什么一个 source 的“格式”不能只写 `TXT`。更准确的 contract 应写成：
+- 权利状态无法解释；
+- modern translation / edition 仍受保护；
+- collection 许可要求署名、非商业或 ShareAlike，但 source 没有办法保留这些信息；
+- 文本依赖特殊 markup，直接显示会严重破坏内容；
+- 上游只有 mutable dump，没有 release/commit/hash；
+- 需要登录、Cookie 或绕过访问控制。
 
-```text
-transport = HTTPS direct file
-container = none
-encoding = UTF-8
-max observed size = < 1 MiB
-identity = immutable commit URL
-auth = none
-cookies = none
-pagination = none
-update = reviewed PR only
-```
+这时最好的状态是“私人本地使用”或“等待更明确 adapter”，而不是为了目录数量硬接。
 
-这样的描述才足够让未来的测试知道要验证什么。
+## 8. 如果你要把自己的 TXT 文件夹做成 source
 
-## 7. CORS：远程 TXT 能在浏览器打开，不代表能被 WebNR fetch
+建议按这个顺序：
 
-WebNR 是浏览器应用。URL import 使用浏览器 `fetch()`，因此跨域请求要遵守 CORS。一个链接在新标签页里能打开，只说明浏览器能导航到它；这不自动证明 JavaScript 能从 `app.webnovel.win` 读取响应正文。
+1. **先统一文件名**；
+2. **抽样检测编码**，能转 UTF-8 就先规范化；
+3. **给每本书稳定 ID**；
+4. **保存来源页/作品页**；
+5. **记录确切许可或公版依据**；
+6. **固定 release/commit/hash**；
+7. **先选 3–10 本做 pilot**，不要一开始放 5000 本；
+8. **测试每一本的失败方式**；
+9. pilot 稳定后再扩大。
 
-遇到远程 TXT 导入失败，可以按这个顺序排查：
+这个流程的目标不是把 YAML 写得漂亮，而是让半年以后你仍然知道：这本书是谁、从哪里来、为什么能用、是不是同一份文件。
 
-1. URL 本身是否返回成功状态；
-2. 是否发生登录、验证码或 anti-bot challenge；
-3. 响应是否允许跨域读取；
-4. 是否发生重定向到 HTML 页面；
-5. 文件尺寸是否异常；
-6. 字符集是否正确；
-7. URL 是否是可变的“latest”地址。
+## 常见问题
 
-WebNR 不应该通过代理、模拟登录、绕 CAPTCHA 或偷带 Cookie 来“修复”一个没有 CORS 的来源。更合适的做法是寻找上游官方 API/feed/download endpoint、固定 release，或者保留 discovery link，让用户从来源站自己下载后进行本地导入。
+### EPUB 能不能直接改后缀成 `.txt`？
 
-## 8. 五个新的开放文本候选告诉我们：格式开放、许可开放、浏览器可运行是三件事
+不能。EPUB 是容器格式，需要真正 parser。改扩展名不会把它变成纯文本。
 
-今天的 source patrol 额外筛查了五个此前未进入 WebNR 维护集合的开放文本 family。它们非常适合解释为什么 raw text admission 必须逐源判断。
+### 远程 TXT 乱码怎么办？
 
-### OpenITI：机器可读的伊斯兰文化文本，但许可与格式都需要显式继承
+如果可以合法下载，先保存到本地，再用 WebNR 的本地字节级解码路径导入；同时检查上游是否有 UTF-8 版本。
 
-[OpenITI](https://openiti.org/documentation/) 提供上万份机器可读文本，主体使用 plain text + OpenITI mARkdown；版本 release 可通过 GitHub/Zenodo 固定。项目文档说明 release 采用 **CC BY-NC-SA 4.0**。它很适合作为研究与本地阅读候选，但一个公共 WebNR source 若要长期维护，就需要把署名、NonCommercial、ShareAlike、mARkdown 显示/清理方式和 release identity 一起设计进去。今天不把它降格成“看起来是 `.txt`，所以直接接”。
+### 文件夹能不能一次导入？
 
-### Folger Shakespeare：官方就有 TXT 下载，但正文采用 CC BY-NC 3.0
+当前没有正式的批量文件夹 UI。少量文件逐个导入；长期收藏先生成 source，会更可控。
 
-Folger 官方提供 Shakespeare 的 PDF、DOC、HTML、TXT、XML、TEI Simple 下载，同时明确数字文本使用 **CC BY-NC 3.0**，要求署名并限制商业用途。对个人阅读它非常友好；对 WebNR 的长期 source admission，则需要先决定如何在产品层持续携带许可与 attribution，并明确未来商业场景。今天保留为强候选，不把 noncommercial 条款隐藏在一个普通 “Free TXT” 标签下面。
+### Source 会不会把整批文本上传到 WebNR？
 
-### CELT：能下载，也明确要求私人、教学和研究用途
+不会。source 保存目录信息；direct-TXT 条目在用户选择时由浏览器读取对应上游文件。用户自己的本地 TXT 则留在当前浏览器配置中。
 
-University College Cork 的 [CELT](https://www.ucc.ie/en/research-sites/celt/) 有大量爱尔兰历史与文学文本。官方 FAQ 明确允许搜索、屏幕阅读、为私人使用/教学/研究下载或打印，同时要求不要把 CELT 文本下载后放到自己的服务器。这里最安全的能力是来源发现和私人导入说明；它不适合被误写成“WebNR 可以自由镜像的开放 TXT 库”。
+## 继续阅读
 
-### Perseus canonical：仓库总体 CC BY-SA 4.0，但内容以 TEI XML 为主且组件权利有差异
+- [2026 年哪里能合法免费看小说](2026-08-08-legal-free-novels-txt-collections.md)
+- [WebNR 当前来源目录与健康说明](2026-09-03-first-month-source-directory-health-report.md)
+- [免费经典小说阅读路线怎么选](2026-09-05-free-classic-ebook-reading-routes-compared.md)
 
-PerseusDL 的 canonical Greek/Latin GitHub 仓库总体采用 **CC BY-SA 4.0 unless otherwise indicated**，同时 README 提醒具体材料可能具有不同版权状态。它的主要机器格式是 TEI XML，不是 WebNR 当前的 raw TXT。未来若做 adapter，应保存 CTS/版本身份、item-level license 和 XML→阅读文本转换 fixture，而不是把 XML 直接塞进 TXT reader。
-
-### EEBO-TCP Phase I：25,363 份转录进入公共领域，但核心发行形态是 TEI/XML
-
-Text Creation Partnership 的 EEBO Phase I 文本自 2015-01-01 起发布到公共领域；官方/项目 GitHub 分发以结构化 XML/TEI 为核心。这是一个权利条件很强、格式转换工作也很明确的候选。真正的 WebNR integration 应先实现确定性的 TEI→plain-text 派生规则、标题/作者 identity 与 fixture，再决定是否生成 direct-reading catalog。
-
-这五个候选里，没有一个需要靠“抓网页正文”来证明价值。相反，它们展示了更可持续的来源增长路线：优先找**公开 release、版本标识、机器文件、明确许可**，然后只实现 WebNR 当前能够测试的最窄能力。
-
-## 9. 给自己的 TXT 文件夹生成 source：一份可操作 checklist
-
-如果你手里有一个可以合法公开的 TXT 文件夹，可以按下面的顺序整理。
-
-### Step A：先冻结一个输入快照
-
-不要一边生成目录，一边继续改文件。先给文件夹一个版本：
-
-```text
-my-collection-2026-09-01/
-```
-
-如果使用 Git：
-
-```text
-git add texts metadata.csv
-git commit -m "Freeze TXT collection 2026-09-01"
-```
-
-之后 source 指向 commit，而不是 `main`。
-
-### Step B：把明显的临时文件排除
-
-典型排除项：
-
-```text
-.DS_Store
-Thumbs.db
-*.tmp
-*.bak
-README-draft.txt
-```
-
-目录生成脚本应该有 allowlist（例如只接受 `.txt`），而不是“文件夹里有什么就全发出去”。
-
-### Step C：建立 stable identity
-
-优先级通常是：
-
-```text
-上游作品 ID > 明确的馆藏 ID > 你自己的永久 slug > 当前文件名
-```
-
-文件名可以改，稳定 ID 最好不要随标题标点变化。
-
-### Step D：把 title/author 与 filename 分开
-
-一份中文 CSV 就足够：
-
-```csv
-id,title,author,filename,license,page_url
-001,作品一,作者甲,001.txt,Public Domain,https://example.org/works/001
-002,作品二,作者乙,002.txt,CC-BY-4.0,https://example.org/works/002
-```
-
-生成 YAML 时，展示标题来自 `title`，文件传输来自 `filename`。这样以后重命名文件、修正书名、增加原文标题都不会把 identity 搅在一起。
-
-### Step E：抽样检查编码，再声明 collection contract
-
-至少抽取：
-
-- 最小文件；
-- 最大文件；
-- 含罕见字符/繁体/日文假名/组合字符的文件；
-- 不同年代生成的文件；
-- 元数据里标记为不同语言的文件。
-
-如果全部 UTF-8，就把 UTF-8 写进 source README；如果混合编码，先统一转码通常比让每次阅读都猜编码更稳定。转码必须保留原始文件 hash 和转换脚本版本，避免“清理之后不知道改了什么”。
-
-### Step F：生成小而可 review 的 `search_index.yml`
-
-第一次不要把 20,000 条一次塞进去。先选 3–20 个代表性作品，覆盖：
-
-- 不同文件大小；
-- 不同作者；
-- 不同字符；
-- 不同元数据形状。
-
-先让 CI、浏览器导入和 public source route 都稳定，再讨论分页、sharding 或自动更新。
-
-## 10. 哪些信息绝对不该被目录生成脚本带进去
-
-TXT 目录很容易混入私人信息。生成 source 时要明确丢弃：
-
-- 本机绝对路径，例如 `/Users/alice/Downloads/...`；
-- Windows 用户名路径；
-- Drive/Dropbox 私有分享 token；
-- Cookie、Authorization header；
-- 个人备注、阅读进度；
-- 账号邮箱；
-- 付费站下载 URL 中的临时签名；
-- 未获授权的正文镜像地址。
-
-WebNR source 需要的是公开可验证的书目与来源事实，不是你的文件系统快照。
-
-## 11. 常见失败与最短修复路径
-
-### 乱码
-
-**本地文件：** 先让 WebNR 的本地检测处理；仍失败时，用文本编辑器确认实际编码，再转换为 UTF-8 后保留原文件备份。
-
-**远程 URL：** 检查服务器 charset。来源没有可靠声明时，下载到本地再导入通常更稳。
-
-### URL 在浏览器能开，WebNR 导入失败
-
-优先怀疑 CORS 或重定向。不要用账号 Cookie、代理或验证码绕过作为默认方案。
-
-### 导入后标题像 `1342-0`
-
-这是远程 URL 文件名本身。把作品加入 WebNR source，让 discovery metadata 提供可读标题；底层 raw 文件仍可保持上游原名。
-
-### 一个文件夹里重复了同一本书很多版本
-
-不要只按标题去重。至少加入版本/来源字段，必要时保留多版，例如：
-
-```text
-Frankenstein — 1818 text
-Frankenstein — 1831 text
-```
-
-对数字档案来说，“同名”远远不等于“同一字节或同一版”。
-
-### 上游更新了文件
-
-固定 commit 的 source 不会自动变。先审计新 revision，再通过新的 PR 更新 pin。这是刻意的设计：变化应该是可见事件，而不是后台漂移。
-
-## 12. WebNR 接下来最值得做什么
-
-raw TXT 路线已经从“只能读本地文件”走到了两个可验证 direct-source 示例：Project Ben-Yehuda 展示多语言 UTF-8 公共领域 dump，GITenberg 展示按作品拆分的 Git-backed 公共领域 TXT。下一阶段有三项价值很高：
-
-1. **本地批量/文件夹导入 UI**：让用户选择多个 TXT，并在写入前看到标题、编码和冲突预览；
-2. **远程 URL 的字节级编码路径**：让 remote import 与 local import 拥有一致、可测试的编码行为，同时尊重服务器 charset；
-3. **生成式 source tooling**：从授权文件夹或 metadata CSV 生成 bounded `search_index.yml`，输出重复 ID、缺失许可、超大文件、非 HTTPS、可变 URL 等 lint。
-
-这些能力一旦落地，“一个文件夹”就能沿着清晰的阶梯变成“可维护 source”，同时继续保持 WebNR 的 local-first 和最小网络权限边界。
-
-## 参考与复核入口
-
-### WebNR 实现与当前 source
-
-1. [WebNR `NovelStorage`：本地与 URL TXT 导入实现](https://github.com/AutoArchive/webNR/blob/main/app/lib/storage.ts)
-2. [Project Ben-Yehuda Public Domain TXT Starter](https://app.webnovel.win/sources/project-ben-yehuda-txt-starter)
-3. [Aozora Bunko Starter](https://app.webnovel.win/sources/aozora-starter)
-4. [GITenberg Direct TXT Starter](https://app.webnovel.win/sources/gitenberg-direct-txt-starter)
-
-### 本轮 direct-TXT 上游
-
-5. [GITenberg: Pride and Prejudice #1342](https://github.com/GITenberg/Pride-and-Prejudice_1342)
-6. [GITenberg: Frankenstein #84](https://github.com/GITenberg/Frankenstein_84)
-7. [GITenberg: The Adventures of Sherlock Holmes #1661](https://github.com/GITenberg/The-Adventures-of-Sherlock-Holmes_1661)
-8. [Project Ben-Yehuda `public_domain_dump`](https://github.com/projectbenyehuda/public_domain_dump)
-
-### 新候选的第一方政策与格式
-
-9. [OpenITI documentation](https://openiti.org/documentation/)
-10. [OpenITI releases](https://github.com/OpenITI/RELEASE)
-11. [Folger Shakespeare download formats](https://www.folger.edu/explore/shakespeares-works/download/)
-12. [Folger copyright policy](https://www.folger.edu/copyright-policy/)
-13. [CELT, University College Cork](https://www.ucc.ie/en/research-sites/celt/)
-14. [CELT FAQ / copyright and use](https://www.ucc.ie/en/research-sites/celt/faq/)
-15. [PerseusDL canonical Greek literature](https://github.com/PerseusDL/canonical-greekLit)
-16. [Text Creation Partnership: EEBO-TCP texts](https://github.com/textcreationpartnership/Texts)
-
-### 浏览器文本与网络基础
-
-17. [MDN: TextDecoder](https://developer.mozilla.org/docs/Web/API/TextDecoder)
-18. [MDN: Fetch API](https://developer.mozilla.org/docs/Web/API/Fetch_API)
-19. [MDN: CORS](https://developer.mozilla.org/docs/Web/HTTP/Guides/CORS)
-
----
-
-**一句话收尾：** 对没有目录的 TXT 合集，先把“文件能打开”升级成“作品身份、编码、来源、权利和快照都可解释”，再决定逐个本地读还是生成 source。目录本身很小，但它把一堆匿名文件变成了可以维护、可以复现、可以安全扩展的阅读集合。
+版本说明：本文描述 **2026-09-01** 的 WebNR TXT 导入与 source 设计边界。后续如果真正增加文件夹批量导入或新的容器格式，会通过新的用户文档说明，而不是回头把当前限制改写成“其实早就支持”。

--- a/docs/blog/posts/2026-09-05-free-classic-ebook-reading-routes-compared.md
+++ b/docs/blog/posts/2026-09-05-free-classic-ebook-reading-routes-compared.md
@@ -2,8 +2,7 @@
 title: 免费经典小说去哪读？Project Gutenberg、Standard Ebooks、Alice & Books、GITenberg 与 WebNR 怎么选
 date: 2026-09-05
 slug: free-classic-ebook-reading-routes-compared
-_description: 2026 年免费经典小说阅读路线实测比较：Project Gutenberg、Standard Ebooks、Alice & Books、GITenberg 与 WebNR 的馆藏定位、格式、账号、版权地域、TXT 导入和适合人群分别有什么差别。
-description: 2026 年免费经典小说阅读路线实测比较：Project Gutenberg、Standard Ebooks、Alice & Books、GITenberg 与 WebNR 的馆藏定位、格式、账号、版权地域、TXT 导入和适合人群分别有什么差别。
+description: 比较 Project Gutenberg、Standard Ebooks、Alice & Books、GITenberg 与 WebNR 的馆藏定位、格式、账号、版权地域、TXT 导入和适合人群，帮助读者快速选路线。
 categories:
   - Reader guides
   - Recommendations
@@ -13,239 +12,144 @@ categories:
 
 # 免费经典小说去哪读？Project Gutenberg、Standard Ebooks、Alice & Books、GITenberg 与 WebNR 怎么选
 
-先给结论。**如果你只想尽快找到最多的免费经典作品，先去 Project Gutenberg；如果你更在意 EPUB 的排版、校对、语义标记和阅读器体验，优先看 Standard Ebooks；如果你想要一个更小、更直观、无需注册、同时提供 PDF/EPUB/在线阅读的经典书架，可以看 Alice & Books；如果你在意 Git 版本、可复现文件和机器处理，GITenberg 更合适；如果你的目标是把纯文本真正放进浏览器本地阅读，WebNR 当前最顺手的路线仍然是本地 TXT 或已经审计过的 direct-TXT source。**
+**先给结论：**
 
-这五条路线不是“谁取代谁”。它们解决的是不同问题：有的擅长大规模数字化，有的擅长精修电子书，有的擅长视觉发现，有的擅长可复现源文件，而 WebNR 目前更像最后一公里的本地阅读层。把这些角色分清，比只比较“有多少本书”更有用。
+- 想先确认“这本经典有没有免费版本” → **Project Gutenberg**；
+- 想要校对、排版和 EPUB 质量更好的版本 → **Standard Ebooks**；
+- 想像逛小书架一样快速挑一本、在线读或下载 PDF/EPUB → **Alice & Books**；
+- 想要 Git commit、可复现纯文本和机器处理 → **GITenberg**；
+- 已经有 TXT，或想把经过审计的纯文本放进浏览器本地书架 → **WebNR**。
 
-本文核验日期为 **2026-09-05**。这里的“免费”不等于“全球无条件公版”。Project Gutenberg、Standard Ebooks、Alice & Books、GITenberg 等第一方页面都以美国公共领域判断为重要基础；一个作品在美国进入公共领域，不代表它在你所在国家或地区一定也是同样状态。下载、分享或再利用前仍应按自己的司法辖区核对版权期限。
+它们不是互相替代的五个“同类网站”。前四个主要解决**作品发现和文件来源**，WebNR 更像最后一公里的**本地阅读层**。
+
+本文核验日期为 **2026-09-05**。这里的“免费”不等于“全球无条件公版”：美国公共领域判断不能自动替代你所在国家或地区的版权期限；现代翻译、编辑版、封面和数字整理也可能有独立权利。
 
 [打开 WebNR Reader](https://app.webnovel.win/){ .md-button .md-button--primary }
-[查看 WebNR 第一个月来源健康报告](https://www.webnovel.win/blog/2026/09/03/first-month-source-directory-health-report/){ .md-button }
+[查看 WebNR 来源目录](https://www.webnovel.win/blog/2026/09/03/first-month-source-directory-health-report/){ .md-button }
 
 ## 一张表先选路线
 
-| 你最在意什么 | 更适合的路线 | 2026-09-05 核验到的特点 | WebNR 里的位置 |
+| 你最在意什么 | 推荐路线 | 你会拿到什么 | 在 WebNR 里的位置 |
 | --- | --- | --- | --- |
-| 馆藏广、搜索经典方便 | **Project Gutenberg** | 数万本免费电子书；无需注册；在线读、EPUB、纯文本等多种格式 | 目前主要作为官方发现入口；部分作品可通过其他经过审计的 TXT 路线进入 WebNR |
-| 排版、校对、现代 EPUB 体验 | **Standard Ebooks** | 公版作品重新校对、排版、做语义标记；项目自己的电子书工作也放入公共领域 | WebNR 保留官方作品发现入口；当前 WebNR 不把 EPUB 假装成 TXT 直接解析 |
-| 想快速浏览漂亮的 PDF/EPUB | **Alice & Books** | 小而直观；无需账号；PDF、EPUB、在线阅读；作品页明确提示美国公版与地域差异 | 本轮新增 discovery-only starter；遵守其禁止自动化/系统化抓取的站点条款 |
-| Git、版本固定、可复现文本 | **GITenberg** | 4 万余本 Git 管理的公版书；适合固定 commit 与机器处理 | WebNR 已有 3 本 commit-pinned direct-TXT 小样本，可直接测试浏览器文本导入 |
-| 本地 TXT、隐私、本地书架 | **WebNR** | 正式支持本地 TXT 和允许 CORS 的文本 URL；正文与进度留在浏览器 | 阅读层本身；不要求账号，也不把第三方网站变成代理抓取服务 |
+| 馆藏广、经典容易搜 | **Project Gutenberg** | 作品页、HTML、EPUB、plain text 等 | 大目录发现；具体 direct-TXT 需逐条固定身份 |
+| 高质量 EPUB | **Standard Ebooks** | 精校、统一排版、语义结构更完整的电子书 | 官方作品发现；WebNR 不假装已原生支持 EPUB |
+| 简单直观地挑一本 | **Alice & Books** | 小型经典书架、在线读、PDF/EPUB | discovery-only，跳转第一方页面 |
+| Git 与可复现文本 | **GITenberg** | 每本书独立 Git repo、commit history、raw TXT | 已有 3 本 commit-pinned direct-TXT 样本 |
+| 私人 TXT、本地阅读 | **WebNR** | 本地 TXT / 允许 CORS 的文本 URL、阅读进度 | 阅读层，不要求账号，不代理第三方站点 |
 
-如果你的问题是“今晚想读《傲慢与偏见》，哪个最省事”，答案可能是 Alice & Books 或 Standard Ebooks；如果问题是“我要一个长期可复现的纯文本测试输入”，答案更可能是 GITenberg；如果问题是“我要把自己已经有的 TXT 放进一个不上传正文的浏览器书架”，则直接打开 WebNR 比继续寻找新的下载站更合理。
+## Project Gutenberg：最适合从“有没有”开始
 
-## Project Gutenberg：先解决“有没有”和“能不能直接拿到”
+Project Gutenberg 的最大价值是**覆盖广、历史长、格式朴素**。很多经典作品可以在线阅读，也有 EPUB、HTML 和 plain text。
 
-Project Gutenberg 仍然是免费经典电子书最自然的第一站。它的第一方站点在本次核验时列出 **7 万多本免费电子书**，明确强调无需付费、无需注册，并以美国版权已经到期的较老作品为重点。作品通常可以直接在网页中阅读，也提供 EPUB、HTML、plain text 等格式；官方帮助页还把“Read Online”作为最简单的阅读方法之一。
+适合：
 
-它最大的优势不是页面最漂亮，而是**覆盖广、历史长、格式朴素且容易迁移**。当你只知道作者或书名，不确定哪里有合法的免费版本，Project Gutenberg 很适合做第一层检索。对研究者、工具作者和长期归档来说，plain text 也有特殊价值：它不依赖某一种电子书容器格式，几十年后仍然容易解析。
+- 只知道书名/作者，想先确认是否有合法免费版本；
+- 想自己决定后续用 Kindle、Calibre、浏览器或 WebNR；
+- 需要纯文本作为长期可读格式。
 
-但 WebNR 没有把整个 Project Gutenberg 网站包装成一个自己的大规模 crawler。原因也很简单：一个大型来源的“网页公开可访问”并不自动等于“每天用自己的爬虫扫完整站最合理”。WebNR 现有 Project Gutenberg Starter 保持面向读者的发现能力；需要真正 direct-TXT 的时候，则优先用具有稳定文件身份、明确大小和可复现 fixture 的小型来源进行验证。
+不应误解成：整个站点都可以被任意客户端高频抓取。项目有单独的 robot / machine access 说明，程序化使用应该走官方机器路线，而不是反复抓人类页面。
 
-**适合谁：**
+第一方入口：
 
-- 想先确认一本老书是否有免费版本；
-- 希望选择 HTML、EPUB、纯文本等不同格式；
-- 不想注册账号；
-- 需要一个长期存在、作品覆盖广的公共领域入口；
-- 愿意自己决定后续用浏览器、Kindle、Calibre、WebNR 或其他工具阅读。
+- [Project Gutenberg](https://www.gutenberg.org/)
+- [Reading options](https://www.gutenberg.org/help/reading_options.html)
+- [Robot access](https://www.gutenberg.org/policy/robot_access.html)
 
-第一方资料：
+## Standard Ebooks：免费之外，更在意“这本书做得好不好”
 
-- [Project Gutenberg 首页](https://www.gutenberg.org/)
-- [Project Gutenberg Reading Options](https://www.gutenberg.org/help/reading_options.html)
-- [Project Gutenberg Public Domain eBook Submission](https://www.gutenberg.org/help/public_domain_ebook_submission)
+Standard Ebooks 的核心价值是**编辑工程**。它会把公版文本重新校对、排版、补语义结构和 metadata，做成更接近现代商业电子书体验的 EPUB。
 
-## Standard Ebooks：当“免费”之外，你还在意一本 EPUB 做得好不好
+如果你已经在用成熟 EPUB 阅读器，它往往比“拿到最原始 TXT”更舒服。
 
-Standard Ebooks 和 Project Gutenberg 的关系很适合用一句话理解：**Project Gutenberg 往往先解决数字化和可获得性，Standard Ebooks 再把其中适合的公版文本做成经过校对、统一排版、语义结构更完整的现代电子书。** Standard Ebooks 自己也明确把 Project Gutenberg 视为重要文本来源，并说明其目标是做出接近商业电子书质量的免费公版版本。
+WebNR 对它保持一个简单边界：**官方作品页可以用来发现高质量版本，但 EPUB 没有真正 parser 之前，不会被宣传成 WebNR 已经原生兼容。**
 
-本次第一方核验中，Standard Ebooks 明确说明：它选择认为已在美国进入公共领域的文本和封面素材，并把自己新增的排版、markup、封面等工作也通过 CC0 / 公共领域 dedication 放开。它还强调语义 XHTML、现代 typography、详细 metadata、popup footnotes、目录和无 DRM 等特性。
+第一方入口：
 
-这意味着，如果你有 Kindle、Kobo、Apple Books、Thorium、Calibre 或其他成熟 EPUB 阅读器，Standard Ebooks 往往比“拿到一份最原始的 TXT”更舒服。它的价值在于**编辑工程**，不是单纯再复制一个免费下载按钮。
+- [Standard Ebooks](https://standardebooks.org/)
+- [About](https://standardebooks.org/about)
+- [Public domain policy](https://standardebooks.org/about/standard-ebooks-and-the-public-domain)
 
-对 WebNR 来说，目前有一个非常现实的边界：**WebNR 正式支持的是 TXT，不会因为 Standard Ebooks 的 EPUB 很好就把 EPUB 当成 TXT 糊弄过去。** 在真正的 EPUB parser、安全审查、渲染策略和 fixtures 完成之前，Standard Ebooks 在 WebNR source 里更适合承担“发现一个高质量版本”的角色，而不是被宣传为 WebNR 已经可以原生读取的容器格式。
+## Alice & Books：想少研究格式，直接挑一本
 
-**适合谁：**
+Alice & Books 的体验更像一个小型现代书店：作品少于大型档案库，但页面直观，很多经典提供在线阅读、PDF 和 EPUB，无需注册。
 
-- 已经用成熟 EPUB 阅读器；
-- 介意乱码、奇怪换行、直引号、脚注和目录质量；
-- 希望一套经典书在不同设备上有比较一致的视觉体验；
-- 想把开源/公版电子书作为再加工基础；
-- 不要求“必须在 WebNR 内直接打开 EPUB”。
+WebNR 对它采用 **discovery-only**：只保留经过审计的第一方入口，不后台抓取 catalog、不复制封面/简介/排行，也不把站点内容做成本地镜像。
 
-第一方资料：
-
-- [Standard Ebooks 首页](https://standardebooks.org/)
-- [About Standard Ebooks](https://standardebooks.org/about)
-- [Standard Ebooks and the Public Domain](https://standardebooks.org/about/standard-ebooks-and-the-public-domain)
-- [Accessibility](https://standardebooks.org/about/accessibility)
-
-## Alice & Books：更像一个“打开就能挑一本”的小型经典书架
-
-Alice & Books 是本轮新审计的来源。它的首页在 2026-09-05 核验时显示 **1,224 本 classics**，主打 PDF、EPUB、在线阅读、无需注册、DRM-free，并说明馆藏作品在美国属于公共领域或采用开放许可。具体作品页会继续给出版权提示，例如《Pride and Prejudice》《Frankenstein》《White Nights》都明确标注 `Public domain (US)`，同时提醒美国以外读者核对本地版权期限。
-
-从纯读者体验看，它的优势很直接：页面比大型档案库更像一个现代书店。你不用先理解文件目录，点开作品就能看到 PDF、EPUB、在线阅读等选项。对于“不想研究格式，只想现在开始读一本经典”的人，这是很好的发现路径。
-
-不过，本轮 WebNR 对它做了一个刻意的能力限制：**新增的 Alice & Books source 是 discovery-only，不是 crawler、API adapter 或镜像。** 这里不是因为《傲慢与偏见》突然不公版，而是因为 AliceAndBooks 当前 Terms of Use 对“站点内容”和“机器访问”写了明确边界：禁止通过 bot/script 等 automated or non-human means 访问，并禁止系统性提取网站数据去建立 collection/database/directory，也禁止 data-mining/robots 一类自动抽取活动。
-
-因此 WebNR 只维护四个经过人工审计的第一方目的地：官方 library，以及《Pride and Prejudice》《Frankenstein》《White Nights》三个代表作品页。source 中的说明是 WebNR 自己写的，不复制对方的封面、简介、下载数、热门排行、阅读时长或推荐数据，也不会后台轮询 AliceAndBooks。
-
-这也是“link-only 是能力等级，不是失败状态”的一个典型例子：**读者可以稳定发现并跳转，WebNR 又没有把普通网页使用权夸大成自动抓取授权。**
+原因不是作品突然“不公版”，而是**作品权利**和**网站机器访问规则**是两个问题。Alice & Books 的当前 Terms 对 automated/non-human access 和系统性提取有明确限制，因此“跳到官方作品页”就是当前合理能力。
 
 [添加 Alice & Books Public Domain Discovery Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Falice-and-books-public-domain-discovery-starter)
 
-第一方资料：
+第一方入口：
 
 - [Alice & Books](https://www.aliceandbooks.com/)
-- [AliceAndBooks Terms of Use](https://www.aliceandbooks.com/terms-of-use)
-- [Pride and Prejudice](https://www.aliceandbooks.com/book/pride-and-prejudice/jane-austen/7)
-- [Frankenstein](https://www.aliceandbooks.com/book/frankenstein/mary-shelley/35)
-- [White Nights](https://www.aliceandbooks.com/book/white-nights/fyodor-dostoevsky/717)
+- [Terms of Use](https://www.aliceandbooks.com/terms-of-use)
 
-## GITenberg：真正有意思的是 Git，而不是“又多一个 Gutenberg 镜像”
+## GITenberg：真正独特的是 Git，而不是“又一个 Gutenberg 链接”
 
-GITenberg 的第一方项目页称目前有 **43,000 多本**书，并把项目描述为 free、open、collaborative、scriptable digital library。它的作品来自 Project Gutenberg 等公版基础，但把“每本书如何被维护”变成更适合软件工程的模型：Git repository、commit history、可 fork、可修订。
+GITenberg 把许多 Project Gutenberg 作品维护在独立 Git 仓库中。对普通读者，它未必比精美作品页更方便；对想要**稳定文件身份**的人，它很有价值：
 
-这对于普通读者未必比一个漂亮 EPUB 页面更直观，但对 WebNR 这种要做**可复现 source health 和导入 regression** 的工具非常有价值。上游 mutable URL 今天和下个月可能变；一个审核过的 commit 则可以作为明确身份。WebNR 现在的 `GITenberg Direct TXT Starter` 故意只选三本书，并把具体 TXT 固定到具体 commit。这样一条 source 的“健康”不是“某个网站首页还活着”，而是“这个已审计字节输入仍然可以被同样的 reader 路径读取”。
+- 可以固定 commit；
+- raw TXT 可直接检查；
+- 上游改动有历史；
+- 出现问题可以回到精确快照。
 
-这是为什么 GITenberg 在本文里不和 Project Gutenberg 竞争“谁的目录更大”。它更像一座桥：把公共领域电子书的世界连接到 Git、版本化 fixtures、可重复测试和机器处理。
+WebNR 的 `GITenberg Direct TXT Starter` 只选三个小样本：
 
-**适合谁：**
+- *Pride and Prejudice*
+- *Frankenstein*
+- *The Adventures of Sherlock Holmes*
 
-- 想固定一个文本版本；
-- 做 NLP、文本处理、reader fixture 或回归测试；
-- 希望看到每本书的修改历史；
-- 能接受 GitHub/Git 风格的来源结构；
-- 在 WebNR 中更看重 direct-TXT 的确定性，而不是大而全目录。
+每条都固定到具体 commit。用户点击后，浏览器只请求那一本 TXT；没有 bulk clone、后台轮询或把整个 GITenberg 镜像进 WebNR。
 
-第一方资料：
+[打开 GITenberg Direct TXT Starter](https://app.webnovel.win/sources/gitenberg-direct-txt-starter)
 
-- [GITenberg Project](https://gitenberg.org/)
-- [WebNR GITenberg Direct TXT Starter](https://app.webnovel.win/sources/gitenberg-direct-txt-starter)
+## WebNR：如果你已经有 TXT，就别再找一个“平台”
 
-## WebNR：它不是又一个电子书下载站，而是把“我已经选好的文本”留在浏览器里
+WebNR 最适合的场景不是替代所有电子书网站，而是：
 
-把前面四个来源放到一起之后，WebNR 的角色反而更清楚。WebNR 当前不是要复制 Project Gutenberg，也不需要重新做一遍 Standard Ebooks 的编辑工程。它更适合负责这条链的后半段：**你已经知道想读什么、已经拥有 TXT 或找到了允许浏览器读取的文本 URL，然后把正文、书架和进度留在自己的浏览器里。**
+- 你已经有自己的 TXT；
+- 你想把正文和进度保存在当前浏览器；
+- 你希望用翻页/滚动、排版、深色模式、书签和 TTS；
+- 或者你从经过审计的 direct-TXT source 里选一本文本直接导入。
 
-截至 2026-09-05，WebNR 正式支持本地 TXT，以及服务器允许浏览器跨域访问的文本 URL。导入内容与阅读进度主要保存在当前浏览器的 IndexedDB，不要求用户注册 WebNR 账号。EPUB 和 PDF 仍然不会被假装成“已经支持”；容器格式需要真正的 parser、安全边界、fixtures 和 E2E 之后才能进入正式能力声明。
+如果你面对的是 EPUB，当前更合理的做法是用 EPUB 阅读器；如果你面对的是网页平台，则用 discovery source 回到第一方作品页。**不要为了“都塞进一个 App”而牺牲格式和来源边界。**
 
-因此，面对一部经典作品，可以按下面的顺序做决策：
+## 五个常见问题
 
-1. **只想读，已经有 TXT：** 直接导入 WebNR，本地文件不需要 CORS。
-2. **想要漂亮 EPUB：** 先看 Standard Ebooks；用专门 EPUB 阅读器通常更合理。
-3. **想快速浏览 PDF/EPUB：** Alice & Books 是一个直观入口，但由原站完成下载/阅读。
-4. **想找最广泛的公版版本：** 从 Project Gutenberg 开始。
-5. **想要稳定、commit-pinned 的文本：** 看 GITenberg/WebNR direct-TXT starter。
-6. **网页上有 TXT，但 WebNR URL 导入失败：** 先查 CORS，而不是找公共代理绕过来源站策略。
+### 我只想读《傲慢与偏见》，去哪最快？
 
-这条分工可以避免一个常见误区：为了让“所有来源都在一个 App 里打开”，最后不得不增加中心化代理、偷偷转发 Cookie、绕过登录或把来源网站的访问策略吃掉。WebNR 当前宁愿让一部分来源保持 discovery-only，也不把这种隐性代理成本伪装成“兼容性”。
+想在线挑版本：Alice & Books 或 Standard Ebooks。想要 plain text / 大型公版目录：Project Gutenberg。想测试可复现 TXT：GITenberg。已经下载 TXT：直接 WebNR。
 
-## 五个来源真正的差别：不是数量，而是编辑、身份和权限
+### Standard Ebooks 为什么不是 WebNR direct-TXT？
 
-### 1. “作品公版”与“这个网站可以被自动抓”是两件事
+因为它的强项是 EPUB。把 EPUB 当 TXT 读会破坏结构；在 parser 完成前保持 discovery 比伪兼容更可靠。
 
-《Pride and Prejudice》本身进入公共领域，不代表某个网站的封面、简介、排行、页面代码、用户数据和编辑内容也自动进入公共领域。Alice & Books 是今天最清楚的例子：作品页明确写美国公版，但网站 Terms 同时限制自动化和系统化数据提取。
+### Alice & Books 的书是公版，为什么 WebNR 不自动抓？
 
-反过来，Standard Ebooks 不只是告诉你基础作品是公版，还主动把自己制作的 ebook 文件工作也 dedication 到公共领域。这类第一方声明会直接影响一个工具以后能否做更丰富的机器接口。
+因为“作品公版”和“网站允许自动化抓取”是两个独立问题。WebNR 遵守其站点访问边界，所以只做人工审计后的第一方链接。
 
-### 2. “下载地址今天能打开”与“稳定 source”也是两件事
+### GITenberg 和 Project Gutenberg 重复吗？
 
-一个 URL 返回 200，只能说明这一次请求得到响应。WebNR 如果要承诺 direct-TXT，还需要知道稳定 identity、编码、响应大小、超时、更新/删除语义、CORS、失败行为，以及上游是否允许这类访问。GITenberg 的 commit-pinned 文件在这里特别有优势；DBNL 则相反，虽然权利证据很强、源站也提供 TXT，但 WebNR 还没有得到可重复的浏览器 CORS 证据，所以当前仍然只做 discovery。
+作品集合有重叠，但用途不同：Project Gutenberg 更适合大目录发现；GITenberg 的 Git/commit 结构适合可复现 raw TXT 和 regression fixture。
 
-### 3. “格式多”不等于“WebNR 都应该解析”
+### 我在美国之外，能直接按美国公版结论使用吗？
 
-PDF、EPUB、MOBI、HTML、TXT 各自服务不同阅读器。一个网站提供五种格式是好事，但 WebNR 不应该因为 source 页面写了 EPUB 就在产品里声称 EPUB 已兼容。当前稳定边界还是 TXT；需要 EPUB 时，用 Standard Ebooks + 专门 EPUB reader 往往比在 WebNR 里做一个半成品解析器更好。
+不能。版权期限按所在地法域、作者/译者和具体版本判断。本文提供找书路线，不替代你所在地的权利判断。
 
-## 今天另外筛查了哪些免费电子书来源
+## 怎么选：只问自己三件事
 
-为了避免这篇比较只围绕已经熟悉的项目，本轮 source program 还筛查了另外四个候选 family，并没有为了“每天必须加一个”把它们全部塞进 maintained set。
+1. **我需要的是“找书”还是“读已经有的文件”？**
+2. **我要 TXT、EPUB、PDF 还是在线阅读？**
+3. **我更在意覆盖、排版、界面简单，还是版本可复现？**
 
-### Loyal Books：适合音频发现，但与现有公版路线高度重叠
+这三个问题答完，路线通常就很清楚：
 
-Loyal Books 的第一方 About 页面说明，它的大量公版内容主要来自 Project Gutenberg，音频则大量来自 LibriVox，并强调 public-domain audiobook；其 App 页面同时列出数千本 audiobook 与数万本 ebook。对读者而言，它的视觉浏览和有声书入口有价值，但对 WebNR 当前的**文本 source** 来说，与 Gutenberg/GITenberg 的覆盖重叠很高，而且本轮没有得到足够细的 item-level ebook provenance 证据来证明“整套 ebook catalog 可以作为一个新的同步接口”。因此本轮不做内容 ingestion，也不为凑数再造一个重复目录。
+- 覆盖 → Gutenberg
+- EPUB 品质 → Standard Ebooks
+- 简单挑书 → Alice & Books
+- 可复现 TXT → GITenberg
+- 本地阅读 → WebNR
 
-- [About Loyal Books](https://www.loyalbooks.com/about)
-- [Loyal Books App](https://www.loyalbooks.com/app)
+如果你想继续比较更广的免费馆藏，看 [2026 年哪里能合法免费看小说](2026-08-08-legal-free-novels-txt-collections.md)；如果你已经拿到一堆 TXT，看 [TXT 集合导入指南](2026-09-01-raw-txt-collection-import-guide.md)。
 
-### Planet eBook：澳大利亚版权边界不应该被悄悄改写成全球公版
-
-Planet eBook 的具体作品页明确写着：这些电子书在澳大利亚发布并在当地 out of copyright，同时提醒读者在下载、阅读或分享前检查自己国家的版权法。这个说明本身很清楚，也正因为清楚，WebNR 不应该把它简化成一个没有地域限定的“全球 public domain TXT source”。当前又没有比现有 Gutenberg/Standard Ebooks 路线更强的 WebNR reader value，因此先 defer 内容集成。
-
-- [Planet eBook](https://www.planetebook.com/)
-
-### ManyBooks：现在已经是“公版经典 + 作者自出版 + 免费/折扣生态”的混合平台
-
-ManyBooks 的第一方 About 页面说明，早期大量电子书来自 Project Gutenberg，但后来平台也向 self-publishing authors 开放；主页同时展示 public-domain classics 与免费/折扣新书。帮助页还说明，下载电子书通常需要先创建账号。
-
-这并不是坏事，只是意味着它已经不是一个可以用“全部公版”四个字描述的单一来源。对 WebNR 来说，若以后接入，需要逐项区分公版作品、作者授权 permafree、外部商店促销和账户下载边界，不能把整个站当作统一 license。今天先保持候选状态，比做一个含混的大目录更安全也更可维护。
-
-- [About ManyBooks](https://manybooks.net/about)
-- [ManyBooks Help](https://manybooks.net/help)
-
-### Better Gutenberg：有意思，但与已有 Gutenberg/GITenberg 路线需要证明“新增价值”
-
-Better Gutenberg 的第一方 About 页面说明，它把 Project Gutenberg 和其他公版 collection 的文本重新处理成更干净的现代 EPUB；当前站点还提供 6,000 多本 EPUB 的整库下载。它是一个值得继续审计的 formatter/curated library，但 WebNR 已经有 Project Gutenberg 的发现路线和 GITenberg 的版本化 TXT 路线。下一步若要接入，应该先回答“对 WebNR 读者新增了什么能力”，以及其再加工 EPUB、更新、归属和批量获取边界，而不是因为它是新网站就重复一个 catalog。
-
-- [About Better Gutenberg](https://bettergutenberg.org/about/)
-
-## 推荐路线：按你的真正目标选，不要按“免费站排行榜”选
-
-### 场景 A：我只想找一本经典，今晚开始读
-
-先搜 Project Gutenberg；如果你希望页面和电子书更精致，再看 Standard Ebooks 或 Alice & Books。它们都不要求你先理解 WebNR source 格式。
-
-### 场景 B：我想把几十本经典长期放在 EPUB 阅读器
-
-优先 Standard Ebooks。对那些 Standard Ebooks 没有制作的作品，再回 Project Gutenberg 或其他公版库补齐。WebNR 当前不是 EPUB library manager，不需要硬塞进来。
-
-### 场景 C：我做文本分析或阅读器测试，要固定输入
-
-优先找可固定 revision 的 GITenberg，或者 WebNR 已经审计的 direct-TXT starter。把 commit、文件路径、编码和大小写进 fixture，比记录“今天下载按钮还能点”更可靠。
-
-### 场景 D：我手里已经有很多 TXT，只想本地读
-
-不要继续找下载站。直接导入 WebNR。本地文件不需要来源站 CORS，也不会因为第三方目录结构变化而失效。若以后需要把一个公开、授权的 TXT 文件夹分享成 source，再生成一个小型、带 provenance 的 `search_index.yml`。
-
-### 场景 E：我看到一个公版网站，想让 WebNR 全自动同步
-
-先不要从“能抓”开始，而从六个问题开始：作品或 edition 的权利是什么？站点允许怎样的机器访问？浏览器能否请求？identity 怎么固定？更新和删除怎么处理？失败时是否会偷偷换镜像？这六个问题答完，再决定是 link-only、direct TXT、feed/API adapter，还是根本不应该接入。
-
-## 本轮 WebNR source 变化
-
-作为这次比较的一部分，WebNR 新增 **Alice & Books Public Domain Discovery Starter**。它不是把 AliceAndBooks 变成后台数据源，而是把四个经过审核的第一方入口放进 reader 的来源发现层，并明确记录当前站点条款导致的自动化边界。
-
-这使 maintained source family 从 23 个增加到 **24 个**，同时保持一个重要原则：**source 数量增长不能靠降低 admission 标准。** 本轮审计的 Loyal Books、Planet eBook、ManyBooks、Better Gutenberg 都保留在候选/后续审计队列，而不是为了日目标强行进入 maintained set。
-
-[打开 Alice & Books Starter](https://app.webnovel.win/sources/alice-and-books-public-domain-discovery-starter)
-
-## 最后一句话
-
-免费经典小说的生态已经不缺“下载按钮”，真正值得比较的是：**谁负责确认作品可自由提供，谁负责校对和排版，谁给你稳定版本，谁只是帮你发现，而你的阅读器到底需要哪一种输入。**
-
-Project Gutenberg 是广泛入口；Standard Ebooks 是精修版本；Alice & Books 是现代化的快速发现；GITenberg 把公版文本变成可版本化的软件资产；WebNR 则把经过选择的 TXT 放进本地浏览器书架。按这个分工使用它们，比追求一个“什么都抓、什么都解析、什么都镜像”的超级来源更可靠。
-
-### 参考与核验资料
-
-以下页面均于 2026-09-05 重新核验：
-
-1. Project Gutenberg — https://www.gutenberg.org/
-2. Project Gutenberg Reading Options — https://www.gutenberg.org/help/reading_options.html
-3. Project Gutenberg Public Domain eBook Submission — https://www.gutenberg.org/help/public_domain_ebook_submission
-4. Standard Ebooks — https://standardebooks.org/
-5. About Standard Ebooks — https://standardebooks.org/about
-6. Standard Ebooks and the Public Domain — https://standardebooks.org/about/standard-ebooks-and-the-public-domain
-7. Standard Ebooks Accessibility — https://standardebooks.org/about/accessibility
-8. Alice & Books — https://www.aliceandbooks.com/
-9. AliceAndBooks Terms of Use — https://www.aliceandbooks.com/terms-of-use
-10. AliceAndBooks: Pride and Prejudice — https://www.aliceandbooks.com/book/pride-and-prejudice/jane-austen/7
-11. AliceAndBooks: Frankenstein — https://www.aliceandbooks.com/book/frankenstein/mary-shelley/35
-12. AliceAndBooks: White Nights — https://www.aliceandbooks.com/book/white-nights/fyodor-dostoevsky/717
-13. GITenberg Project — https://gitenberg.org/
-14. Loyal Books About — https://www.loyalbooks.com/about
-15. Loyal Books App — https://www.loyalbooks.com/app
-16. Planet eBook — https://www.planetebook.com/
-17. ManyBooks About — https://manybooks.net/about
-18. ManyBooks Help — https://manybooks.net/help
-19. Better Gutenberg About — https://bettergutenberg.org/about/
-20. WebNR 第一个月来源健康报告 — https://www.webnovel.win/blog/2026/09/03/first-month-source-directory-health-report/
+核验日期：**2026-09-05**。项目目录、条款和作品状态会变化；当前 WebNR 来源能力以 [Sources](https://www.webnovel.win/sources/) 为准。


### PR DESCRIPTION
Continue the user-requested Blog cleanup after #147 by rewriting the four remaining core guides that still mixed reader advice with daily source-program/audit language, and reconcile the independently verified #147 production identity so the unchanged production verifier tests the actual deployed site.

Reader rewrites
- legal/free reading directory: keep reader-facing Project Gutenberg / Standard Ebooks / Aozora / Project Madurai / Project Ben-Yehuda guidance; remove candidate-sweep and integration-queue prose
- Legado compatibility report: keep the tested 2026-08-30.1 L1–L5 contract and fixture behavior; remove community-collection audit ledger and operating backlog
- raw-TXT import guide: keep practical local/URL/source workflows, encoding, CORS, provenance and Ben-Yehuda/GITenberg examples; remove daily integration/candidate narrative
- classic reading-route comparison: keep the five-way decision guide; remove source-program candidate review and turn discovery/direct-TXT distinctions into reader explanations

Production evidence reconciliation
- #147 has independently deployed exact source commit `0359bae0d3c8dc1a1725975faf294b81bc123620` to application, documentation mirror, and canonical documentation
- record the verified app-pages artifact `fdf00ad236feaaa5220622d3a4087f2f653b9e71` and gh-pages artifact `cd94f6aa92ee4b07be16def647dc0ad19ff0fcf8`
- do not weaken or bypass `scripts/verify-production-builds.mjs`; make it verify the current production identity

All four article slugs/URLs remain unchanged. No reader runtime, source catalog, analytics behavior, or application behavior changes.

Acceptance: strict documentation build and generated-output checks pass; all four Quality jobs pass on the final exact head; required existing article markers/canonical/RSS/sitemap contracts remain; rewritten pages lead with reader decisions and contain no CI/PR/provider-metric/operating-queue narrative; Production evidence verifies current exact deployed identities.