### PR TITLE
Content: refresh community recommendation radar

### DIFF
--- a/docs/blog/posts/2026-09-07-where-to-ask-web-novel-recommendations.md
+++ b/docs/blog/posts/2026-09-07-where-to-ask-web-novel-recommendations.md
@@ -115,7 +115,7 @@ WebNR 的 Discussion Radar 只保存 WebNR 自写的发现标签和第一方公�
 
 ## 和 8 月 Radar 怎么配合使用
 
-如果你还没确定应该写哪些筛选条件，可以先看 [2026 年 8 月英文网文读者在聊什么](../2026/08/28/web-novel-discussion-radar-2026-08/)。那篇文章总结了 completed、媒介/平台、stat blocks、slice of life、长尾发现和 AI 披露等常见条件；本文解决下一步问题：**条件写好了，到哪里问最合适。**
+如果你还没确定应该写哪些筛选条件，可以先看 [2026 年 8 月英文网文读者在聊什么](https://www.webnovel.win/blog/2026/08/28/web-novel-discussion-radar-2026-08/)。那篇文章总结了 completed、媒介/平台、stat blocks、slice of life、长尾发现和 AI 披露等常见条件；本文解决下一步问题：**条件写好了，到哪里问最合适。**
 
 ## 验证方法与边界
 

--- a/docs/blog/posts/2026-09-07-where-to-ask-web-novel-recommendations.md
+++ b/docs/blog/posts/2026-09-07-where-to-ask-web-novel-recommendations.md
@@ -1,0 +1,124 @@
+---
+title: 英文网文推荐应该去哪里问？Royal Road、SpaceBattles、Reddit、Sufficient Velocity 与 Tapas 怎么选
+date: 2026-09-07
+slug: where-to-ask-web-novel-recommendations
+summary: 不同英文网文社区擅长回答不同类型的找书问题。本文按“找连载、找完结、找同人、找长尾、找特定阅读体验”给出可直接使用的社区路线。
+description: 2026 年 9 月实测 Royal Road、SpaceBattles、r/rational、Sufficient Velocity 与 Tapas 的公开讨论入口，说明不同找书需求应该去哪里问、怎么写推荐请求，以及哪些入口更偏作者交流而不是读者推荐。
+categories:
+  - Reader guides
+  - Community
+---
+
+# 英文网文推荐应该去哪里问？Royal Road、SpaceBattles、Reddit、Sufficient Velocity 与 Tapas 怎么选
+
+**先给结论：不要把所有“求推荐”都发到同一个地方。** 如果你主要读 Royal Road 连载，先去 Royal Road 的 Recommendations；如果你在找同人、跨界作品或需要非常具体的 fic search，SpaceBattles 的 Story Ideas & Recommendations 更直接；如果你的问题很窄、偏 rational fiction、网络连载或短篇，r/rational 的固定推荐线程更合适；Sufficient Velocity 更适合从 Story Library 和创作社区继续扩展候选；Tapas Writing | Novels 则明显更偏作者、作品展示与写作交流，不应把它当成纯读者榜单。
+
+本文在 **2026-09-07** 重新打开这些第一方公开入口，并检查了能直接观察到的版块用途与当前页面。这里比较的是“一个读者应该从哪里开始找”，不是流量排名，也不代表任何社区的全部用户意见。
+
+[添加 Web Novel Discussion Radar Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fweb-novel-discussion-radar-starter){ .md-button .md-button--primary }
+
+## 先把你的问题写成一张需求卡
+
+发帖或搜索之前，先写五项：
+
+1. **完成度**：completed、ongoing，还是都可以；
+2. **作品形态**：original fiction、fanfiction、web serial、published ebook、audiobook；
+3. **平台限制**：Royal Road、KU、Audible、网页免费阅读，还是不限；
+4. **阅读体验**：例如 slow burn、slice of life、少 stat blocks、群像、女性主角、短战斗；
+5. **排除项**：例如 no harem、不要未完坑、不要某类 crossover，或只要某个 fandom。
+
+“推荐一本 Progression Fantasy”通常会得到一大串重复书名；“已完结、少 stat blocks、有群像和幽默、不要 harem、RR 或 KU 都可以”更容易让别人判断你到底需要什么。
+
+## 1. Royal Road：先解决“我还想在 RR 里读什么”
+
+[Royal Road Recommendations](https://www.royalroad.com/forums/5850) 是最直接的平台内入口。2026-09-07 检查时，这个版块仍在持续出现找相似作品、寻找下一本、传统幻想推荐和长尾作品发现等讨论。
+
+它最适合：
+
+- 你已经明确想继续在 Royal Road 阅读；
+- 想找正在连载的新作品或低曝光作品；
+- 能用几本已读作品作为口味坐标；
+- 希望讨论作品，而不是只看一个静态榜单。
+
+它不适合解决“所有平台上最值得读什么”这种过宽问题。Royal Road 的社区天然更熟悉自己平台里的作品，因此最好把平台限制写在请求里。
+
+## 2. SpaceBattles：同人、crossover 和非常具体的 fic search 更强
+
+[SpaceBattles Story Ideas & Recommendations](https://forums.spacebattles.com/forums/story-ideas-recommendations.63/) 的版块说明直接把用途写成 story recommendations、reviews、requests 与故事讨论。2026-09-07 的公开页面仍能看到 Fic Search、按具体 fandom 组织的 ideas/recommendations 线程，以及大量按设定继续细分的讨论。
+
+它最适合：
+
+- 找 fanfiction、crossover 或特定 fandom；
+- 只记得一些剧情特征，想做 fic search；
+- 想问“有没有符合这些具体条件的故事”；
+- 愿意沿着长期主题线程继续挖老作品。
+
+SpaceBattles 还有独立的 Creative Library，用更接近故事归档的方式发现 Creative Writing 与 Quests 内容。**“我要搜索一篇特定 fic”** 与 **“我要浏览新故事”** 是两种任务：前者先去 Story Ideas & Recommendations，后者可以再看 Library。
+
+## 3. r/rational：需求很窄时，固定推荐线程反而更省事
+
+2026-09-07 的 [r/rational Monday Request and Recommendation Thread](https://www.reddit.com/r/rational/comments/1w9syy3/d_monday_request_and_recommendation_thread/) 仍明确允许读者提出具体请求，也允许推荐 rational 或相邻作品。当天的公开请求就包括短篇、末日后重建类 serial / fanfiction 等很窄的条件。
+
+它最适合：
+
+- 你的问题已经具体到一个叙事机制或世界设定；
+- rational / rational-adjacent 是重要筛选条件；
+- web serial、fanfiction、传统出版物都可以混在候选里；
+- 你不需要一个大型平台目录，而是需要人来理解自然语言条件。
+
+这里最值得借鉴的不是某一次回复数量，而是**固定推荐线程的结构**：把零散求书集中在一个持续更新的入口里，让读者用完整条件提问。
+
+## 4. Sufficient Velocity：先从 Story Library 找作品，再用创作社区扩展线索
+
+[Sufficient Velocity](https://forums.sufficientvelocity.com/) 当前首页把 **Story Library** 单独列为 “User written stories”，同时保留 User Fiction、Quests 与 Creative Discussion & Worldbuilding 等版块。它更像“故事库 + 创作论坛”的组合，而不是一个专门的全站求书板。
+
+因此更合理的顺序是：
+
+- 想直接浏览故事：先用 Story Library；
+- 想看作者、读者怎样讨论设定和创作：再去 Creative Discussion & Worldbuilding；
+- 想找 fanfiction 或某个现成作品生态：再进入 User Fiction 下的对应区域。
+
+如果你的目标只是“给我十本符合 X 条件的小说”，SpaceBattles 的专门推荐版或 Reddit 的固定推荐线程通常更直接；如果你想从故事本身继续追到创作社区，Sufficient Velocity 更有价值。
+
+## 5. Tapas Writing | Novels：适合发现作者和作品展示，但要过滤自荐噪声
+
+[Tapas Writing | Novels](https://forums.tapas.io/c/writing-novels) 2026-09-07 可公开访问，当前主题同时包含“Seeking horror novels to read”、作品分享、写作问题、反馈和作者经验。Tapas 的官方 Terms of Service 也把 Tapas Forum 明确列为服务的一部分，并说明用户保留自己提交内容的所有权。
+
+这意味着它可以帮助你发现作者和作品，但它不是纯读者推荐区。使用时最好：
+
+- 优先搜索明确的 “seeking / looking for / recommendations” 主题；
+- 把纯 promotion / share-your-story 线程与真实求书请求分开看；
+- 不把作者自荐数量当作读者共识或作品质量信号。
+
+如果你想了解一个平台上的作者生态，它很有用；如果你只想高效找下一本，先用更专门的推荐入口。
+
+## 一张表快速选入口
+
+| 你的问题 | 优先入口 | 为什么 |
+| --- | --- | --- |
+| 还想继续读 Royal Road，有没有相似连载？ | Royal Road Recommendations | 平台内作品和长尾发现最直接 |
+| 找某个 fandom、crossover，或者只记得剧情特征 | SpaceBattles Story Ideas & Recommendations | 专门承担 recs、reviews、requests 与 fic search |
+| 条件很怪、很窄，偏 rational / serial / fanfic | r/rational 固定推荐线程 | 适合自然语言长条件和跨媒介候选 |
+| 想先逛故事库，再深入创作社区 | Sufficient Velocity | Story Library 与创作论坛在同一生态 |
+| 想看作者作品、自荐与写作交流 | Tapas Writing | Novels | 作者侧信号丰富，但需要过滤 promotion |
+
+## 不要把“热闹”误当成“适合你”
+
+一个版块帖子多、更新快，并不自动意味着它更会回答你的问题。真正影响找书效率的是：
+
+- 这个社区是否熟悉你要找的作品形态；
+- 有没有专门的 recommendations / fic search / monthly thread 结构；
+- 你的条件能否被社区常用的标签和语言表达；
+- 你是要“浏览目录”，还是要“让人理解一个复杂请求”。
+
+WebNR 的 Discussion Radar 只保存 WebNR 自写的发现标签和第一方公开入口，不复制帖子正文、用户名、投票、评分或账号状态，也不调用这些社区的 API。读者点击结果后，仍在原平台自己的规则和访问控制下阅读。
+
+## 和 8 月 Radar 怎么配合使用
+
+如果你还没确定应该写哪些筛选条件，可以先看 [2026 年 8 月英文网文读者在聊什么](../2026/08/28/web-novel-discussion-radar-2026-08/)。那篇文章总结了 completed、媒介/平台、stat blocks、slice of life、长尾发现和 AI 披露等常见条件；本文解决下一步问题：**条件写好了，到哪里问最合适。**
+
+## 验证方法与边界
+
+本文于 **2026-09-07** 手动检查 Royal Road Recommendations、SpaceBattles Story Ideas & Recommendations 与其官方 Terms、当天 r/rational 推荐线程与 Reddit 当前 User Agreement / Data API Terms、Sufficient Velocity 首页与帮助/规则页面，以及 Tapas Writing | Novels 与官方 Terms of Service。
+
+这里只记录公开可访问的入口、第一方版块说明和 WebNR 的编辑判断。没有登录、没有调用社区 API、没有抓取或复制帖子集合、没有统计用户级行为，也没有用少量帖子推断“整个社区都喜欢什么”。入口未来可能移动或改规则；WebNR 会在后续 Radar 中重新验证，而不是静默替换来源。

--- a/public/sources/web-novel-discussion-radar-starter/README.txt
+++ b/public/sources/web-novel-discussion-radar-starter/README.txt
@@ -35,8 +35,8 @@ Screening and source-specific audit
    Access/runtime: the board is publicly readable over HTTPS without a WebNR credential. The WebNR source does not request SpaceBattles during synchronization, does not use an account or API, and does not depend on forum pagination, filters, cookies, JavaScript, or rate-limit behavior. A reader choosing the result navigates to SpaceBattles under its own controls.
    Update/deletion: the 2026-09-07 audit verified the public board and current first-party terms. A moved, removed, or access-restricted destination will be corrected or downgraded through normal review rather than followed by a crawler or silently replaced.
 
-Candidates screened on 2026-09-07 but not admitted
----------------------------------------------------
+Candidate routes screened on 2026-09-07
+---------------------------------------
 - SpaceBattles Creative Library — useful first-party browsing surface for stories and quests, and current staff documentation describes it as a content-discovery interface. It is not added separately in this refresh because Story Ideas & Recommendations more directly answers the current reader task and avoids duplicating two routes from the same platform before usage value is demonstrated.
 - Sufficient Velocity Story Library — first-party public browsing surface for user-written stories. Deferred because the current source refresh is about recommendation/request routes; a later source can admit it only if the catalog role is distinct from existing fiction/discovery sources and its link-only reader value is demonstrated.
 - Sufficient Velocity Creative Discussion & Worldbuilding — public first-party creative discussion area. Deferred because its current purpose is broader creation/worldbuilding discussion rather than a dedicated reader recommendation queue.

--- a/public/sources/web-novel-discussion-radar-starter/README.txt
+++ b/public/sources/web-novel-discussion-radar-starter/README.txt
@@ -5,10 +5,10 @@ Purpose
 -------
 This WebNR-owned source is a monthly, reader-facing directory of public discussion routes for web-novel discovery. It is designed to answer “where are readers discussing this kind of recommendation question?” while keeping community posts, comments, account state, story text, ratings, votes, and platform-owned metadata on the originating service.
 
-Capability admitted on 2026-08-28
-----------------------------------
+Capability admitted on 2026-08-28; refreshed 2026-09-07
+-------------------------------------------------------
 - Native WebNR search_index.yml served from app.webnovel.win.
-- Seven WebNR-authored catalog entries covering five screened community/collection candidates: Royal Road Recommendations, r/ProgressionFantasy recommendation threads, r/litrpg monthly/recommendation threads, r/noveltranslations monthly recommendations, and Scribble Hub Forum discoverability discussions.
+- Nine WebNR-authored catalog entries covering seven screened community/collection candidates: Royal Road Recommendations, r/ProgressionFantasy recommendation threads, r/litrpg monthly/recommendation threads, r/noveltranslations monthly recommendations, Scribble Hub Forum discoverability discussions, SpaceBattles Story Ideas & Recommendations, and r/rational weekly request/recommendation threads.
 - Each entry stores only a first-party public destination URL, WebNR-authored title/description/tags, the observed/publication date used for the radar, and a link-only editorial license marker.
 - No remote post body, comment, username, vote count, story text, cover, rating, account state, or private/personal data is copied into the source.
 - No API credential, login cookie, crawler, CAPTCHA bypass, robots bypass, paid access, or background synchronization is used.
@@ -20,23 +20,38 @@ Screening and source-specific audit
    Access/runtime: HTTPS public reader pages; no credentials required for the admitted route. WebNR runtime fetches only this local YAML index, so Royal Road rate limits, pagination, cookies, JavaScript behavior, and transient forum availability never become synchronization dependencies.
    Update/deletion: monthly radar review re-checks the route and date context. Historical source changes remain recoverable in Git. A moved/deleted discussion is corrected through the normal PR lane rather than silently substituted.
 
-2. Reddit r/ProgressionFantasy, r/litrpg, and r/noveltranslations public discussion collections — admitted at bounded link-only editorial capability.
+2. Reddit r/ProgressionFantasy, r/litrpg, r/noveltranslations, and r/rational public discussion collections — admitted at bounded link-only editorial capability.
    Origin: public Reddit community pages, Reddit User Agreement effective 2026-07-01, and Reddit Data API Terms last revised 2026-07-20. The current source does not call Reddit APIs and does not register or impersonate an API client. It stores WebNR-authored labels and links to public threads only.
    Access/runtime: no Reddit request occurs when WebNR synchronizes the source. Readers choosing a result navigate to Reddit under Reddit’s own access controls. No pagination, rate-limit, OAuth, cookie, account, moderation, deletion, or API-response semantics are claimed by WebNR.
-   Update/deletion: each monthly sample is date-stamped. Future radar cycles can add new public routes through review while preserving earlier provenance in repository history.
+   Update/deletion: each sampled route is date-stamped. The 2026-09-07 refresh added that day’s r/rational Monday Request and Recommendation Thread after first-party public verification. Future radar cycles can add new public routes through review while preserving earlier provenance in repository history.
 
 3. Scribble Hub Forum discoverability discussion — admitted at bounded link-only editorial capability.
    Origin: Scribble Hub first-party Terms of Service updated 2026-06-29 and its public forum. The Terms describe user content as user-posted material and grant Scribble Hub service-scoped rights to host/display/distribute it. WebNR therefore keeps the discussion itself on Scribble Hub and stores only a WebNR-authored discovery label and first-party URL.
    Access/runtime: public HTTPS route observed during the audit; no account, API, cookie, feed, or credential is required for the WebNR source itself. WebNR sync remains a local-YAML operation.
    Update/deletion: monthly health review verifies that the public route still represents a useful discovery discussion; corrections use normal PR review.
 
+4. SpaceBattles Story Ideas & Recommendations — admitted on 2026-09-07 at bounded link-only editorial capability.
+   Origin: the first-party SpaceBattles forum exposes a dedicated Story Ideas & Recommendations board whose public description explicitly covers story recommendations, reviews, requests, workshop ideas, and story discussion. The current SpaceBattles Terms of Service state that user-generated content expresses its author’s views, that users retain copyright over submitted content, and that SpaceBattles receives the service license needed to publish or re-publish that content. WebNR therefore does not copy forum posts, usernames, reviews, thread statistics, or story text; it stores only a WebNR-authored label and the first-party board URL.
+   Access/runtime: the board is publicly readable over HTTPS without a WebNR credential. The WebNR source does not request SpaceBattles during synchronization, does not use an account or API, and does not depend on forum pagination, filters, cookies, JavaScript, or rate-limit behavior. A reader choosing the result navigates to SpaceBattles under its own controls.
+   Update/deletion: the 2026-09-07 audit verified the public board and current first-party terms. A moved, removed, or access-restricted destination will be corrected or downgraded through normal review rather than followed by a crawler or silently replaced.
+
+Candidates screened on 2026-09-07 but not admitted
+---------------------------------------------------
+- SpaceBattles Creative Library — useful first-party browsing surface for stories and quests, and current staff documentation describes it as a content-discovery interface. It is not added separately in this refresh because Story Ideas & Recommendations more directly answers the current reader task and avoids duplicating two routes from the same platform before usage value is demonstrated.
+- Sufficient Velocity Story Library — first-party public browsing surface for user-written stories. Deferred because the current source refresh is about recommendation/request routes; a later source can admit it only if the catalog role is distinct from existing fiction/discovery sources and its link-only reader value is demonstrated.
+- Sufficient Velocity Creative Discussion & Worldbuilding — public first-party creative discussion area. Deferred because its current purpose is broader creation/worldbuilding discussion rather than a dedicated reader recommendation queue.
+- Tapas Writing | Novels — publicly readable official forum category, and Tapas Terms of Service explicitly include the Tapas Forum while stating that users retain ownership of submitted content. Deferred because the category mixes writing questions, feedback, self-promotion, and reader requests; it is useful as an editorial research route but presently noisier than the admitted recommendation destinations.
+- r/rational Monday Request and Recommendation Thread — passed the existing Reddit platform audit and was admitted as the ninth route because the 2026-09-07 first-party thread has an explicit request/recommendation purpose and remains link-only; no Reddit API or copied user content is involved.
+
 Why this source is a native integration rather than a copied discussion feed
 --------------------------------------------------------------------------
 The WebNR repository interface currently consumes bounded search_index.yml catalogs. The audited platforms expose user discussions under platform-specific rights and access rules, while Reddit’s programmatic API carries its own registration/terms boundary. This source uses WebNR’s native catalog format to make community discovery searchable without importing community text. A future richer adapter requires a source-specific machine interface, explicit access/redistribution bounds, stable identity, pagination or cursor behavior where applicable, rate-limit/backoff rules, update/deletion semantics, response-size/timeout bounds, and versioned fixtures before promotion.
 
-Provenance and reproducible monthly sampling
---------------------------------------------
-The 2026-08 radar uses a fixed 2026-08-01 through 2026-08-28 observation window and a fixed community basket: Royal Road Recommendations/Debate, r/ProgressionFantasy, r/litrpg, r/noveltranslations, and Scribble Hub Forum. Query families include recommendations, finished/completed, audiobook, underrated/small authors, AI-assisted, slice of life, romance, and stat blocks. The source stores only a small set of representative reader routes; the companion research article explains sampling limits and treats public posts as examples of discussion structure rather than population estimates.
+Provenance and reproducible sampling
+------------------------------------
+The 2026-08 radar used a fixed 2026-08-01 through 2026-08-28 observation window and a fixed community basket: Royal Road Recommendations/Debate, r/ProgressionFantasy, r/litrpg, r/noveltranslations, and Scribble Hub Forum. Query families included recommendations, finished/completed, audiobook, underrated/small authors, AI-assisted, slice of life, romance, and stat blocks.
+
+The 2026-09-07 refresh re-checked that maintained basket and screened six additional public collection/routes for the next community slot: SpaceBattles Story Ideas & Recommendations, SpaceBattles Creative Library, Sufficient Velocity Story Library, Sufficient Velocity Creative Discussion & Worldbuilding, Tapas Writing | Novels, and the current r/rational Monday Request and Recommendation Thread. SpaceBattles Story Ideas & Recommendations and r/rational passed as bounded additions. The source still stores only a small set of representative reader routes; companion reader articles explain sampling limits and treat public posts as examples of discussion structure rather than population estimates.
 
 Compatibility and health
 ------------------------
@@ -46,8 +61,8 @@ Compatibility and health
 - Credentials: none.
 - External synchronization requests: none.
 - WebNR index size: intentionally tiny and far below the 5 MiB repository-index limit.
-- Last source-specific audit: 2026-08-28.
+- Last source-specific audit: 2026-09-07.
 
 Reader value
 ------------
-A user can add one WebNR repository URL, search phrases such as completed, audiobook, underrated, rankings, or translated novels, and jump to a public community route where that recommendation pattern is actively discussed. The local index supplies stable WebNR-owned discovery labels while the originating community retains the discussion and its governance.
+A user can add one WebNR repository URL, search phrases such as completed, audiobook, underrated, fic search, rational, rankings, or translated novels, and jump to a public community route where that recommendation pattern is discussed. The local index supplies stable WebNR-owned discovery labels while the originating community retains the discussion and its governance.

--- a/public/sources/web-novel-discussion-radar-starter/search_index.yml
+++ b/public/sources/web-novel-discussion-radar-starter/search_index.yml
@@ -123,3 +123,39 @@ scribble-hub-discoverability-202608:
   region: Global / English
   page_url: https://forum.scribblehub.com/threads/visibility-vs-recommendations-vs-rankings-which-platforms-approach-to-promoting-your-fiction-do-you-prefer.26416/
   license: Link-only-WebNR-editorial
+
+spacebattles-story-recommendations-202609:
+  title: SpaceBattles 故事推荐与 Fic Search — 2026 年 9 月
+  author: WebNR editorial
+  description: WebNR 记录的 SpaceBattles Story Ideas & Recommendations 第一方公开入口，适合 story recommendations、reviews、requests、fic search 与按 fandom 继续细分的讨论。
+  categories:
+    - Community discussion
+    - Fanfiction discovery
+  tags:
+    - SpaceBattles
+    - recommendations
+    - fic search
+    - fanfiction
+  date: '2026-09-07'
+  archived date: '2026-09-07'
+  region: Global / English
+  page_url: https://forums.spacebattles.com/forums/story-ideas-recommendations.63/
+  license: Link-only-WebNR-editorial
+
+rational-weekly-recommendations-20260907:
+  title: r/rational 周一请求与推荐线程 — 2026-09-07
+  author: WebNR editorial
+  description: WebNR 记录的当周 r/rational 第一方公开推荐线程，适合 rational / rational-adjacent、web serial、fanfiction 与其他窄条件的找书请求。
+  categories:
+    - Community discussion
+    - Reader recommendations
+  tags:
+    - r/rational
+    - recommendations
+    - web serial
+    - Reddit
+  date: '2026-09-07'
+  archived date: '2026-09-07'
+  region: Global / English
+  page_url: https://www.reddit.com/r/rational/comments/1w9syy3/d_monday_request_and_recommendation_thread/
+  license: Link-only-WebNR-editorial


### PR DESCRIPTION
## Why
The 2026-09-07 recurring editorial slot is the community/discussion slot. Current first-party verification also found two useful bounded recommendation routes that fit the existing Web Novel Discussion Radar without introducing a new source family or copying community content.

## Scope
- add one reader-facing guide answering where to ask different kinds of English web-fiction recommendation questions;
- extend the existing Discussion Radar catalog with two link-only routes: SpaceBattles Story Ideas & Recommendations and the 2026-09-07 r/rational Monday Request and Recommendation Thread;
- refresh the source README with the current platform audit, six screened candidate routes, deferrals, and unchanged no-copy/no-API runtime boundary.

## Evidence
First-party/public checks on 2026-09-07 covered Royal Road Recommendations, SpaceBattles Story Ideas & Recommendations plus SpaceBattles terms, the current r/rational recommendation thread plus Reddit User Agreement/Data API Terms, Sufficient Velocity public library/creative surfaces and rules/help, and Tapas Writing | Novels plus Tapas Terms of Service.

## Preserved behavior
No existing source entry, route, canonical, redirect, analytics setting, reader runtime, Legado behavior, navigation structure, or copied third-party content is removed or broadened. The source remains a local WebNR YAML catalog containing only WebNR-authored labels and first-party public links. GA4/full-URL behavior remains untouched.

## Validation
Expected repository Quality gate: Web quality, Documentation quality, Production evidence, and Chromium user journeys. The documentation build must include the new stable blog URL in static output/sitemap/canonical output, and the application build must include both added catalog entries. Final review will restart only after all expected checks are green.

## Production acceptance
After exact-head squash merge, verify the application and documentation deployments attributable to the squash commit; verify the new guide on `https://www.webnovel.win/`, the Discussion Radar source on `https://app.webnovel.win/`, representative existing docs/reader behavior, sitemap/canonical output, and unchanged GA4 full-URL assertions.

## Risk / rollback
Low and bounded to one new documentation page plus two link-only catalog rows and their audit documentation. Roll back by reverting the squash commit if build, source validation, public routing, or deployment evidence fails.