### PR TITLE
Refresh translated-fiction recommendation route

### DIFF
--- a/.github/seo-data/daily/2026-09-10.md
+++ b/.github/seo-data/daily/2026-09-10.md
@@ -1,0 +1,106 @@
+# WebNR daily operation — 2026-09-10
+
+## Baseline and repository state
+
+This cycle resumed and completed the existing WebNR automation closeout before starting new work. Pull request #160 was the only open WebNR automation PR; contributor-owned Dependabot pull requests were not taken over. Its first production-evidence run had already proved that the canonical Cloudflare documentation build had advanced to the same source commit as the September 9 reader/source release, while the closeout metadata still expected the prior canonical identity. The verifier was preserved unchanged. The closeout branch corrected only the operating records, reran all expected Quality jobs successfully, received a fresh from-scratch final review on exact head `010f160a12187a62ae0a6794ad9b9e785333707f`, and was exact-head squash merged as `23dcf75af391b3440a493a1441419a126349b060`.
+
+The September 10 operating branch starts from that exact current `main` commit. The pinned `.github/seo-skills` submodule remains `f42128a3f05c73cf10c786a2711c488bb3a14839`; the upstream `AutoArchive/seo-skill` default branch resolves to exactly the same commit, so no submodule movement is warranted. Repository instructions, `daily-task.md`, `site.md`, `plan.md`, `editorial-calendar.md`, `data-analysis.md`, `promotion.md`, `status.md`, `block.md`, the latest daily record, and the applicable pinned operating, analytics, evidence-collection, and delivery skills were re-read before the new change. No `autoaction.md` is present, so this source refresh remains in the normal pull-request lane.
+
+## Evidence and data refresh
+
+### Finalized windows
+
+With the configured three-day finalization lag, the newest finalized watermark is **2026-09-07**. The comparable windows are:
+
+- 7-day: **2026-09-01 through 2026-09-07** versus **2026-08-25 through 2026-08-31**;
+- 28-day: **2026-08-11 through 2026-09-07** versus **2026-07-14 through 2026-08-10**.
+
+The configured connected Google Drive folder `webNR SEO Weekly CSV` was resolved exactly and contained no non-trashed files. No matching GA4 or Search Console export can therefore be scored for either window. These provider aggregates are **unavailable, not zero**; no traffic, CTR, ranking, conversion, or query trend is inferred from missing exports.
+
+Cloudflare request analytics remain unavailable through the connected analytics path. The credential spans multiple accounts and the connector requires an explicit account scope before listing the configured `webnovel.win` zone. This cycle did not guess or persist an account ID. That does not weaken exact production evidence: the repository production verifier independently checks public build identities.
+
+### Runtime analytics and production baseline
+
+The source analytics contract remains unchanged: GA4 measurement `G-DGH8HNQKE4`, full browser URL reporting including query parameters, `page_path` including pathname plus search, with Google signals and ad-personalization signals disabled. The canonical documentation surface and reader application were both reachable during the bounded public check, and their reader-facing product positioning remained the expected compact documentation/home surface and local-first no-login TXT/URL reader respectively. No analytics-removal, canonical-ownership, landing-shell, primary-flow, or public-runtime defect was reproduced.
+
+The canonical deployment identity established during #160 is source commit `91ecc4a0cf9aa9697726bac3f6316cef799e64cc` for the application, documentation mirror, and canonical Cloudflare documentation build. The #160 rerun passed Production evidence, Web quality, Documentation quality, and Chromium user journeys before closeout merge. Because #160 changed only `.github/seo-data/**`, it did not manufacture a new rendered deployment.
+
+### Off-site visibility patrol
+
+A bounded brand/domain and recent-publication search rechecked the previously verified independent `eliteai.tools` WebNR detail page. It still contains an actual outbound link to `https://www.webnovel.win/`, so it remains a **verified external link** rather than a search-only mention. Its description still says WebNR has “no tracking or analytics,” which is stale relative to WebNR's current explicit GA4 disclosure. The page also contains broader third-party product descriptions that are not treated as WebNR-authored claims. This is an external mischaracterization, not a site-owned technical defect. Repository policy does not authorize automated outreach or third-party edits, so no mutation was attempted.
+
+No independent external citation for the September 9 reader guide was verified in the bounded sample. Search-index absence in a small sample is not recorded as zero visibility.
+
+## Technical decision
+
+No new reproducible application, documentation, build, canonical, redirect, analytics, source-output, accessibility, dependency, or primary-reader-flow defect was found after the #160 correction. The cycle therefore proceeds with the smallest source-health improvement supported by current evidence rather than manufacturing another technical change.
+
+## Source discovery, audits, integration, and health
+
+Repository history was checked before counting the candidates below. Five route/collection candidates not previously recorded under these exact September 10 candidate identities were screened:
+
+1. **r/noveltranslations Monthly Recommendation Thread — September 09, 2026** — `https://www.reddit.com/r/noveltranslations/comments/1wbtmgy/monthly_recommendation_thread_september_09_2026/`
+2. **Royal Road “I forgot the title...” subforum** — `https://www.royalroad.com/forums/5852`
+3. **Royal Road “What are your top 5 Fictions in Royal Road?”** — `https://www.royalroad.com/forums/thread/175989`
+4. **Scribble Hub “I'm looking for a forgotten novel.”** — `https://forum.scribblehub.com/threads/im-looking-for-a-forgotten-novel.9953/`
+5. **r/OtomeIsekai “What are you currently reading?” — 2026-09-06** — `https://www.reddit.com/r/OtomeIsekai/comments/1w90fcs/what_are_you_currently_reading/`
+
+### Full audit: r/noveltranslations September recommendation thread — PASS and integrated as a freshness replacement
+
+Origin and reader task: the current first-party monthly recommendation thread was published on 2026-09-09. Its rules concentrate suggestion requests in one thread, require suggestions to be replies to requests, explicitly reject aggregator/piracy-site requests, and encourage readers to describe protagonist, setting, plot, atmosphere, theme, comparable works, genre, length, and reading level. It is the current representative route for the translated-fiction recommendation task already present in Discussion Radar.
+
+Rights/access boundary: the existing Reddit platform audit remains applicable. WebNR does not invoke the Reddit Data API, authenticate, copy post bodies, comments, usernames, votes, moderation state, or account data. The source stores only one first-party public URL plus WebNR-authored title, description, tags, date, and link-only editorial marker.
+
+Runtime/update behavior: WebNR source synchronization reads local YAML only. There is no Reddit pagination, OAuth, rate-limit, deletion, or response-schema dependency. Because this is a recurring monthly route family, the smallest useful integration is to refresh the existing August representative row to the current September thread rather than accumulating one near-duplicate row per month. Repository history retains the prior August route.
+
+Decision: **PASS; integrated** by replacing `noveltranslations-monthly-recs-202608` with `noveltranslations-monthly-recs-202609`. The Discussion Radar remains ten intentionally small representative routes.
+
+### Full audit: Royal Road “I forgot the title...” — PASS at link-only capability; defer admission
+
+Origin and purpose: Royal Road's first-party Fictions forum exposes a stable `I forgot the title...` subforum whose public description is specifically for readers needing help finding a story they read before. It was active during the 2026-09-10 check and represents a distinct “identify a forgotten story” task rather than a generic recommendation list.
+
+Rights/access boundary: Royal Road's Terms of Service were last updated **2026-09-01**. They state that content can be read without signing up, reserve platform/content rights, preserve user ownership of user-uploaded content, and prohibit unauthorized scraping/crawling/bot access and competitive copying. WebNR therefore does not scrape, mirror, copy user posts, user identities, story text, reply counts, or platform metadata. A future admission would be only a WebNR-authored link label pointing to the stable first-party subforum.
+
+Runtime/update behavior: at link-only capability, WebNR would perform no Royal Road request during source synchronization; readers navigate to Royal Road under its own controls. No cookies, account, API, scraping, pagination, or background polling are required.
+
+Decision: **PASS at bounded link-only capability, deferred from today's catalog change.** The route adds a genuinely different reader task, but introducing that new task is a taxonomy expansion. Today's smaller coherent change is the already-maintained monthly translated-recommendation freshness replacement. Retain the stable subforum as the strongest candidate for a later distinct-task Discussion Radar update.
+
+### Full audit: Royal Road “What are your top 5 Fictions in Royal Road?” — accessible/linkable; defer as duplicate recommendation semantics
+
+Origin and purpose: this first-party Recommendations thread began on 2026-09-03 and remained active on 2026-09-10. Its opening question asks readers for their personal top Royal Road fictions and explicitly explores variation between personal favorites. It is useful as a current editorial listening sample, not as a population ranking.
+
+Rights/access/runtime: the same 2026-09-01 Royal Road Terms boundary applies. WebNR may link to the public thread but must not copy or transform user lists, names, counts, story metadata, or discussion text into a competing catalog; no scraper, bot, account, or synchronization request is introduced.
+
+Decision: **defer.** The stable Royal Road Recommendations board already covers “give/ask recommendations and personal favorites,” so another catalog row for one favorites thread would duplicate route semantics. Reply/view counts are not treated as popularity evidence.
+
+### Screened candidates
+
+- **Scribble Hub “I'm looking for a forgotten novel.”** demonstrates the same forgotten-title reader need on another first-party public forum, but it is a single 2022 thread rather than a stable category. It is retained as evidence that the task exists across platforms, not admitted as a maintained route. The existing Scribble Hub link-only boundary remains unchanged.
+- **r/OtomeIsekai “What are you currently reading?”** is a current public reader-discussion thread and may be useful for adjacent translated-story discovery, but its basket spans manga/manhwa and other media beyond WebNR's core web-fiction route. It is deferred rather than broadening the source taxonomy from one small sample.
+
+This satisfies the cycle floor of five discovered candidates, three full audits, and at least one passing integration attempt without lowering rights/access/runtime requirements.
+
+### Rotating maintained-source health checks
+
+- **Royal Road Recommendations** remained publicly reachable on 2026-09-10, continued to describe itself as the place for recommendation requests and personal favorites, and had current active threads. Its maintained link-only role remains valid.
+- **Project Gutenberg** retained live public-domain book pages and plain-text acquisition on the sampled public title route. No source capability change was indicated.
+- **Standard Ebooks** retained its public catalog and free/open public-domain ebook positioning on the sampled discovery surface. No reproducible source failure required downgrade or removal.
+
+No maintained source sampled today required deletion, downgrade, or emergency replacement.
+
+## Reader-content, search, community, and measurement decisions
+
+The substantial September 9 current-reading guide remains inside the rolling 48-hour publication window during this September 10 cycle. The repository explicitly says not to manufacture cadence-only filler, so **no new reader article is published today**. The September 9 guide, curated Blog structure, stable canonical URLs, and existing internal routes remain unchanged.
+
+- **Search:** preserve the current stable reader URLs and product-first/curated information architecture; there is insufficient finalized provider evidence for a new search-facing experiment.
+- **Community:** refresh only the stale representative r/noveltranslations monthly route. Keep the Royal Road forgotten-title route as a later distinct-task candidate; do not convert one favorites thread or one adjacent-media sample into a popularity claim.
+- **Promotion:** observe the verified independent external link and stale third-party description only; no unauthorized posting, account creation, outreach, directory submission, or third-party mutation.
+- **Measurement:** preserve the current GA4 implementation and full-URL policy. GA4/GSC exports and Cloudflare request analytics remain unavailable rather than zero.
+
+## Delivery plan and rollback
+
+The coherent September 10 repository change is intentionally narrow: refresh one already-maintained Discussion Radar monthly route from its August representative to the current September r/noveltranslations thread, update its source audit/freshness documentation, and record this operating cycle. No reader article, design, analytics, canonical, route layout, Legado behavior, source-family count, or unrelated source row is changed.
+
+Expected pull-request Quality jobs are Web quality, Documentation quality, Production evidence, and Chromium user journeys. The source catalog is part of reader application public output, so after exact-head squash merge the application deployment for the exact merge commit must succeed and the deployed source output must contain `noveltranslations-monthly-recs-202609`. Representative unaffected checks include the other nine Discussion Radar entries and unchanged reader/analytics behavior. The rollback point is the eventual squash commit for this source refresh if validation, deployment identity, source output, or public acceptance fails.
+
+Exact PR, CI, review, squash, deployment, and public acceptance identities remain pending until the delivery lifecycle completes and will be recorded through the normal metadata-only closeout rather than predicted here.

--- a/public/sources/web-novel-discussion-radar-starter/README.txt
+++ b/public/sources/web-novel-discussion-radar-starter/README.txt
@@ -5,7 +5,7 @@ Purpose
 -------
 This WebNR-owned source is a monthly, reader-facing directory of public discussion routes for web-novel discovery. It is designed to answer “where are readers discussing this kind of recommendation question?” while keeping community posts, comments, account state, story text, ratings, votes, and platform-owned metadata on the originating service.
 
-Capability admitted on 2026-08-28; refreshed 2026-09-09
+Capability admitted on 2026-08-28; refreshed 2026-09-10
 -------------------------------------------------------
 - Native WebNR search_index.yml served from app.webnovel.win.
 - Ten WebNR-authored catalog entries covering eight screened community/collection candidates: Royal Road Recommendations, r/ProgressionFantasy recommendation threads, r/litrpg monthly/recommendation threads, r/noveltranslations monthly recommendations, Scribble Hub Forum discoverability discussions, SpaceBattles Story Ideas & Recommendations, r/rational weekly request/recommendation threads, and r/Fantasy daily recommendation threads.
@@ -23,7 +23,7 @@ Screening and source-specific audit
 2. Reddit r/ProgressionFantasy, r/litrpg, r/noveltranslations, r/rational, and r/Fantasy public discussion collections — admitted at bounded link-only editorial capability.
    Origin: public Reddit community pages, Reddit User Agreement effective 2026-07-01, and Reddit Data API Terms last revised 2026-07-20. The current source does not call Reddit APIs and does not register or impersonate an API client. It stores WebNR-authored labels and links to public threads only.
    Access/runtime: no Reddit request occurs when WebNR synchronizes the source. Readers choosing a result navigate to Reddit under Reddit’s own access controls. No pagination, rate-limit, OAuth, cookie, account, moderation, deletion, or API-response semantics are claimed by WebNR.
-   Update/deletion: each sampled route is date-stamped. The 2026-09-07 refresh added that day’s r/rational Monday Request and Recommendation Thread. The 2026-09-09 refresh added that day’s r/Fantasy Daily Recommendations and Simple Questions Thread after public first-party verification. Future radar cycles can add new public routes through review while preserving earlier provenance in repository history.
+   Update/deletion: each sampled route is date-stamped. The 2026-09-07 refresh added that day’s r/rational Monday Request and Recommendation Thread. The 2026-09-09 refresh added that day’s r/Fantasy Daily Recommendations and Simple Questions Thread after public first-party verification. The 2026-09-10 refresh replaced the August representative r/noveltranslations monthly recommendation route with the current 2026-09-09 thread rather than accumulating duplicate monthly rows. Future radar cycles can refresh or add public routes through review while preserving earlier provenance in repository history.
 
 3. Scribble Hub Forum discoverability discussion — admitted at bounded link-only editorial capability.
    Origin: Scribble Hub first-party Terms of Service updated 2026-06-29 and its public forum. The Terms describe user content as user-posted material and grant Scribble Hub service-scoped rights to host/display/distribute it. WebNR therefore keeps the discussion itself on Scribble Hub and stores only a WebNR-authored discovery label and first-party URL.
@@ -40,6 +40,12 @@ Screening and source-specific audit
    Reader value: this route is intentionally broader than WebNR-specific or Progression Fantasy communities. It provides a useful cross-platform fallback when a reader’s request spans web serials, ebooks, audiobooks, series, and traditionally published fantasy rather than one source platform.
    Access/runtime: the admitted WebNR capability is one date-stamped first-party link plus WebNR-authored metadata. WebNR makes no Reddit API request, copies no post/comment/user data, and makes no claim about vote counts, community consensus, or recommendation quality.
    Update/deletion: daily threads are ephemeral by design, so the catalog records the exact 2026-09-09 observed thread and date. Later radar refreshes may add or replace a current representative route through normal review without inventing a permanent API or feed.
+
+6. r/noveltranslations Monthly Recommendation Thread — current representative refreshed on 2026-09-10 at bounded link-only editorial capability.
+   Origin: the first-party 2026-09-09 monthly thread concentrates recommendation requests and direct replies, asks readers to describe the kind of book sought, and explicitly disallows requests for aggregator or pirate sites. The same current Reddit User Agreement and Data API Terms boundary applies.
+   Reader value: this is the current monthly representative for translated-novel recommendation requests already covered by the Discussion Radar. Refreshing the representative thread improves freshness without creating one catalog row for every month.
+   Access/runtime: WebNR stores only the current first-party public URL and WebNR-authored metadata. No Reddit API, login, post copy, user data, vote data, comments, crawler, or background synchronization is used.
+   Update/deletion: the prior August representative remains recoverable in Git history. Later monthly refreshes replace the representative only after a current first-party check; no redirect or silently substituted copy is assumed.
 
 Candidate routes screened on 2026-09-07
 ---------------------------------------
@@ -58,6 +64,15 @@ Five route/collection candidates not previously recorded under these exact curre
 - Royal Road Top 3 recommendations [Sept 2026] — screened as a current public first-party forum thread. Deferred because the maintained Royal Road Recommendations board already covers this reader task and preserves a more stable route than one personal favorites thread.
 - Royal Road September Thread - Promote your Story — screened as a current public first-party promotion thread. Rejected for this reader-recommendation directory because its primary purpose is creator self-promotion rather than reader requests or independent recommendation discussion.
 
+Candidate routes screened on 2026-09-10
+---------------------------------------
+Five route/collection candidates not previously recorded under these exact September 10 identities were checked against repository history:
+- r/noveltranslations Monthly Recommendation Thread — September 09, 2026 — fully audited and integrated as a freshness replacement for the August representative. It keeps the existing translated-fiction recommendation task current without increasing the catalog row count.
+- Royal Road “I forgot the title...” — fully audited as a stable public first-party subforum with the explicit purpose of helping readers identify stories they previously read. Royal Road Terms last updated 2026-09-01 permit ordinary reading without signup while restricting unauthorized copying, scraping, crawling, bots, and competitive use. It passes a bounded link-only capability but is deferred because adding this distinct task is a taxonomy expansion separate from today’s smallest freshness change.
+- Royal Road “What are your top 5 Fictions in Royal Road?” — fully audited as a current public first-party recommendations thread. It is useful for editorial listening but deferred from the catalog because the maintained Royal Road Recommendations board already covers personal favorites and recommendation requests. Reply/view counts and individual lists are not copied or treated as a population ranking.
+- Scribble Hub “I'm looking for a forgotten novel.” — screened as public evidence of the forgotten-title task on another platform. It is a single 2022 thread rather than a stable route, so it is deferred in favor of the stronger Royal Road category candidate for any later task-level expansion.
+- r/OtomeIsekai “What are you currently reading?” — screened as a current public reader-discussion thread. It spans manga/manhwa and adjacent media beyond the current web-fiction route, so it is deferred rather than widening the maintained source taxonomy from one small sample.
+
 Why this source is a native integration rather than a copied discussion feed
 --------------------------------------------------------------------------
 The WebNR repository interface currently consumes bounded search_index.yml catalogs. The audited platforms expose user discussions under platform-specific rights and access rules, while Reddit’s programmatic API carries its own registration/terms boundary. This source uses WebNR’s native catalog format to make community discovery searchable without importing community text. A future richer adapter requires a source-specific machine interface, explicit access/redistribution bounds, stable identity, pagination or cursor behavior where applicable, rate-limit/backoff rules, update/deletion semantics, response-size/timeout bounds, and versioned fixtures before promotion.
@@ -68,7 +83,9 @@ The 2026-08 radar used a fixed 2026-08-01 through 2026-08-28 observation window 
 
 The 2026-09-07 refresh re-checked that maintained basket and screened six additional public collection/routes for the next community slot: SpaceBattles Story Ideas & Recommendations, SpaceBattles Creative Library, Sufficient Velocity Story Library, Sufficient Velocity Creative Discussion & Worldbuilding, Tapas Writing | Novels, and the current r/rational Monday Request and Recommendation Thread. SpaceBattles Story Ideas & Recommendations and r/rational passed as bounded additions.
 
-The 2026-09-09 refresh compared three current route shapes — monthly release index, weekly reading roundup, and daily recommendation request — and screened the five exact candidates listed above. r/Fantasy Daily Recommendations and Simple Questions was admitted as the only new catalog route because it adds a genuinely broader cross-platform request task. The other current threads remain direct editorial references or deferrals rather than duplicate catalog rows. The source still stores only a small set of representative reader routes; companion reader articles explain sampling limits and treat public posts as examples of discussion structure rather than population estimates.
+The 2026-09-09 refresh compared three current route shapes — monthly release index, weekly reading roundup, and daily recommendation request — and screened the five exact candidates listed above. r/Fantasy Daily Recommendations and Simple Questions was admitted as the only new catalog route because it adds a genuinely broader cross-platform request task. The other current threads remain direct editorial references or deferrals rather than duplicate catalog rows.
+
+The 2026-09-10 refresh concentrated on route freshness and the distinct “find a forgotten title” task. The current r/noveltranslations monthly thread replaced the August representative in place. Royal Road's stable forgotten-title subforum passed a bounded link-only audit but was intentionally left for a separate task-taxonomy decision. A current Royal Road favorites thread, a historical Scribble Hub forgotten-title thread, and an adjacent-media r/OtomeIsekai reading thread were retained as listening evidence or deferrals rather than used to inflate the maintained catalog. The source continues to store only a small set of representative reader routes; companion reader articles explain sampling limits and treat public posts as examples of discussion structure rather than population estimates.
 
 Compatibility and health
 ------------------------
@@ -78,7 +95,7 @@ Compatibility and health
 - Credentials: none.
 - External synchronization requests: none.
 - WebNR index size: intentionally tiny and far below the 5 MiB repository-index limit.
-- Last source-specific audit: 2026-09-09.
+- Last source-specific audit: 2026-09-10.
 
 Reader value
 ------------

--- a/public/sources/web-novel-discussion-radar-starter/search_index.yml
+++ b/public/sources/web-novel-discussion-radar-starter/search_index.yml
@@ -88,10 +88,10 @@ litrpg-audio-preferences-202608:
   page_url: https://www.reddit.com/r/litrpg/comments/1vl0yhf/audiobook_recommendations/
   license: Link-only-WebNR-editorial
 
-noveltranslations-monthly-recs-202608:
-  title: 翻译网文月度推荐线程 — 2026 年 8 月
+noveltranslations-monthly-recs-202609:
+  title: 翻译网文月度推荐线程 — 2026 年 9 月
   author: WebNR editorial
-  description: WebNR 记录的 r/noveltranslations 固定推荐入口；社区把具体找书需求集中到月度线程，并要求读者描述目标作品特征。
+  description: WebNR 记录的 r/noveltranslations 当前月度推荐入口；社区把具体找书需求集中到月度线程，并要求读者描述目标作品特征。此条目只保留第一方公开链接与 WebNR 自写说明。
   categories:
     - Community discussion
     - Translated web fiction
@@ -100,10 +100,10 @@ noveltranslations-monthly-recs-202608:
     - recommendations
     - monthly thread
     - Reddit
-  date: '2026-08-09'
-  archived date: '2026-08-28'
+  date: '2026-09-09'
+  archived date: '2026-09-10'
   region: Global / English
-  page_url: https://www.reddit.com/r/noveltranslations/comments/1vjx4jf/monthly_recommendation_thread_august_09_2026/
+  page_url: https://www.reddit.com/r/noveltranslations/comments/1wbtmgy/monthly_recommendation_thread_september_09_2026/
   license: Link-only-WebNR-editorial
 
 scribble-hub-discoverability-202608:


### PR DESCRIPTION
Refresh the existing Web Novel Discussion Radar representative r/noveltranslations monthly recommendation route from August to the current September 9, 2026 thread, preserving the source at bounded link-only capability and keeping the catalog at ten representative rows. Also refresh the source-specific audit and record the September 10 operating cycle.

Scope: three files only — the Discussion Radar YAML row, its README audit/freshness record, and `.github/seo-data/daily/2026-09-10.md`. No reader article, design, analytics, canonical, route layout, Legado behavior, source-family count, or unrelated source entry changes.

Evidence: the September thread is first-party and explicitly concentrates recommendation requests; WebNR stores only the first-party URL plus WebNR-authored metadata, with no Reddit API/login/post/user/vote copy. Five candidates were screened and three fully audited; the Royal Road forgotten-title subforum passed bounded link-only review but is deliberately deferred as a separate task-taxonomy expansion.

Validation/acceptance: expected Quality jobs are Web quality, Documentation quality, Production evidence, and Chromium user journeys. After merge, the exact application deployment must expose source key `noveltranslations-monthly-recs-202609` while the other nine radar entries and GA4/runtime behavior remain unchanged. Rollback is the exact squash commit if source validation, deployment identity, or public acceptance fails.