### PR TITLE
feat: add forgotten-title recovery guide and fic-search route

### DIFF
--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -20,7 +20,7 @@
 
 -   :material-compass-outline: **我想找网文、连载或同人**
 
-    英文平台从 [英文连载小说平台怎么选](posts/2026-08-10-english-serial-fiction-platforms.md) 开始；区域生态可分别看 [中文](posts/2026-08-18-chinese-online-fiction-ecosystem.md)、[日文](posts/2026-08-20-japanese-web-novel-discovery.md)、[韩文](posts/2026-08-22-korean-web-novel-discovery.md)；同人看 [Fanfiction / transformative serial guide](posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md)。
+    英文平台从 [英文连载小说平台怎么选](posts/2026-08-10-english-serial-fiction-platforms.md) 开始；忘记以前读过的网文或同人标题时，看 [忘记英文网文书名怎么找回](posts/2026-09-12-how-to-find-a-forgotten-web-novel.md)；区域生态可分别看 [中文](posts/2026-08-18-chinese-online-fiction-ecosystem.md)、[日文](posts/2026-08-20-japanese-web-novel-discovery.md)、[韩文](posts/2026-08-22-korean-web-novel-discovery.md)；同人看 [Fanfiction / transformative serial guide](posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md)。
 
 </div>
 
@@ -30,6 +30,7 @@
 
 | 你要解决的问题 | 建议先读 |
 | --- | --- |
+| 忘记以前读过的网文 / 同人标题 | [忘记英文网文书名怎么找回](posts/2026-09-12-how-to-find-a-forgotten-web-novel.md) |
 | 英文连载平台差别是什么 | [英文连载小说平台怎么选](posts/2026-08-10-english-serial-fiction-platforms.md) |
 | Progression Fantasy / LitRPG 怎么筛 | [Progression Fantasy 与 LitRPG 推荐方法](posts/2026-08-24-progression-fantasy-litrpg-recommendation-method.md) |
 | 同人小说去哪里找 | [Fanfiction / transformative serial discovery guide](posts/2026-08-26-fanfiction-transformative-serial-discovery-guide.md) |

--- a/docs/blog/posts/2026-09-12-how-to-find-a-forgotten-web-novel.md
+++ b/docs/blog/posts/2026-09-12-how-to-find-a-forgotten-web-novel.md
@@ -1,0 +1,147 @@
+---
+title: 忘记英文网文书名怎么找回？先整理“确定记得什么”，再去 Royal Road、SpaceBattles 和 story-identification 找
+date: 2026-09-12
+slug: how-to-find-a-forgotten-web-novel
+summary: 只记得一段剧情、角色能力、读过的平台或大概年份，却忘了书名？先把确定信息和猜测分开，再按“原平台找回 → 同人 Fic Search → 类型作品识别 → 通用找书社区”的顺序求助，通常比一句“帮我找本书”有效得多。
+description: 2026 年 9 月实测 Royal Road 的 I forgot the title、SpaceBattles Fic Search Thread、Science Fiction & Fantasy Stack Exchange 的 story-identification，以及 Goodreads、LibraryThing、r/whatsthatbook 等通用找书入口，给出忘记英文网文、连载或同人标题时可直接照做的找回方法。
+categories:
+  - Reader guides
+  - Community
+---
+
+# 忘记英文网文书名怎么找回？先整理“确定记得什么”，再去 Royal Road、SpaceBattles 和 story-identification 找
+
+**先给结论：不要先搜“那本主角会魔法的小说”，也不要一上来把所有模糊记忆都写成事实。最快的做法是先做一张“找书证据卡”，把你确定记得的内容、可能记错的内容和读书环境分开，再把问题送到最贴近原阅读场景的社区。**
+
+如果你大概率是在 Royal Road 读过，先去 Royal Road 自己的 **I forgot the title...**；如果是同人文，尤其可能在 FanFiction.net、SpaceBattles、Questionable Questing 等地方读过，SpaceBattles 的 **Fic Search Thread** 明确就是给“我知道这篇 fic 存在、以前读过，但现在找不到”的问题；如果作品属于科幻或奇幻、平台已经完全记不清，可以再用 Science Fiction & Fantasy Stack Exchange 的 **story-identification**。最后才把问题扩大到 Goodreads、LibraryThing 或 r/whatsthatbook 这类通用书名识别社区。
+
+WebNR 在 **2026-09-12** 重新检查了这些公开入口及其当前用途。本文比较的是“读者应该把哪种问题送到哪里”，不是社区规模、成功率或热度排名；也不会因为某个页面公开可见就把帖子、用户名、答案、票数或作品正文复制进 WebNR。
+
+[添加 Web Novel Discussion Radar Starter](https://app.webnovel.win/?repos=https%3A%2F%2Fapp.webnovel.win%2Fsources%2Fweb-novel-discussion-radar-starter){ .md-button .md-button--primary }
+
+## 一分钟路线：先判断你丢的是“标题”，还是“来源”
+
+| 你现在最确定的线索 | 最先去哪里 | 为什么 |
+| --- | --- | --- |
+| 几乎确定是在 Royal Road 读过 | [Royal Road — I forgot the title...](https://www.royalroad.com/forums/5852) | 这是平台内专门找回以前读过但忘记标题故事的稳定版块 |
+| 确定是某篇同人文，记得 fandom / crossover / 场景，但链接丢了 | [SpaceBattles — Fic Search Thread](https://forums.spacebattles.com/threads/fic-search-thread.134658/) | 线程本身明确区分“找一篇确定存在、以前读过的 fic”和一般推荐 |
+| 确定是科幻或奇幻，但平台、书名、作者都不确定 | [SFF Stack Exchange — story-identification](https://scifi.stackexchange.com/questions/tagged/story-identification) | 这个标签专门处理“识别唯一作品”，并要求给出时间、媒介、情节、语言等证据 |
+| 只确定是一本书，可能不是网文 | [Goodreads — What’s the Name of That Book???](https://www.goodreads.com/group/show/185-what-s-the-name-of-that-book) | 公共小组把忘记书名作为明确任务，并要求标题写 genre + plot details |
+| 想用一个传统读者社区继续扩大范围 | [LibraryThing — Name that Book](https://www.librarything.com/ngroups/724/Name-that-Book) | 公开小组明确用于找回曾经读过但忘记名字的书；应由读者在普通浏览器中手动使用 |
+| 想再尝试一个专门的 Reddit 找书社区 | [r/whatsthatbook](https://www.reddit.com/r/whatsthatbook/) | 社区长期要求问题标题包含可识别的作品细节，而不是“please help”之类空标题 |
+
+一个实用顺序是：**原平台专门入口 → 作品类型专门入口 → 通用找书社区。** 越靠前的社区越可能熟悉平台标签、旧连载、改名、删文、搬站和 fandom 语境；越靠后的社区覆盖更广，但你也更需要把线索整理清楚。
+
+## 1. 先做“找书证据卡”，不要直接写一段混合记忆
+
+找回一篇旧网文最难的地方通常不是“信息太少”，而是**确定信息和脑补混在一起**。几年之后，人很容易把封面、推荐语、另一本书的设定甚至后来看到的同人二创混进原记忆。
+
+建议先写六栏，哪怕只写在自己的备忘录里：
+
+| 字段 | 应该写什么 |
+| --- | --- |
+| **确定的平台 / 媒介** | Royal Road、FanFiction.net、论坛帖、Kindle、网页连载；不确定就写“不确定” |
+| **最晚读到它的时间** | “2024 年以前读过”比“小时候读过”更有用；如果只记得设备或人生阶段，也写出来 |
+| **确定的情节锚点** | 一个很具体的场景、职业、能力代价、开局地点、关系、特殊物品 |
+| **可能记错的部分** | 角色名像什么、标题里可能有哪个词、封面颜色——单独标成“低置信度” |
+| **排除项** | 已经查过但确认不是的作品；这样别人不用重复猜 |
+| **阅读上下文** | 语言、是否翻译、fandom、是否 crossover、是否完结、章节大概长度、当时通过什么链接发现 |
+
+最重要的是**把“我确定”与“我猜”分开写**。例如：“确定主角第一次获得能力是在地铁站；可能是时间暂停，但也可能只是所有人不能动。”后一种写法给识别者保留了纠错空间。
+
+如果你还能访问旧设备或旧浏览器，社区求助之前先检查浏览器历史、书签、阅读器本地书架、邮件通知、Discord/论坛收藏和搜索历史。社区最擅长的是把片段记忆映射回作品，不应该代替你手里仍然可搜索的一手记录。
+
+## 2. Royal Road：大概率在 RR 读过，就不要先去全网求书
+
+Royal Road 的 [I forgot the title...](https://www.royalroad.com/forums/5852) 和普通 Recommendations 是两个不同任务。前者就是给“以前读过一个故事，现在忘记标题”使用；后者更适合“我喜欢 A，想找类似 B”。
+
+如果你记得作品曾经在 Royal Road，问题里优先写平台内部信号：
+
+- 当时大概是哪一年；
+- 作品是 ongoing、hiatus 还是看起来已完结；
+- 你记得的 tags / genre；
+- 是否有 LitRPG 状态栏、cultivation、isekai、portal fantasy 等明显结构；
+- 某个只有读过作品的人容易认出的开局或中段场景；
+- 你是否记得它后来去 Kindle Unlimited、删文或改名。
+
+这样做的优势不是 Royal Road“更大”，而是**平台读者共享同一套标签、榜单、更新和下架语境**。如果作品本来就在 RR，先利用这层局部知识通常比把问题扔给一个覆盖所有书的社区更精确。
+
+## 3. SpaceBattles Fic Search：找“我以前读过的那篇 fic”，不是求新的推荐
+
+[SpaceBattles Fic Search Thread](https://forums.spacebattles.com/threads/fic-search-thread.134658/) 的边界非常清楚。线程长期用于寻找**确定曾经存在、自己以前读过、后来找不到的 fic**；当前线程说明还专门把一般 recommendation 引导到别的推荐线程。
+
+因此，如果你的问题是：
+
+> “我记得一篇 Harry Potter / Worm crossover，某一章发生了 X，应该在 2023 年前读过，但现在找不到。”
+
+这就是 Fic Search 的形状。
+
+如果你的问题是：
+
+> “有没有好看的 Harry Potter / Worm crossover？”
+
+那就不是同一个任务。
+
+对同人文，**fandom、配对、crossover 组合、主角身份、原站、是否 SI/OC、你记得的独特场景**通常比“文笔很好”“挺长的”更可识别。还要把“我记得它在 FFN”这种来源记忆标成置信度：旧 fic 可能搬站、删文、改名，原链接失效并不代表作品从未存在。
+
+WebNR 本轮把这个稳定 Fic Search 入口加入 Discussion Radar，但仍然只保存 WebNR 自写标题、用途说明和第一方链接。SpaceBattles 帖子、用户名、回复和 fic 内容继续留在原站，WebNR 同步来源时也不会后台抓取该论坛。
+
+## 4. SFF Stack Exchange：平台忘光了，但作品确实是科幻 / 奇幻
+
+Science Fiction & Fantasy Stack Exchange 的 [story-identification](https://scifi.stackexchange.com/questions/tagged/story-identification) 和普通推荐最大的区别是：**它要求目标应当有一个可识别的正确作品，而不是让大家给你一串“也许你会喜欢”的书。**
+
+它的 tag guidance 给出了一套很适合直接借用的字段：
+
+- 作品媒介：novel、short story、website、fanfic 等；
+- 你大概什么时候读到它，而不仅是猜出版年份；
+- 当时作品看起来新还是旧；
+- plot、setting、characters、themes；
+- 阅读语言；
+- 如果适用，封面、目标年龄；
+- 已经排除的候选。
+
+这套模板对网文也很好用。尤其是“**什么时候读过**”与“**当时在哪种媒介读过**”，往往能直接排除后来才发布的作品，或者把搜索范围从传统出版缩回网页连载。
+
+它也有明确边界：这个标签面向 science fiction / fantasy，而且不是 recommendation。如果你只记得一部普通现实题材小说，应该换更通用的找书社区。
+
+## 5. Goodreads、LibraryThing、r/whatsthatbook：什么时候才值得扩大范围
+
+当你已经不确定它是不是网文，或者原平台社区完全没有结果，再把问题送到通用找书社区更合理。
+
+Goodreads 的 [What’s the Name of That Book???](https://www.goodreads.com/group/show/185-what-s-the-name-of-that-book) 公开规则要求 topic title 写出 **genre + plot details**，还建议写明大概哪一年读到。这个规则值得直接借鉴：一个标题如果只有“YA Fantasy help”或“Looking for a book”，别人必须先点进去才能知道任何信息；把最独特的一条情节写进标题，识别成本会低很多。
+
+LibraryThing 的 [Name that Book](https://www.librarything.com/ngroups/724/Name-that-Book) 也公开说明自己用于帮助读者找回忘记名字的书，并把已确认的主题标为 Found。不过它当前 Terms 对 automated access / scraping 有明确限制，所以 WebNR 不把它当成可后台同步的目录；这里提供的是**读者手动打开的外部路线**，不是一个自动化 source adapter。
+
+r/whatsthatbook 同样长期强调标题必须包含至少一个具体作品细节。使用 Reddit 时要以社区当前规则为准；如果帖子因为标题太模糊被删除，正确做法是按规则重写一个包含剧情或媒介线索的标题，而不是重复发同样的空泛请求。
+
+## 6. 一个更容易被识别的提问模板
+
+把下面这套结构压缩成你自己的信息，不要为了填满字段而编造：
+
+**标题：** `[可能的平台/媒介] + [最独特的情节或设定] + [大概阅读年份]`
+
+**正文：**
+
+1. **我确定的：** 语言、媒介、阅读时间上限、一个或两个关键场景；
+2. **我不确定的：** 可能的平台、可能的角色名、可能的能力或标题词；
+3. **作品形态：** 网页连载 / fanfic / ebook / audiobook，完结状态如果记得就写；
+4. **排除：** 已经确认不是哪些作品；
+5. **为什么这些线索属于同一本：** 如果你怀疑混入了另一部作品，直接说明。
+
+例如，比起“找一本主角会时间能力的 RR 小说”，更好的标题是：
+
+**`[Royal Road?][2024 年前] 主角在地铁/车站第一次发现周围所有人无法行动，后来能力有使用代价`**
+
+正文再说明“Royal Road 只是大概 70% 确定；‘时间停止’是推测，确定的是周围人无法行动”。这种写法允许别人用不同解释反推同一场景。
+
+## 7. 找到以后，别把“找到链接”误解成“可以搬内容”
+
+找回标题之后，下一步通常是重新收藏、在原平台继续读，或者把**允许浏览器访问且你有权使用的文本 URL**导入自己的阅读器。找回一个链接并不会改变原站的版权、登录、付费、robots、CORS 或作者授权边界。
+
+WebNR 的 Discussion Radar 因此故意只做“路线目录”：告诉你哪里适合问某类问题，不把社区讨论变成自己的数据库。如果最终找到的是一个受支持、允许导入的 TXT URL，可以再按 [TXT 导入指南](https://www.webnovel.win/blog/2026/09/01/raw-txt-collection-import-guide/) 判断；如果你真正需要的是“最近有什么值得读”，则回到 [本周英文网文发现路线](https://www.webnovel.win/blog/2026/09/09/how-to-track-current-web-fiction-recommendations/)；如果连“应该去哪个社区问”都还没决定，可以看 [英文网文推荐应该去哪里问](https://www.webnovel.win/blog/2026/09/07/where-to-ask-web-novel-recommendations/)。
+
+## 验证方法与边界
+
+本文于 **2026-09-12** 重新检查 Royal Road 的公开 forgotten-title 版块、SpaceBattles Fic Search Thread、Science Fiction & Fantasy Stack Exchange 的 story-identification tag 页面与 tag guidance，以及 Goodreads / LibraryThing 的公开找书小组与 r/whatsthatbook 当前可见规则信号。SpaceBattles 的第一方 Terms 继续说明用户保留其提交内容版权并授予站点服务所需许可；Stack Exchange 的公开用户贡献按相应版本的 CC BY-SA 条款发布；LibraryThing 当前 Terms 明确限制自动化抓取和 AI agent 访问。
+
+WebNR 没有登录这些社区、没有代表读者发帖、没有调用社区 API、没有复制帖子正文或用户资料，也没有把帖子数、回复数、成员数或搜索结果顺序解释成“成功率”或“社区热度”。这些入口会变化；本文把 **2026-09-12** 作为本次验证日期，实际发帖前仍应阅读原社区当时显示的规则。

--- a/public/sources/web-novel-discussion-radar-starter/CURRENT.txt
+++ b/public/sources/web-novel-discussion-radar-starter/CURRENT.txt
@@ -1,0 +1,16 @@
+Web Novel Discussion Radar Starter — current capability
+=====================================================
+
+Last verified: 2026-09-12
+
+The current native `search_index.yml` contains twelve WebNR-authored link-only reader routes. The September 12 change adds the stable SpaceBattles Fic Search Thread as a distinct story-identification route for fics a reader previously encountered but can no longer locate. This is separate from the broader SpaceBattles Story Ideas & Recommendations board and from Royal Road's platform-specific `I forgot the title...` route.
+
+Runtime boundary
+----------------
+- WebNR synchronizes only this local source directory.
+- Catalog rows contain first-party destination URLs plus WebNR-authored titles, descriptions, tags, dates, and link-only license markers.
+- No community post, comment, username, vote/reaction, story text, rating, account state, or private/personal data is copied.
+- No background request to Royal Road, Reddit, Scribble Hub, SpaceBattles, Stack Exchange, Goodreads, or LibraryThing is made by this source.
+- No credential, API client, crawler, CAPTCHA bypass, robots bypass, paid access, or login/session state is used.
+
+The cumulative historical audit through 2026-09-11 remains in `README.txt`. The September 12 candidate screening, three full audits, admission decision, rights/access boundary, identity/update semantics, and deferrals are recorded in `audit-2026-09-12.txt`.

--- a/public/sources/web-novel-discussion-radar-starter/audit-2026-09-12.txt
+++ b/public/sources/web-novel-discussion-radar-starter/audit-2026-09-12.txt
@@ -1,0 +1,52 @@
+Web Novel Discussion Radar — 2026-09-12 story-identification audit
+=================================================================
+
+Scope
+-----
+This audit extends the existing Discussion Radar with one distinct reader task: finding a story or fic that the reader knows they previously read but can no longer identify or locate. It does not widen WebNR into mirroring community posts, user profiles, ratings, vote counts, book metadata, or story text.
+
+Candidate screening
+-------------------
+Five public routes not already maintained under these exact identities were screened on 2026-09-12:
+
+1. SpaceBattles Fic Search Thread — fully audited and admitted as a twelfth Discussion Radar route.
+2. Science Fiction & Fantasy Stack Exchange `story-identification` — fully audited and deferred from the source catalog; useful as an editorial fallback for SF/F identification, but it covers many media types and is not sufficiently web-fiction-specific to justify another maintained catalog row today.
+3. LibraryThing `Name that Book` — fully audited and deferred. It is a strong human-operated book-identification route, but the current LibraryThing Terms expressly prohibit automated/systematic access, scraping, headless/AI-agent access, and derivative database use except through authorized interfaces. WebNR therefore does not create a background adapter or health-fetch dependency for it.
+4. Goodreads `What's the Name of That Book???` — screened as a public general-book identification group and deferred because its task is broader than web fiction and the current change already has a platform-specific passing route.
+5. r/whatsthatbook — screened as a public Reddit story/book-identification community and deferred because the Radar already carries several bounded Reddit routes, while this cycle's smallest non-duplicative addition is the SpaceBattles fic-specific route.
+
+Admitted route: SpaceBattles Fic Search Thread
+----------------------------------------------
+Origin and purpose: The first-party SpaceBattles thread at `https://forums.spacebattles.com/threads/fic-search-thread.134658/` is specifically for stories/fics that a reader knows existed and previously encountered but can no longer find. The current visible thread guidance distinguishes that task from general recommendations and redirects recommendation-seeking elsewhere.
+
+Rights and terms: SpaceBattles' first-party Terms of Service state that submitted user content expresses its author's views, that users retain copyright over submitted content, and that SpaceBattles receives the service license needed to use/publish/re-publish that content. This admission therefore remains link-only. WebNR copies no forum post, username, thread statistics, story text, review, attachment, or user metadata.
+
+Access/runtime: The first-party route remains indexed and readable to ordinary visitors, while automated direct fetching may be challenged by the forum. That is not a WebNR runtime dependency: source synchronization reads only the local `search_index.yml`. A reader who chooses the result navigates to SpaceBattles under SpaceBattles' own controls. No WebNR crawler, login, cookie, API client, CAPTCHA bypass, pagination walker, or rate-limit workaround is introduced.
+
+Format and capability: one stable HTTPS destination represented as a WebNR-authored native catalog row with title, description, categories, tags, observed/archive date, region, and `Link-only-WebNR-editorial` license marker. There is no remote schema, pagination contract, content extraction, or update feed to normalize.
+
+Identity/update/deletion: the stable thread URL is the admitted identity. Health review checks whether it still represents the same fic-search task. If it is moved, removed, restricted, or repurposed, WebNR corrects or removes the local link through normal review; it does not crawl for a replacement. Git history preserves the previous identity.
+
+Duplication and reader value: the existing SpaceBattles Story Ideas & Recommendations row is a broad recommendations/discussion board. The new row is deliberately narrower: it is for recovering a specific fic known to have existed. This mirrors the task distinction already established by Royal Road's `I forgot the title...` route while covering a different platform/community and fanfiction corpus.
+
+Fully audited defer: SFF Stack Exchange story-identification
+------------------------------------------------------------
+Origin/purpose: the first-party `story-identification` tag is explicitly for identifying a specific science-fiction or fantasy work when the name or creator is forgotten, including novels, websites, and fanfic. Its guidance asks for media, approximate reading/publication period, plot, setting, characters, language, and ruled-out candidates, and states that the tag is not for general recommendations.
+
+Rights/access: public Stack Exchange contributions carry the applicable CC BY-SA version documented by Stack Exchange. WebNR would not need that reuse license for a link-only route, because it would store only its own label and the first-party URL. No account or API is required for the proposed local catalog representation.
+
+Decision: defer. It is useful enough to cite in the companion reader guide, but it spans film, television, games, comics and other SF/F media. Adding it to the maintained Web Novel Discussion Radar today would broaden the catalog beyond the smallest task-specific change.
+
+Fully audited defer: LibraryThing Name that Book
+-------------------------------------------------
+Origin/purpose: the first-party public group says it exists to help readers find a book whose name they have forgotten and maintains posting guidance plus a Found convention.
+
+Terms/access: current LibraryThing Terms distinguish ordinary human browsing from automated access and expressly prohibit unauthorized crawling, scraping, automated systematic collection, headless/AI-agent access and derivative database use. Authorized APIs are separate. WebNR therefore does not attempt to make LibraryThing a synchronized source, does not use a crawler for health checks, and does not copy the group's topics or member data.
+
+Decision: defer from the maintained source catalog. The companion guide may point human readers to the public route as a manual fallback, with the automation boundary stated explicitly.
+
+Runtime and privacy boundary
+----------------------------
+After this audit the Discussion Radar contains twelve WebNR-authored link-only catalog rows. Maintained source-family count is unchanged. The source remains local YAML: no community request is made during WebNR synchronization, no credential is added, no personal data is stored, and no external discussion content is mirrored.
+
+Verified: 2026-09-12.

--- a/public/sources/web-novel-discussion-radar-starter/search_index.yml
+++ b/public/sources/web-novel-discussion-radar-starter/search_index.yml
@@ -195,3 +195,21 @@ royal-road-forgotten-title-202609:
   region: Global / English
   page_url: https://www.royalroad.com/forums/5852
   license: Link-only-WebNR-editorial
+
+spacebattles-fic-search-202609:
+  title: SpaceBattles Fic Search 找回旧同人文 — 2026 年 9 月
+  author: WebNR editorial
+  description: WebNR 记录的 SpaceBattles Fic Search Thread 第一方公开入口，用于寻找自己确认曾经读过、但现在找不到标题或链接的 fic；与一般推荐请求分开。WebNR 只保留链接和自写说明，不复制帖子、用户名、回复或作品正文。
+  categories:
+    - Community discussion
+    - Story identification
+  tags:
+    - SpaceBattles
+    - fic search
+    - story identification
+    - fanfiction
+  date: '2026-09-12'
+  archived date: '2026-09-12'
+  region: Global / English
+  page_url: https://forums.spacebattles.com/threads/fic-search-thread.134658/
+  license: Link-only-WebNR-editorial


### PR DESCRIPTION
## Why
The rolling reader-content cadence is due on September 12, and the maintained Discussion Radar has a distinct story-identification gap for readers who know a fic existed but have lost its title/link.

## Scope
- publish a practical reader guide for recovering a forgotten English web novel or fic using a confidence-aware evidence card and platform-specific routes;
- add the stable SpaceBattles Fic Search Thread as one bounded, link-only Discussion Radar row;
- record September 12 screening of five candidate story-identification routes and full audits of SpaceBattles Fic Search, SFF Stack Exchange `story-identification`, and LibraryThing `Name that Book`;
- add a current capability note without rewriting the cumulative historical source audit;
- link the new guide from the curated Blog problem index.

## Preserved behavior / boundaries
- no reader runtime, Legado compatibility, analytics, routes, canonical ownership, deployment configuration, or existing source rows are changed;
- the new source row stores only a first-party URL and WebNR-authored metadata; no forum post, username, reply, vote, story text, account state, crawler, API credential, login, or background sync is added;
- LibraryThing is not integrated because its current Terms explicitly restrict automated/AI-agent access; it appears only as a manual reader fallback in the guide.

## Validation
Expected repository Quality CI: Web quality, Documentation quality, Production evidence, and Chromium user journeys. The final review will restart from this scope after every expected check reaches success.

## Deployment and acceptance
This is rendered/public content. After squash merge, verify the exact merged source commit through the normal documentation/application deployment evidence; publicly verify the new blog URL, Blog index link, source catalog row on the app source artifact, GA4 disclosure/implementation continuity, and representative unaffected reader/docs routes.

Rollback: revert the squash commit; no data migration or external mutation is involved.