### PR TITLE
feat: add Bokselskap Norwegian literature discovery source

### DIFF
--- a/.github/seo-data/daily/2026-09-08.md
+++ b/.github/seo-data/daily/2026-09-08.md
@@ -1,0 +1,90 @@
+# WebNR daily operating record — 2026-09-08
+
+## Baseline and instruction sync
+
+- The cycle began from exact default-branch commit `2c7808caafd6d147e8e4895b10fb5e8dbf540363` after checking the current remote `main` and active pull requests. No WebNR `seo/` automation pull request was open. Dependabot pull requests #135 and #138 remain contributor-owned dependency work and were not taken over.
+- `.github/seo-skills` remains pinned at `f42128a3f05c73cf10c786a2711c488bb3a14839`. The configured upstream `AutoArchive/seo-skill` `main` was independently checked and still points to exactly the same commit, so there is no compatible submodule pointer update to carry this cycle.
+- The latest completed default-branch Quality run before this cycle is `34147500336` for `2c7808caafd6d147e8e4895b10fb5e8dbf540363`; it completed successfully.
+
+## Data-analysis pass
+
+### Windows and evidence quality
+
+- Site timezone: `America/Los_Angeles`; configured provider finalization lag: three days.
+- Finalized watermark for this cycle: 2026-09-05.
+- Comparable finalized 7-day windows, if provider exports become available: 2026-08-30..2026-09-05 versus 2026-08-23..2026-08-29.
+- Comparable finalized 28-day windows, if provider exports become available: 2026-08-09..2026-09-05 versus 2026-07-12..2026-08-08.
+- The configured Google Drive folder `webNR SEO Weekly CSV` was resolved, but it contains no matching GA4 or Search Console export files. Traffic, landing-page, query, CTR, position, device, country, and indexing trends are therefore unavailable rather than zero and cannot be compared for the finalized windows.
+- The Cloudflare analytics connection is present, but the credential spans multiple accounts and the exact account scope for `webnovel.win` cannot be selected safely from the current non-interactive connector context without guessing an account ID. Cloudflare request/visit analytics are therefore unavailable rather than zero. No Cloudflare configuration was changed.
+- Repository-native delivery evidence remains available: current default-branch Quality is green, the recorded application/documentation production identities remain attributable, and no new CI or deployment failure was observed before selecting this cycle's routine work.
+
+### Content and search findings
+
+- The substantial reader guide published on 2026-09-07 remains inside the rolling 48-hour reader-publication window. No cadence-only article is due on 2026-09-08, so this cycle does not create filler content or disturb the curated Blog/landing shell.
+- Without current GA4 or Search Console exports there is no evidence for a keyword-driven rewrite, new query-target page, canonical migration, or navigation change. Existing reader-first routes and stable URLs are preserved.
+- A bounded read-only off-site visibility sample using the canonical domain, WebNR brand variants, and the exact recent recommendation-guide title found no verified independent external WebNR link or citation. Search results mainly surfaced WebNR-controlled pages and unrelated web-novel products. This is a bounded sampled observation, not a claim that no mention or backlink exists anywhere. No outreach, account action, directory submission, backlink request, or automated community posting was performed.
+
+### Product and production decision
+
+- Technical decision: no reproducible product, build, deployment, analytics-implementation, redirect, canonical, sitemap, or primary-flow defect was confirmed from the available repository and public evidence at selection time. Preserve the current GA4 destination `G-DGH8HNQKE4`, full-URL reporting including query strings, and disabled Google signals/ad-personalization signals.
+- Search decision: make no speculative search-facing change while provider query/page evidence is unavailable.
+- Measurement decision: preserve the current implementation and record GA4, Search Console, and Cloudflare provider gaps exactly as unavailable rather than zero.
+
+## Daily source discovery — five new candidates
+
+The repository history was checked for exact candidate names before counting them as new to this program. Five candidates not previously recorded under those names were discovered:
+
+1. **Bokselskap** (`bokselskap.no`) — Norwegian digital-literature portal developed by Det norske språk- og litteraturselskap in cooperation with the National Library of Norway. It exposes first-party catalog/author/download routes and documents OPDS. Fully audited below and selected for a bounded link-only integration.
+2. **Ebooks libres et gratuits** — French-language ebook collection with a first-party OPDS catalog and several download formats. Fully audited below; deferred because the collection includes both rights-free works and contemporary-author exceptions, so a blanket acquisition adapter would require item-level rights/jurisdiction handling.
+3. **textos.info** — Spanish-language open digital library with online/PDF/EPUB/Kindle access and an OPDS route. Fully audited below; deferred because public-domain, Creative Commons/copyleft, specifically authorized, and user-published works share the same broader service and require per-item provenance/license preservation.
+4. **Беларуская Палічка / Knihi.com** — Belarusian electronic library whose first-party reader page publishes an OPDS URL. Candidate discovery passed, but a full rights/access/runtime audit has not yet been completed, so no adapter or source claim is made this cycle.
+5. **Biblioteca Digital Hispánica / Biblioteca Nacional de España structured public-domain data** — current BNE/BNElab discovery exposed structured historical/public-domain collection data and TXT-capable datasets. Candidate discovery passed; exact collection scope, rights fields, stable item identity, transport, and browser/runtime behavior still require a source-specific full audit before admission.
+
+The result satisfies the daily discovery floor without recycling Gallica, Litteraturbanken, Cervantes Virtual, or other candidates already present in earlier WebNR records.
+
+## Full source audits
+
+### Bokselskap — pass at link-only discovery capability
+
+- Origin/maintainer: first-party Bokselskap, developed by Det norske språk- og litteraturselskap (NSL) in cooperation with the National Library of Norway.
+- Reader value: the first-party site presents more than 400 Norwegian literary works and exposes stable catalog, author, reading/download, and OPDS guidance. The author directory provides a useful route into Norwegian classics and complements the current maintained source set.
+- Formats/interface: Bokselskap documents online reading plus EPUB, MOBI, HTML, PDF and OPDS for many ebooks. This cycle does **not** claim that WebNR parses the EPUB/OPDS material.
+- Rights: Bokselskap states that it mainly publishes authors dead for at least 70 years or works published with rightsholder authorization, but separately warns that digital/critical editions, introductions, and editorial work can carry their own copyright. Its site material is generally offered for private non-commercial use and broader reuse may require written agreement.
+- Runtime boundary selected: WebNR stores only three first-party navigation destinations plus WebNR-authored labels/descriptions. It does not copy catalog rows, book text, ebooks, covers, biographies, introductions, editorial apparatus, or OPDS entries and makes no background origin request.
+- Browser/network boundary: because the admitted capability is link-only, no WebNR runtime depends on Bokselskap CORS, robots, pagination, response size, cookies, login, feed cadence, or ebook parsing. A future richer adapter requires an exact endpoint/rights/transport/update/deletion/fixture audit.
+- Decision: **integrate** as `Bokselskap Norwegian Literature Discovery Starter`, bounded to catalog/home, author directory, and download/OPDS-guidance routes.
+
+### Ebooks libres et gratuits — defer direct/OPDS integration
+
+- Origin: first-party French ebook project with a public catalog, multiple ebook formats, and a documented OPDS endpoint.
+- Reader value: broad French-language classic/free-ebook discovery and machine-readable catalog access are potentially useful.
+- Rights finding: the project describes its primary mission around rights-free texts but also explicitly carries contemporary-author exceptions and item/jurisdiction-specific warnings. Non-commercial use language does not justify treating the whole catalog as unrestricted public-domain redistribution.
+- Runtime finding: an OPDS adapter would need to preserve work-level rights, jurisdiction warnings, format/acquisition semantics, pagination, update/deletion behavior, transport limits, and provenance through versioned fixtures.
+- Decision: **defer** blanket integration. Revisit only as a curated rights-explicit subset or an adapter that retains item-level rights/provenance without broadening the source's permission boundary.
+
+### textos.info — defer blanket integration
+
+- Origin: first-party Spanish-language digital library with online reading, common ebook formats, and an OPDS discovery route.
+- Reader value: useful Spanish-language discovery and a potentially rich machine-readable catalog.
+- Rights finding: the site's own explanation distinguishes public-domain works, Creative Commons/copyleft works, specifically authorized works, and other contributed material. A service-wide “free” label is therefore not sufficient evidence for uniform redistribution rights.
+- Runtime finding: a safe adapter needs item-level license/provenance retention, stable item identity, feed/acquisition semantics, pagination, update/deletion rules, browser transport evidence, and explicit fixtures.
+- Decision: **defer** blanket integration and preserve it as a candidate for a rights-explicit curated subset or provenance-preserving OPDS adapter.
+
+## Rotating maintained-source health checks
+
+- **Folger Shakespeare TXT Starter:** current first-party Folger play/download surfaces for representative admitted works remain reachable. Folger still exposes its free non-commercial TXT and other machine-readable download formats. The admitted direct-TXT model and current CC BY-NC boundary remain consistent with the maintained source; no downgrade or repair is required.
+- **Project Gutenberg Starter:** the first-party `Pride and Prejudice` ebook page remains reachable, identifies the work as public domain in the USA, and continues to expose plain-text download options. The maintained discovery capability remains healthy.
+- **Aozora Bunko Starter:** representative official Aozora book-card pages remain reachable with current work/author metadata and first-party reading/download routes. The maintained link-only discovery capability remains healthy.
+
+No reproducible failure in the rotating sample requires removal, downgrade, or replacement. Source-health checks are capability-specific rather than an assertion that every origin file or route was exhaustively tested.
+
+## Decisions and delivery scope
+
+- **Technical:** no confirmed repair required; preserve current production and analytics semantics.
+- **Content:** keep the 2026-09-07 substantial guide as the active rolling-48-hour asset; do not publish filler on 2026-09-08.
+- **Source:** integrate Bokselskap at link-only capability; defer Ebooks libres et gratuits and textos.info pending item-level rights/provenance modeling; keep Knihi.com and BNE structured-data candidates in the research queue until full audits are complete.
+- **Search:** no speculative change without finalized Search Console evidence.
+- **Community/off-site:** no verified independent external mention in the bounded sample; continue read-only observation and do not automate promotion.
+- **Measurement:** GA4/GSC exports and safely scoped Cloudflare traffic metrics remain unavailable, not zero.
+
+The source implementation is intentionally limited to `public/sources/bokselskap-norwegian-literature-discovery-starter/` plus this public-safe operating record. It does not change reader code, Legado capability, analytics, navigation, existing source boundaries, or deployment configuration. Exact PR, CI, squash-merge, deployment, public-verification, and closeout evidence will be appended only after those facts exist.

--- a/public/sources/bokselskap-norwegian-literature-discovery-starter/README.txt
+++ b/public/sources/bokselskap-norwegian-literature-discovery-starter/README.txt
@@ -1,0 +1,80 @@
+Bokselskap Norwegian Literature Discovery Starter
+=================================================
+
+Repository URL
+--------------
+https://app.webnovel.win/sources/bokselskap-norwegian-literature-discovery-starter
+
+One-click add URL
+-----------------
+https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fbokselskap-norwegian-literature-discovery-starter
+
+Purpose
+-------
+This WebNR-maintained source is a small link-only discovery directory for
+Bokselskap, the Norwegian ebook portal developed by Det norske språk- og
+litteraturselskap (NSL) in cooperation with the National Library of Norway. It
+helps readers reach the official Norwegian-classics catalog, author directory,
+and download/OPDS guidance while leaving reading and every ebook file at the
+first-party site.
+
+Origin identity and reader value
+--------------------------------
+Bokselskap describes itself as a digital library created to preserve Norwegian
+literature and currently presents more than 400 books across novels, short
+stories, plays, poetry, travel writing, letters, diaries, and other genres. Its
+first-party author directory includes writers such as Henrik Ibsen, Camilla
+Collett, Arne Garborg, Amalie Skram, Ragnhild Jølsen, Laura Kieler, and Sigrid
+Undset. The site provides online reading and downloadable EPUB, MOBI, HTML, and
+PDF editions, and documents an OPDS catalog for many EPUB files.
+
+The three entries in this starter are deliberately navigation records rather than
+copies of the origin catalog:
+
+- the Bokselskap home/catalog route for browsing Norwegian classics;
+- the first-party author directory;
+- the first-party download page, which also links to Bokselskap's OPDS guidance.
+
+Rights and reuse boundary
+-------------------------
+Bokselskap states that it mainly publishes texts whose authors have been dead for
+at least 70 years, or texts for which the rights holder has authorized
+publication. The same policy warns that a public-domain underlying work can still
+carry edition-specific rights when an editorial philologist constitutes the text,
+and that introductions and other editorial material can have separate copyright.
+It generally permits site material for private, non-commercial use and asks that
+other reuse be agreed in writing with Bokselskap/the publisher.
+
+WebNR therefore does not mirror Bokselskap text, EPUB/MOBI/PDF/HTML files, OPDS
+entries, covers, introductions, editorial apparatus, biographies, or catalog
+metadata. This starter stores only first-party destination URLs plus short
+WebNR-authored labels and descriptions. Work- and edition-specific rights remain
+at the origin.
+
+Current WebNR behavior
+----------------------
+Selecting an item opens its official Bokselskap page. WebNR performs no runtime
+OPDS, HTML, XML, EPUB, search-result, catalog, or chapter polling for this starter.
+It does not proxy downloads, automate accounts, send credentials or cookies,
+extract TEI/XML, or follow the site's OPDS acquisition links in the background.
+The existing WebNR reader still imports local or supported direct text separately;
+this source makes no claim that WebNR can currently parse Bokselskap EPUB files.
+
+Audit boundary and future upgrade
+---------------------------------
+The public landing pages, download guidance, OPDS documentation, and published
+rights/reuse statement were reviewed on 2026-09-08. Because the admitted runtime
+is link-only, robots behavior, CORS, request cadence, pagination, response-size
+limits, feed parsing, and ebook acquisition are outside this source's current
+runtime dependency: WebNR does not make those automated requests.
+
+A future OPDS or ebook adapter would require a separate audit of the exact
+machine-readable endpoint, HTTPS behavior, robots/access policy, pagination,
+update/deletion semantics, timeouts, response-size ceilings, provenance,
+attribution, edition-level rights, and WebNR's EPUB support, backed by versioned
+fixtures. It must not infer that an underlying public-domain author makes every
+Bokselskap digital edition unrestricted for redistribution.
+
+Last verified
+-------------
+2026-09-08

--- a/public/sources/bokselskap-norwegian-literature-discovery-starter/search_index.yml
+++ b/public/sources/bokselskap-norwegian-literature-discovery-starter/search_index.yml
@@ -1,0 +1,50 @@
+bokselskap-norwegian-literature/catalog.md:
+  title: Bokselskap — 挪威经典文学官方目录
+  author: Det norske språk- og litteraturselskap (NSL)
+  description: Bokselskap 与挪威国家图书馆合作维护的官方电子书入口，提供 400 多部挪威文学作品的在线阅读与下载发现。WebNR 只保存第一方入口和自写说明，不复制作品正文、电子书文件、目录数据或编辑材料。
+  page_url: https://www.bokselskap.no/
+  source: WebNR Bokselskap Norwegian Literature Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Bokselskap
+    - Norwegian literature
+    - 挪威文学
+    - classics
+    - official library
+  categories:
+    - Official literature discovery
+  region: nb-NO
+
+bokselskap-norwegian-literature/authors.md:
+  title: Bokselskap — 挪威作家官方索引
+  author: Det norske språk- og litteraturselskap (NSL)
+  description: Bokselskap 的第一方作者目录，可从 Henrik Ibsen、Camilla Collett、Arne Garborg、Amalie Skram、Ragnhild Jølsen、Sigrid Undset 等作者继续进入作品。WebNR 不抓取作者简介、作品列表或站点目录，只提供稳定发现入口。
+  page_url: https://www.bokselskap.no/forfattere
+  source: WebNR Bokselskap Norwegian Literature Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Bokselskap
+    - Norwegian authors
+    - 挪威作家
+    - classics
+    - discovery
+  categories:
+    - Official literature discovery
+  region: nb-NO
+
+bokselskap-norwegian-literature/downloads.md:
+  title: Bokselskap — 官方电子书下载与 OPDS 指南
+  author: Det norske språk- og litteraturselskap (NSL)
+  description: Bokselskap 的第一方下载页列出 EPUB、MOBI、PDF、HTML 等可用格式，并指向其 OPDS 使用说明。WebNR 当前只链接该指南，不自动读取 OPDS、下载电子书或把原站文件重新分发为 WebNR 内容源。
+  page_url: https://www.bokselskap.no/hjelp_om/nedlastingsside
+  source: WebNR Bokselskap Norwegian Literature Discovery Directory
+  license: Link-only-WebNR-editorial
+  tags:
+    - Bokselskap
+    - OPDS
+    - EPUB
+    - Norwegian literature
+    - download guide
+  categories:
+    - Official literature discovery
+  region: nb-NO


### PR DESCRIPTION
## Outcome

Add one bounded, reader-useful Norwegian literature discovery source after the 2026-09-08 operating analysis.

## Scope

- add `Bokselskap Norwegian Literature Discovery Starter` with three first-party link-only routes: catalog/home, author directory, and download/OPDS guidance;
- preserve Bokselskap/edition-specific rights boundaries and avoid copying catalog rows, book text, ebook files, editorial apparatus, biographies, or OPDS entries;
- record the daily data-analysis pass, five newly discovered candidate sources, three full audits, rotating source-health checks, and explicit technical/content/source/search/community/measurement decisions.

## Preserved behavior

No reader code, Legado capability, analytics, navigation, deployment configuration, or existing source definition changes. GA4 remains `G-DGH8HNQKE4` with full-URL reporting and the existing privacy settings. The link-only source performs no background request to Bokselskap.

## Validation and acceptance

Expected repository Quality gates must all succeed. After CI, the complete PR will be reviewed again from scratch. If merged, the exact squash commit must be attributable in the application production build and the source YAML must be publicly available at the application source route before closeout.

## Risk and rollback

Risk is limited to an additive source catalog and public-safe operating record. Rollback is removal of this source family through the normal PR lifecycle; no origin content is mirrored or cached by this change.