### PR TITLE
Preserve retired WebNR blog routes

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,4 @@
+# Preserve public URLs retired from navigation by the reader-first Blog cleanup.
+/blog/2025/02/27/7-web-novel-readers-compared-open-source-vs-commercial--2024-technical-deep-dive/ /blog/2025/02/27/archive--web-novel-reader-comparison-february-2025-snapshot/ 301
+/blog/archive/* /blog/ 301
+/blog/category/* /blog/ 301

--- a/scripts/build-docs-production.sh
+++ b/scripts/build-docs-production.sh
@@ -48,7 +48,11 @@ rm -f site/CNAME
 
 test -f site/index.html
 test -f site/build.json
+test -f site/_redirects
 grep -Fq "\"commit\": \"${build_sha}\"" site/build.json
+grep -Fxq '/blog/2025/02/27/7-web-novel-readers-compared-open-source-vs-commercial--2024-technical-deep-dive/ /blog/2025/02/27/archive--web-novel-reader-comparison-february-2025-snapshot/ 301' site/_redirects
+grep -Fxq '/blog/archive/* /blog/ 301' site/_redirects
+grep -Fxq '/blog/category/* /blog/ 301' site/_redirects
 
 # Keep the documentation analytics contract aligned with the reader: one GA4
 # destination, explicit full URL/query reporting, and disabled Google/ad


### PR DESCRIPTION
## Why

PR #147 intentionally removed archive/category navigation, but it also removed the corresponding public routes from the generated artifact. The current canonical site returns 404 for previously published archive/category URLs, while the renamed February 2025 article relies on a stale old asset rather than an explicit compatibility rule.

## Change

- add three Cloudflare Pages redirect rules: the former article slug to its current stable archive slug, all retired archive paths to `/blog/`, and all retired category paths to `/blog/`
- assert that the redirect manifest and all three rules are present in every documentation build

## Preserved behavior

The curated Blog UI remains unchanged: archive/category navigation stays disabled. No article content, current URL, sitemap, RSS, reader runtime, source catalog, canonical ownership, or analytics behavior changes.

## Validation

- `scripts/build-docs-production.sh` completed locally with the pinned documentation dependencies
- generated `site/_redirects` contains the exact three rules
- existing documentation build, canonical, RSS, sitemap, and GA4 checks passed inside the build script

## Deployment and acceptance

The documentation workflow should publish the exact squash commit. On `www.webnovel.win`, the old article route must redirect permanently to the current archive route, representative `/blog/archive/...` and `/blog/category/...` routes must redirect permanently to `/blog/`, and the current article plus Blog hub must remain canonical and reachable.

Risk is limited to these retired route families. Reverting the squash commit removes the compatibility rules.